### PR TITLE
DB Auto Reconnect on connection drop

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,7 +1,4 @@
 postgresql:
-  # leave the host line empty if you do want to use Unix Domain socket connection
-  # We use container internal networking as it is easier to to setup a test-container-setup
-  # and the performance is identical to socket connections in our internal tests
   host: green-coding-postgres-container
   user: postgres
   dbname: green-coding

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,5 +1,6 @@
 gunicorn==21.2.0
 psycopg[binary]==3.1.18
+psycopg_pool==3.2.1
 fastapi==0.110.0
 starlette>=0.35
 uvicorn[standard]==0.28.0

--- a/docker/startup_gunicorn.sh
+++ b/docker/startup_gunicorn.sh
@@ -2,12 +2,11 @@
 source /var/www/startup/venv/bin/activate
 
 /var/www/startup/venv/bin/gunicorn \
---workers=2 \
+--workers=8 \
 --access-logfile=- \
 --error-logfile=- \
 --worker-tmp-dir=/dev/shm \
---threads=4 \
---worker-class=gthread \
+--worker-class=uvicorn.workers.UvicornWorker \
 --bind unix:/tmp/green-coding-api.sock \
 -m 007 \
 --user www-data \

--- a/lib/db.py
+++ b/lib/db.py
@@ -21,31 +21,19 @@ class DB:
             # Users are required to use the mask of the API requests to read the data.
             # force domain socket connection by not supplying host
             # pylint: disable=consider-using-f-string
-            if config['postgresql']['host'] is None:
-                self._pool = ConnectionPool(
-                    "postgresql://%s:%s@localhost:%s/%s" % (
-                        config['postgresql']['user'],
-                        config['postgresql']['password'],
-                        config['postgresql']['port'],
-                        config['postgresql']['dbname'],
-                    ),
-                    min_size=1,
-                    max_size=2,
-                    open=True
-                )
-            else:
-                self._pool = ConnectionPool(
-                    "postgresql://%s:%s@%s:%s/%s" % (
-                        config['postgresql']['user'],
-                        config['postgresql']['password'],
-                        config['postgresql']['host'],
-                        config['postgresql']['port'],
-                        config['postgresql']['dbname'],
-                    ),
-                    min_size=1,
-                    max_size=2,
-                    open=True
-                )
+
+            self._pool = ConnectionPool(
+                "postgresql://%s:%s@%s:%s/%s" % (
+                    config['postgresql']['user'],
+                    config['postgresql']['password'],
+                    config['postgresql']['host'],
+                    config['postgresql']['port'],
+                    config['postgresql']['dbname'],
+                ),
+                min_size=1,
+                max_size=2,
+                open=True
+            )
 
     def __query(self, query, params=None, return_type=None, row_factory=None):
         ret = False

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -34,7 +34,7 @@ class ConfigurationCheckError(Exception):
 ######## CHECK FUNCTIONS ########
 def check_db():
     try:
-        DB()
+        DB().query('SELECT 1')
     except psycopg_OperationalError:
         error_helpers.log_error('DB is not available. Did you start the docker containers?')
         os._exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PyYAML==6.0.1
 pandas==2.2.1
 psycopg[binary]==3.1.18
+psycopg_pool==3.2.1
 pyserial==3.5
 psutil==5.9.8
 schema==0.7.5


### PR DESCRIPTION
The easiest way is to use the implemented psycopg_pool class which implements dynamic retry times with increasing wait times: https://www.psycopg.org/articles/2021/01/17/pool-design/

Since we have no async or mutli-processing code the pool has no further advantage. I still opted for two connections open to have a failover

The pool itself is not opened through a context manager to have the connections be reused

Furthermore all rollback and error handling code has been removed, as the context manager takes care of this. The error only bubbles if the retry count of 30 seconds is exceeded.

Using this mechanic can be problematic for a benchmarking tool in the first place and allows us only to make DB connections when NO benchmarking is happing, which means in between any actual measurement phases.

@ribalba Is this assumption valid? Did I forget any place where excessive retries might happen that then not fail since after some time the connection comes up again? But then have skewed measurements?