### PR TITLE
orjson requirement added

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -232,6 +232,7 @@ if [[ $no_python != true ]] ; then
     print_message "Updating python requirements"
     python3 -m pip install --upgrade pip
     python3 -m pip install -r requirements.txt
+    python3 -m pip install -r docker/requirements.txt
     python3 -m pip install -r metric_providers/psu/energy/ac/xgboost/machine/model/requirements.txt
 fi
 

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -173,6 +173,7 @@ if [[ $no_python != true ]] ; then
     print_message "Updating python requirements"
     python3 -m pip install --upgrade pip
     python3 -m pip install -r requirements.txt
+    python3 -m pip install -r docker/requirements.txt
     python3 -m pip install -r metric_providers/psu/energy/ac/xgboost/machine/model/requirements.txt
 fi
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,4 @@
 -r requirements.txt
 pydantic==2.6.4
 pytest==8.1.1
-requests==2.31.0
 pylint==3.1.0
-starlette>=0.32
-anybadge==1.14.0
-
-# just to clear the pylint errors for the files in /api
-scipy==1.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,3 @@ anybadge==1.14.0
 
 # just to clear the pylint errors for the files in /api
 scipy==1.12.0
-orjson==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,8 @@ psycopg_pool==3.2.1
 pyserial==3.5
 psutil==5.9.8
 schema==0.7.5
-anybadge==1.14.0
-requests==2.31.0
-fastapi==0.110.0
-orjson==3.10.0
 
 # calibration script dep
 tqdm==4.66.2
 plotext==5.2.8
 docker==7.0.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,10 @@ schema==0.7.5
 anybadge==1.14.0
 requests==2.31.0
 fastapi==0.110.0
+orjson==3.10.0
 
 # calibration script dep
 tqdm==4.66.2
 plotext==5.2.8
 docker==7.0.0
+


### PR DESCRIPTION
orjson is a requirement since the optimizations were introduced for the normal runner.py too.

Currently we only install it through `requirements-dev.txt` 

Since our unit tests install this file this dependency issue was not spotted.

This PR normalizes the install by not having functional requirements in the `requirements-dev.txt` but only such needed for pure testing.


Additionally all functional requirements for API includes are now fully installed to reduce complexity as a tradeoff for unneeded install on non-API machines (measurement nodes)