### PR TITLE
Guard clause for not mapped metric provider

### DIFF
--- a/frontend/js/energy-timeline.js
+++ b/frontend/js/energy-timeline.js
@@ -40,10 +40,10 @@ $(document).ready(function () {
                 <fieldset style="border:none;">
                         <div class="field">
                             <div class="header title">
-                                <strong>${METRIC_MAPPINGS[metric_name]['clean_name']}</strong> via
-                                <strong>${METRIC_MAPPINGS[metric_name]['source']}</strong>
+                                <strong>${getPretty(metric_name, 'clean_name')}</strong> via
+                                <strong>${getPretty(metric_name, 'source')}</strong>
                                  - ${detail_name}
-                                <i data-tooltip="${METRIC_MAPPINGS[metric_name]['explanation']}" data-position="bottom center" data-inverted>
+                                <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted>
                                     <i class="question circle icon link"></i>
                                 </i>
                             </div>
@@ -110,10 +110,10 @@ $(document).ready(function () {
                     // iterate over the key metrics that shalle be displayed as badge
                     return `<div class="field">
                             <div class="header title">
-                                <strong>${METRIC_MAPPINGS['cores_energy_powermetrics_component']['clean_name']}</strong> via
-                                <strong>${METRIC_MAPPINGS['cores_energy_powermetrics_component']['source']}</strong>
+                                <strong>${getPretty('cores_energy_powermetrics_component', 'clean_name')}</strong> via
+                                <strong>${getPretty('cores_energy_powermetrics_component', 'source')}</strong>
                                  - ${`[COMPONENT]`}
-                                <i data-tooltip="${METRIC_MAPPINGS['cores_energy_powermetrics_component']['explanation']}" data-position="bottom center" data-inverted>
+                                <i data-tooltip="${getPretty('cores_energy_powermetrics_component', 'explanation')}" data-position="bottom center" data-inverted>
                                     <i class="question circle icon link"></i>
                                 </i>
                             </div>

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -44,6 +44,14 @@ class GMTMenu extends HTMLElement {
 }
 customElements.define('gmt-menu', GMTMenu);
 
+const getPretty = (metric_name, key)  => {
+    if (METRIC_MAPPINGS[metric_name] == null || METRIC_MAPPINGS[metric_name][key] == null) {
+        console.log(metric_name, ' is undefined in METRIC_MAPPINGS or has no key');
+        return `${metric_name}_${key}`;
+    }
+    return METRIC_MAPPINGS[metric_name][key];
+}
+
 const replaceRepoIcon = (uri) => {
 
   if(!uri.startsWith('http')) return uri; // ignore filesystem paths

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -224,8 +224,8 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
     let tr = document.querySelector(`div.tab[data-tab='${phase}'] table.compare-metrics-table tbody`).insertRow();
     if(comparison_case !== null) {
         tr.innerHTML = `
-            <td data-position="bottom left" data-inverted="" data-tooltip="${METRIC_MAPPINGS[metric_name]['explanation']}"><i class="question circle icon"></i>${METRIC_MAPPINGS[metric_name]['clean_name']}</td>
-            <td>${METRIC_MAPPINGS[metric_name]['source']}</td>
+            <td data-position="bottom left" data-inverted="" data-tooltip="${getPretty(metric_name, 'explanation')}"><i class="question circle icon"></i>${getPretty(metric_name, 'clean_name')}</td>
+            <td>${getPretty(metric_name, 'source')}</td>
             <td>${scope}</td>
             <td>${detail_name}</td>
             <td>${metric_data.type}</td>
@@ -239,8 +239,8 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
 
     } else {
         tr.innerHTML = `
-            <td data-position="bottom left" data-inverted="" data-tooltip="${METRIC_MAPPINGS[metric_name]['explanation']}"><i class="question circle icon"></i>${METRIC_MAPPINGS[metric_name]['clean_name']}</td>
-            <td>${METRIC_MAPPINGS[metric_name]['source']}</td>
+            <td data-position="bottom left" data-inverted="" data-tooltip="${getPretty(metric_name, 'explanation')}"><i class="question circle icon"></i>${getPretty(metric_name, 'clean_name')}</td>
+            <td>${getPretty(metric_name, 'source')}</td>
             <td>${scope}</td>
             <td>${detail_name}</td>
             <td>${metric_data.type}</td>
@@ -252,9 +252,9 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
 
 
     updateKeyMetric(
-        phase, metric_name, METRIC_MAPPINGS[metric_name]['clean_name'], detail_name,
+        phase, metric_name, getPretty(metric_name, 'clean_name'), detail_name,
         value , std_dev_text, unit, detail_data.mean, metric_data.unit,
-        METRIC_MAPPINGS[metric_name]['explanation'], METRIC_MAPPINGS[metric_name]['source']
+        getPretty(metric_name, 'explanation'), getPretty(metric_name, 'source')
     );
 }
 
@@ -297,8 +297,8 @@ const displayDiffMetricBox = (phase, metric_name, metric_data, detail_name, deta
 
     let tr = document.querySelector(`div.tab[data-tab='${phase}'] table.compare-metrics-table tbody`).insertRow();
     tr.innerHTML = `
-        <td data-position="bottom left" data-inverted="" data-tooltip="${METRIC_MAPPINGS[metric_name]['explanation']}"><i class="question circle icon"></i>${METRIC_MAPPINGS[metric_name]['clean_name']}</td>
-        <td>${METRIC_MAPPINGS[metric_name]['source']}</td>
+        <td data-position="bottom left" data-inverted="" data-tooltip="${getPretty(metric_name, 'explanation')}"><i class="question circle icon"></i>${getPretty(metric_name, 'clean_name')}</td>
+        <td>${getPretty(metric_name, 'source')}</td>
         <td>${scope}</td>
         <td>${detail_name}</td>
         <td>${metric_data.type}</td>
@@ -309,9 +309,9 @@ const displayDiffMetricBox = (phase, metric_name, metric_data, detail_name, deta
         <td>${extra_label}</td>`;
 
     updateKeyMetric(
-        phase, metric_name, METRIC_MAPPINGS[metric_name]['clean_name'], detail_name,
+        phase, metric_name, getPretty(metric_name, 'clean_name'), detail_name,
         value, '', metric_data.unit, null, null,
-        METRIC_MAPPINGS[metric_name]['explanation'], METRIC_MAPPINGS[metric_name]['source']
+        getPretty(metric_name, 'explanation'), getPretty(metric_name, 'source')
     );
 
 }

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -144,18 +144,18 @@ const displayComparisonMetrics = (phase_stats_object) => {
                     as we can have the same metric multiple times just with different detail names
                 */
                 if(radar_chart_condition(metric_name) && phase_stats_object.comparison_details.length >= 2) {
-                    radar_chart_labels.push(METRIC_MAPPINGS[metric_name]['clean_name']);
+                    radar_chart_labels.push(getPretty(metric_name, 'clean_name'));
                 }
 
                 if (top_bar_chart_condition(metric_name)) {
-                    top_bar_chart_labels.push(`${METRIC_MAPPINGS[metric_name]['clean_name']} (${METRIC_MAPPINGS[metric_name]['source']})`);
+                    top_bar_chart_labels.push(`${getPretty(metric_name, 'clean_name')} (${getPretty(metric_name, 'source')})`);
                 }
 
                 if (total_chart_bottom_condition(metric_name)) {
                     if(found_bottom_chart_metric) {
                         showWarning(phase, `Another metric for the bottom chart was already set (${found_bottom_chart_metric}), skipping ${metric_name} and only first one will be shown.`);
                     } else {
-                        total_chart_bottom_legend[phase].push(METRIC_MAPPINGS[metric_name]['clean_name']);
+                        total_chart_bottom_legend[phase].push(getPretty(metric_name, 'clean_name'));
                         found_bottom_chart_metric = `${metric_name} ${detail_name}`;
                     }
                 }
@@ -218,7 +218,7 @@ const displayComparisonMetrics = (phase_stats_object) => {
                 if(phase_stats_object.comparison_case !== null) { // compare charts will display for everything apart stats.html
                     displayCompareChart(
                         phase,
-                        `${METRIC_MAPPINGS[metric_name]['clean_name']} via ${METRIC_MAPPINGS[metric_name]['source']} - ${detail_name} <i data-tooltip="${METRIC_MAPPINGS[metric_name]['explanation']}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`,
+                        `${getPretty(metric_name, 'clean_name')} via ${getPretty(metric_name, 'source')} - ${detail_name} <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`,
                         metric_data.unit,
                         compare_chart_labels,
                         compare_chart_data,

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -222,7 +222,7 @@ const displayTimelineCharts = (metrics, notes) => {
 
     for (const metric_name in metrics) {
 
-        const element = createChartContainer("#chart-container", `${METRIC_MAPPINGS[metric_name]['clean_name']} via ${METRIC_MAPPINGS[metric_name]['source']} <i data-tooltip="${METRIC_MAPPINGS[metric_name]['explanation']}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
+        const element = createChartContainer("#chart-container", `${getPretty(metric_name, 'clean_name')} via ${getPretty(metric_name, 'source')} <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
 
         let legend = [];
         let series = [];

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -185,10 +185,10 @@ const loadCharts = async () => {
         let badge = `
                 <div class="field">
                     <div class="header title">
-                        <strong>${METRIC_MAPPINGS[series[my_series].metric_name]['clean_name']}</strong> via
-                        <strong>${METRIC_MAPPINGS[series[my_series].metric_name]['source']}</strong>
+                        <strong>${getPretty(series[my_series].metric_name, 'clean_name')}</strong> via
+                        <strong>${getPretty(series[my_series].metric_name, 'source')}</strong>
                          - ${series[my_series].detail_name}
-                        <i data-tooltip="${METRIC_MAPPINGS[series[my_series].metric_name]['explanation']}" data-position="bottom center" data-inverted>
+                        <i data-tooltip="${getPretty(series[my_series].metric_name, 'explanation')}" data-position="bottom center" data-inverted>
                             <i class="question circle icon link"></i>
                         </i>
                     </div>
@@ -199,7 +199,7 @@ const loadCharts = async () => {
         document.querySelector("#badge-container").innerHTML += badge;
 
 
-        const element = createChartContainer("#chart-container", `${METRIC_MAPPINGS[series[my_series].metric_name]['clean_name']} via ${METRIC_MAPPINGS[series[my_series].metric_name]['source']} - ${series[my_series].detail_name} <i data-tooltip="${METRIC_MAPPINGS[series[my_series].metric_name]['explanation']}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
+        const element = createChartContainer("#chart-container", `${getPretty(series[my_series].metric_name, 'clean_name')} via ${getPretty(series[my_series].metric_name, 'source')} - ${series[my_series].detail_name} <i data-tooltip="${getPretty(series[my_series].metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
 
         const chart_instance = echarts.init(element);
 


### PR DESCRIPTION
Metric provider details for display in our modular frontend are typically defined in the `config.js` file. 
https://docs.green-coding.berlin/docs/frontend/customization/

However often the cases arises that this is forgotten or a provider is mispelled etc.

At the moment the admin just fails if that happens. However we want to soft-fail instead.

This PR introduces this functionality by not accessing the mappings directly, but by making a guard clause around it and then just outputting the raw access key.

Example screenshot attached where no mapping for *cpu_time_cgroup_container* was found and the raw key is outputted.

<img width="1206" alt="Screenshot 2023-12-03 at 8 09 49 AM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/31dfa7d6-ef32-4d21-ada8-f6e974e06048">
