### PR TITLE
Added failed run visiblity

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -122,7 +122,7 @@ def get_run_info(run_id):
                     LEFT JOIN categories as t on t.id = elements) as categories,
                 filename, start_measurement, end_measurement,
                 measurement_config, machine_specs, machine_id, usage_scenario,
-                created_at, invalid_run, phases, logs
+                created_at, invalid_run, phases, logs, failed
             FROM runs
             WHERE id = %s
             """

--- a/api/main.py
+++ b/api/main.py
@@ -226,7 +226,7 @@ async def get_repositories(uri: str | None = None, branch: str | None = None, ma
 async def get_runs(uri: str | None = None, branch: str | None = None, machine_id: int | None = None, machine: str | None = None, filename: str | None = None, limit: int | None = None):
 
     query = """
-            SELECT r.id, r.name, r.uri, r.branch, r.created_at, r.invalid_run, r.filename, m.description, r.commit_hash, r.end_measurement
+            SELECT r.id, r.name, r.uri, r.branch, r.created_at, r.invalid_run, r.filename, m.description, r.commit_hash, r.end_measurement, r.failed
             FROM runs as r
             LEFT JOIN machines as m on r.machine_id = m.id
             WHERE 1=1

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -64,6 +64,7 @@ CREATE TABLE runs (
     phases JSON,
     logs text,
     invalid_run text,
+    failed boolean DEFAULT false,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone
 );

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -97,8 +97,12 @@ const getRunsTable = (el, url, include_uri=true, include_button=true, searching=
             title: 'Name',
             render: function(el, type, row) {
 
-                if(row[9] == null) el = `${el} (in progress 🔥)`;
+                // only show Failed OR in Progress
+                if(row[10] == true) el = `${el} <span class="ui red horizontal label">Failed</span>`;
+                else if(row[9] == null) el = `${el} (in progress 🔥)`;
+
                 if(row[5] != null) el = `${el} <span class="ui yellow horizontal label" title="${row[5]}">invalidated</span>`;
+
                 return `<a href="/stats.html?id=${row[0]}" target="_blank">${el}</a>`
             },
         },

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -92,6 +92,9 @@ const fillRunData = (run_data, key = null) => {
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td><a href="${commit_link}" target="_blank">${run_data?.[item]}</a></td></tr>`)
         } else if(item == 'name' || item == 'filename') {
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${run_data?.[item]}</td></tr>`)
+        } else if(item == 'failed' && run_data?.[item] == true) {
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Status</strong></td><td><span class="ui red horizontal label">This run has failed. Please see logs for details</span></td></tr>`)
+
         } else if(item == 'uri') {
             let entry = run_data?.[item];
             if(run_data?.[item].indexOf('http') === 0) entry = `<a href="${run_data?.[item]}">${run_data?.[item]}</a>`;

--- a/migrations/2024_03_19_failed.sql
+++ b/migrations/2024_03_19_failed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."runs" ADD COLUMN "failed" bool DEFAULT FALSE;

--- a/runner.py
+++ b/runner.py
@@ -1309,7 +1309,7 @@ class Runner:
 
     def set_run_failed(self):
         if not self._run_id:
-            raise RuntimeError('Cannot set run to failed as no run_id is yet set!')
+            return # Nothing to do, but also no hard error needed
 
         DB().query("""
             UPDATE runs

--- a/runner.py
+++ b/runner.py
@@ -973,6 +973,8 @@ class Runner:
 
         print(TerminalColors.HEADER, '\nCurrent known containers: ', self.__containers, TerminalColors.ENDC)
 
+    # This method only exists to make logs read-only available outside of the self context
+    # Internally we are still using normal __stdout_logs access to read and not funnel through this method
     def get_logs(self):
         return self.__stdout_logs
 
@@ -1197,7 +1199,7 @@ class Runner:
             else: # implicit 1
                 self.__phases.popitem(last=True)
 
-    # this function should never be called twice to avoid double logging of metrics
+    # this method should never be called twice to avoid double logging of metrics
     def stop_metric_providers(self):
         if self._dev_no_metrics:
             return
@@ -1304,6 +1306,17 @@ class Runner:
             SET start_measurement=%s, end_measurement=%s
             WHERE id = %s
             """, params=(self.__start_measurement, self.__end_measurement, self._run_id))
+
+    def set_run_failed(self):
+        if not self._run_id:
+            raise RuntimeError('Cannot set run to failed as no run_id is yet set!')
+
+        DB().query("""
+            UPDATE runs
+            SET failed = TRUE
+            WHERE id = %s
+            """, params=(self._run_id, ))
+
 
     def store_phases(self):
         print(TerminalColors.HEADER, '\nUpdating phases in DB', TerminalColors.ENDC)
@@ -1421,8 +1434,8 @@ class Runner:
 
     def run(self):
         '''
-            The run function is just a wrapper for the intended sequential flow of a GMT run.
-            Mainly designed to call the functions individually for testing, but also
+            The run method is just a wrapper for the intended sequential flow of a GMT run.
+            Mainly designed to call the methods individually for testing, but also
             if the flow ever needs to repeat certain blocks.
 
             The runner is to be thought of as a state machine.
@@ -1512,6 +1525,7 @@ class Runner:
 
         except BaseException as exc:
             self.add_to_log(exc.__class__.__name__, str(exc))
+            self.set_run_failed()
             raise exc
         finally:
             try:


### PR DESCRIPTION
Before the GMT could not distinguish between a run in progress and a failed run.

Under certain circumstances it can still happen that a run has failed but will show as in progress: When the run starts then fails but the DB also disconnects and the failed state cannot be saved to the database.

This we accept, although it could be fixed by an additional cleaning job that scans the run queue and sets all non-failed jobs that have not ended but are not running to failed

<img width="1176" alt="Screenshot 2024-03-19 at 9 17 55 AM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/3cf8784c-762c-46fd-a1c9-de305b0f641d">
<img width="729" alt="Screenshot 2024-03-19 at 9 18 01 AM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/312d6b82-e5fe-4b0b-b55c-770a89ff72f7">
