### PR TITLE
Allow services to be omitted in usage_scenario

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -129,8 +129,7 @@ class SchemaChecker():
         if 'networks' in usage_scenario:
             self.validate_networks_no_invalid_chars(usage_scenario['networks'])
 
-        for service_name in usage_scenario.get('services'):
-            service = usage_scenario['services'][service_name]
+        for service in usage_scenario.get('services', {}):
             if 'image' not in service and 'build' not in service:
                 raise SchemaError("The 'image' key under services is required when 'build' key is not present.")
 

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -129,9 +129,11 @@ class SchemaChecker():
         if 'networks' in usage_scenario:
             self.validate_networks_no_invalid_chars(usage_scenario['networks'])
 
-        for service in usage_scenario.get('services', {}):
-            if 'image' not in service and 'build' not in service:
-                raise SchemaError("The 'image' key under services is required when 'build' key is not present.")
+        if 'services' in usage_scenario:
+            for service_name in usage_scenario.get('services'):
+                service = usage_scenario['services'][service_name]
+                if 'image' not in service and 'build' not in service:
+                    raise SchemaError("The 'image' key under services is required when 'build' key is not present.")
 
         usage_scenario_schema.validate(usage_scenario)
 

--- a/runner.py
+++ b/runner.py
@@ -338,8 +338,9 @@ class Runner:
             # creating benchmarking scripts and you want to have all options in the compose but not in each benchmark.
             # The cleaner way would be to handle an empty service key throughout the code but would make it quite messy
             # so we chose to remove it right at the start.
-            for key in [sname for sname, content in yml_obj['services'].items() if content is None]:
-                del yml_obj['services'][key]
+            if 'services' in yml_obj:
+                for key in [sname for sname, content in yml_obj['services'].items() if content is None]:
+                    del yml_obj['services'][key]
 
             self._usage_scenario = yml_obj
 
@@ -379,7 +380,7 @@ class Runner:
                         raise PermissionError(f"Container '{container_name}' is already running on system. Please close it before running the tool.")
 
     def populate_image_names(self):
-        for service_name, service in self._usage_scenario.get('services', []).items():
+        for service_name, service in self._usage_scenario.get('services', {}).items():
             if not service.get('image', None): # image is a non essential field. But we need it, so we tmp it
                 if self._dev_repeat_run:
                     service['image'] = f"{service_name}"
@@ -541,7 +542,7 @@ class Runner:
 
         # technically the usage_scenario needs no services and can also operate on an empty list
         # This use case is when you have running containers on your host and want to benchmark some code running in them
-        for _, service in self._usage_scenario.get('services', []).items():
+        for _, service in self._usage_scenario.get('services', {}).items():
             # minimal protection from possible shell escapes.
             # since we use subprocess without shell we should be safe though
             if re.findall(r'(\.\.|\$|\'|"|`|!)', service['image']):
@@ -640,15 +641,13 @@ class Runner:
     def setup_services(self):
         # technically the usage_scenario needs no services and can also operate on an empty list
         # This use case is when you have running containers on your host and want to benchmark some code running in them
-        for service_name in self._usage_scenario.get('services', []):
+        for service_name, service in self._usage_scenario.get('services', {}).items():
             print(TerminalColors.HEADER, '\nSetting up containers', TerminalColors.ENDC)
 
             if 'container_name' in self._usage_scenario['services'][service_name]:
                 container_name = self._usage_scenario['services'][service_name]['container_name']
             else:
                 container_name = service_name
-
-            service = self._usage_scenario['services'][service_name]
 
             print('Resetting container')
             # By using the -f we return with 0 if no container is found

--- a/tests/README.MD
+++ b/tests/README.MD
@@ -1,6 +1,8 @@
 ## Pre-reqs
-Make sure you have `pytest` and `pydantic` installed:
-`pip install pytest pydantic`
+Make sure you have the required dev dependencies installed:
+```sh
+python3 -m pip install -r ../requirements-dev.txt
+```
 
 We assume that your green-metrics-tool is already set up to work on your machine, as it will use your local config.yml
 file to determine which metric providers can be utilized in the tests.

--- a/tests/README.MD
+++ b/tests/README.MD
@@ -1,8 +1,6 @@
 ## Pre-reqs
-Make sure you have the required dev dependencies installed:
-```sh
-python3 -m pip install -r ../requirements-dev.txt
-```
+Make sure you have `pytest` and `pydantic` installed:
+`pip install pytest pydantic`
 
 We assume that your green-metrics-tool is already set up to work on your machine, as it will use your local config.yml
 file to determine which metric providers can be utilized in the tests.


### PR DESCRIPTION
Quote from an existing source code comment:
> technically the usage_scenario needs no services and can also operate on an empty list
> This use case is when you have running containers on your host and want to benchmark some code running in them

Actually, it was not possible to use an usage_scenario without `services`. This PR solves it.

This PR also includes a change to the README in the tests directory to make clear, that some more requirements have to be installed to run the unit tests. I hope that's ok.