### PR TITLE
Phase Stats Providers

### DIFF
--- a/phase_stat_providers/carbon/intensity/entsoe/provider.py
+++ b/phase_stat_providers/carbon/intensity/entsoe/provider.py
@@ -1,0 +1,43 @@
+import os
+
+# from phase_stat_providers.base import BasePhaseStatProvider
+
+class CarbonIntensityStaticProvider(BasePhaseStatProvider):
+    def __init__(self, value):
+        self._value = value
+        self._data = []
+    def input(metric, detail_name, phase, value, type, max_value, min_value, unit, created_at)
+        self._data.append([
+            'metric': metric,
+            'detail_name': detail_name,
+            'phase': phase,
+            'value': value,
+            'type': type,
+            'max_value': max_value,
+            'min_value': min_value,
+            'unit': unit,
+            'created_at': created_at
+        ])
+
+    def output():
+        for data in self._data:
+            # TODO: Query the API and get an average value
+            from entsoe import EntsoeRawClient
+            # import pandas as pd
+
+            # client = EntsoeRawClient(api_key=<YOUR API KEY>)
+
+            # start = pd.Timestamp('20171201', tz='Europe/Brussels')
+            # end = pd.Timestamp('20180101', tz='Europe/Brussels')
+            # country_code = 'DE'  # Belgium
+            # country_code_from = 'FR'  # France
+            # country_code_to = 'DE_LU' # Germany-Luxembourg
+            # type_marketagreement_type = 'A01'
+            # contract_marketagreement_type = 'A01'
+            # process_type = 'A51'
+
+            # # methods that return XML
+            #
+            intensity = get_intensity(start=data['phase']['start'], end=data['phase']['end'])
+            intensity = transformToMicrogram(intensity)
+            yield (run_id, 'carbon_intensity_entsoe', '[SYSTEM]', f"{idx:03}_{data['phase']['name']}", intensity, 'MEAN', None, None, f"ugCO2e")

--- a/phase_stat_providers/carbon/intensity/static/provider.py
+++ b/phase_stat_providers/carbon/intensity/static/provider.py
@@ -1,0 +1,25 @@
+import os
+
+# from phase_stat_providers.base import BasePhaseStatProvider
+
+class CarbonIntensityStaticProvider(BasePhaseStatProvider):
+    def __init__(self, value):
+        self._value = value
+        self._data = []
+
+    def input(metric, detail_name, phase, value, type, max_value, min_value, unit, created_at)
+        self._data.append([
+            'metric': metric,
+            'detail_name': detail_name,
+            'phase': phase,
+            'value': value,
+            'type': type,
+            'max_value': max_value,
+            'min_value': min_value,
+            'unit': unit,
+            'created_at': created_at
+        ])
+
+    def output():
+        for data in self._data:
+            yield (run_id, 'carbon_intensity_static', '[SYSTEM]', f"{idx:03}_{data['phase']['name']}", self._value, 'MEAN', None, None, f"ugCO2e")

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -100,13 +100,18 @@ def build_and_store_phase_stats(run_id, sci=None):
                 power_min = (min_value * 10**6) / ((phase['end'] - phase['start']) / value_count)
                 csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_sum, 'MEAN', power_max, power_min, 'mW'))
 
+                # -------------- REFACTOR START
                 if metric.endswith('_machine'):
                     machine_co2 = (value_sum / 3_600) * config['sci']['I']
                     csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_co2_')}", detail_name, f"{idx:03}_{phase['name']}", machine_co2, 'TOTAL', None, None, 'ug'))
-
+                # -------------- REFACTOR END
 
             else:
                 csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', max_value, min_value, unit))
+
+
+        # -------------- REFACTOR START
+
         # after going through detail metrics, create cumulated ones
         if network_io_bytes_total:
             # build the network energy
@@ -130,6 +135,9 @@ def build_and_store_phase_stats(run_id, sci=None):
         if phase['name'] == '[RUNTIME]' and machine_co2 is not None and sci is not None \
                          and sci.get('R', None) is not None and sci['R'] != 0:
             csv_buffer.write(generate_csv_line(run_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
+
+
+        # -------------- REFACTOR END
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning


### PR DESCRIPTION
This PR refactors the phase_stats to use a plug-in mechanism.

Concept:

- A new class is created in config.yml: Phase Stats Provider
- This can then define an input that it swallows
- and an output that it emits.
- The provider will then take the input and aggregate it and create an average value
- It needs a name as output
- And the provider can also multiply by a fixed value

- The system gets one or more inputs
    - It can then aggregate these itself, or spit out something per value again

~~Translated with DeepL.com (free version)~~


Note: This PR is a draft and might not come into action in this form. It is public only to track and save progress on Github