### PR TITLE
Caching pip packages betweeen docker builds

### DIFF
--- a/docker/Dockerfile-gunicorn
+++ b/docker/Dockerfile-gunicorn
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 FROM python:3.12.2-slim-bookworm
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,9 +5,10 @@ WORKDIR /var/www/startup/
 COPY requirements.txt requirements.txt
 RUN python -m venv venv
 RUN venv/bin/pip install --upgrade pip
-RUN venv/bin/pip install -r requirements.txt
-RUN find venv -type d -name "site-packages" -exec sh -c 'echo /var/www/green-metrics-tool > "$0/gmt-lib.pth"' {} \;
+RUN --mount=type=cache,target=/root/.cache/pip venv/bin/pip install -r requirements.txt
 
+# This sets the include path for python, so we can use a module like include syntax in our files
+RUN find venv -type d -name "site-packages" -exec sh -c 'echo /var/www/green-metrics-tool > "$0/gmt-lib.pth"' {} \;
 
 COPY startup_gunicorn.sh /var/www/startup/startup_gunicorn.sh
 


### PR DESCRIPTION
This introduces the *new* buildx caching mechanism that even allows caches between builds and is outside of the layer caching.

Effectively now python packages will be cached and do no need to be redownloaded when building the gunicorn container for production or testing. Only if packages are updated.

What I did not introduce is to map it also to the OS cache, so it means that when we upgrade pandas it will still be downloaded 2 times. For the host OS install and for the docker container.

I found this to be more sane as otherwise I had to mount an external volume into the container which seems possible, but I could not get it working directly as it is outside of the build context in ../venv ... maybe a fix for a future improvement