### PR TITLE
Mcp energy fix

### DIFF
--- a/metric_providers/psu/energy/ac/mcp/machine/provider.py
+++ b/metric_providers/psu/energy/ac/mcp/machine/provider.py
@@ -13,3 +13,33 @@ class PsuEnergyAcMcpMachineProvider(BaseMetricProvider):
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,
         )
+
+    def read_metrics(self, run_id, containers=None):
+        df = super().read_metrics(run_id, containers)
+
+        '''
+        Conversion to Joules
+
+        If ever in need to convert the database from Joules back to a power format:
+
+        WITH times as (
+                    SELECT id, value, detail_name, time, (time - LAG(time) OVER (ORDER BY detail_name ASC, time ASC)) AS diff, unit
+                    FROM measurements
+                    WHERE run_id = RUN_ID AND metric = 'psu_energy_ac_ipmi_machine'
+
+                    ORDER BY detail_name ASC, time ASC)
+                    SELECT *, value / (diff / 1000) as power FROM times;
+
+        One can see that the value only changes once per second
+        '''
+
+        intervals = df['time'].diff()
+        intervals[0] = intervals.mean()  # approximate first interval
+        df['interval'] = intervals  # in microseconds
+        df['value'] = df.apply(lambda x: x['value'] * x['interval'] / 1_000_00, axis=1) # value is in centiwatts, so divide by 1_000_00 instead of 1_000 as we would do for Watts
+        df['value'] = df.value.fillna(0) # maybe not needed
+        df['value'] = df.value.astype(int)
+
+        df = df.drop(columns='interval')  # clean up
+
+        return df

--- a/metric_providers/psu/energy/ac/mcp/machine/source.c
+++ b/metric_providers/psu/energy/ac/mcp/machine/source.c
@@ -261,7 +261,7 @@ int main(int argc, char **argv) {
         }
         // The MCP returns the current power consumption in 10mW steps.
         gettimeofday(&now, NULL);
-        printf("%ld%06ld %ld\n", now.tv_sec, now.tv_usec, (long)(data[0]*10*((double)msleep_time/1000)) );
+        printf("%ld%06ld %d\n", now.tv_sec, now.tv_usec, data[0]);
         usleep(msleep_time*1000);
     }
     close(fd);


### PR DESCRIPTION
The MCP was experiencing issues when the measurement interval set below 10 ms.

The results where close to zero or even negative apparent power. By identifying the protocol on https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/20005473B.pdf it shows that the MCP is using an internal measurement interval to estimate the current frequency and also the power factor.
This estimation can guess a negative power factor, which is physically incorrect and thus a definite bug. Why this error internally occurs is unclear, but it can be mitigated by setting a different measurement interval.

The equation is 2^n*(1/f) (f = 50 Hz for typical networks in europe):
- n=1 => 40 ms
- n=2 => 80 ms
- n=3 => 160 ms
- n=4 => 320 ms
etc.

Good values can be achieved with n=1 so this PR sets this as default.

2. Furthermore when making shorter intervals the current way of calculating energy showed a problem with the OS. The sleep times where getting more unreliable, so calculating the energy beforehand in the C-Code was getting to low values.

By only calculating the energy only when the timestamps are set by reading the output stream gives more reliable and accurate results.