### PR TITLE
Normalized -i switch to always be ms

### DIFF
--- a/metric_providers/cpu/frequency/sysfs/core/get-scaling-cur-freq.sh
+++ b/metric_providers/cpu/frequency/sysfs/core/get-scaling-cur-freq.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cores=$(cat /proc/cpuinfo | grep processor | awk '{print $3}')
 check_system=false
-i=''
+i='100'
 
 while getopts "i:c" o; do
     case "$o" in
@@ -15,6 +15,8 @@ while getopts "i:c" o; do
             ;;
     esac
 done
+
+i=$(bc <<< "scale=3; $i / 1000")
 
 if $check_system; then
     file_path="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
@@ -37,5 +39,5 @@ while true; do
     for core in $cores; do
         echo -en $(($(date +%s%N)/1000)) $(cat /sys/devices/system/cpu/cpu${core}/cpufreq/scaling_cur_freq) "${core}\n"
     done
-    sleep ${i:-0.1}
+    sleep $i
 done

--- a/metric_providers/cpu/frequency/sysfs/core/provider.py
+++ b/metric_providers/cpu/frequency/sysfs/core/provider.py
@@ -7,7 +7,7 @@ class CpuFrequencySysfsCoreProvider(BaseMetricProvider):
         super().__init__(
             metric_name='cpu_frequency_sysfs_core',
             metrics={'time': int, 'value': int, 'core_id': int},
-            resolution=0.001*resolution,
+            resolution=resolution,
             unit='Hz',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='get-scaling-cur-freq.sh',

--- a/metric_providers/gpu/energy/nvidia/smi/component/README.md
+++ b/metric_providers/gpu/energy/nvidia/smi/component/README.md
@@ -1,0 +1,5 @@
+# Information
+
+See https://docs.green-coding.io/docs/measuring/metric-providers/gpu-energy-nvidia-smi-component/ for details.
+
+This provider uses NVIDIA-SMI to read the current power from the GPU.

--- a/metric_providers/gpu/energy/nvidia/smi/component/metric-provider-nvidia-smi-wrapper.sh
+++ b/metric_providers/gpu/energy/nvidia/smi/component/metric-provider-nvidia-smi-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-i=''
+i='100'
 
 while getopts "i:" o; do
     case "$o" in
@@ -11,8 +11,9 @@ while getopts "i:" o; do
     esac
 done
 
+i=$(bc <<< "scale=3; $i / 1000")
 
 while true; do
-    echo -en $(($(date +%s%N)/1000)) $(nvidia-smi --query-gpu=power.draw --format=csv,noheader,nounits| awk '{ gsub("\\.", ""); print }')"\n"
-    sleep ${i:-0.1}
+    echo -en $(($(date +%s%N)/1000)) $(nvidia-smi --query-gpu=power.draw --format=csv,noheader,nounits| awk '{ gsub("\\.", ""); print }')"0\n"
+    sleep $i
 done

--- a/metric_providers/gpu/energy/nvidia/smi/component/provider.py
+++ b/metric_providers/gpu/energy/nvidia/smi/component/provider.py
@@ -7,7 +7,7 @@ class GpuEnergyNvidiaSmiComponentProvider(BaseMetricProvider):
         super().__init__(
             metric_name='gpu_energy_nvidia_smi_component',
             metrics={'time': int, 'value': int},
-            resolution=0.001 * resolution,
+            resolution=resolution,
             unit='mJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='metric-provider-nvidia-smi-wrapper.sh',
@@ -40,8 +40,8 @@ class GpuEnergyNvidiaSmiComponentProvider(BaseMetricProvider):
         intervals = df['time'].diff()
         intervals[0] = intervals.mean()  # approximate first interval
         df['interval'] = intervals  # in microseconds
-        # value is initially not in Watts, but in centiWatts. So we just divide by 1_000_00
-        df['value'] = df.apply(lambda x: x['value'] * x['interval'] / 1_000_00, axis=1)
+        # value is initially in milliWatts. So we just divide by 1_000_000
+        df['value'] = df.apply(lambda x: x['value'] * x['interval'] / 1_000_000, axis=1)
         df['value'] = df.value.fillna(0) # maybe not needed
         df['value'] = df.value.astype(int)
 

--- a/metric_providers/psu/energy/ac/ipmi/machine/ipmi-get-machine-energy-stat.sh
+++ b/metric_providers/psu/energy/ac/ipmi/machine/ipmi-get-machine-energy-stat.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -euo pipefail
 
-i=''
+i='100'
 check_system=false
 while getopts "i:c" o; do
     case "$o" in
@@ -13,6 +13,8 @@ while getopts "i:c" o; do
             ;;
     esac
 done
+
+i=$(bc <<< "scale=3; $i / 1000")
 
 if $check_system; then
     first_line=$(sudo /usr/sbin/ipmi-dcmi --get-system-power-statistics | head -1)
@@ -32,7 +34,6 @@ fi
 
 
 while true; do
-    echo -en $(($(date +%s%N)/1000)) $(sudo /usr/sbin/ipmi-dcmi --get-system-power-statistics | head -1 |  awk '{print $4}')"\n"
-    sleep ${i:-0.1}
-
+    echo -en $(($(date +%s%N)/1000)) $(sudo /usr/sbin/ipmi-dcmi --get-system-power-statistics | head -1 |  awk '{print $4}')"000\n"
+    sleep $i
 done

--- a/metric_providers/psu/energy/ac/ipmi/machine/provider.py
+++ b/metric_providers/psu/energy/ac/ipmi/machine/provider.py
@@ -7,7 +7,7 @@ class PsuEnergyAcIpmiMachineProvider(BaseMetricProvider):
         super().__init__(
             metric_name='psu_energy_ac_ipmi_machine',
             metrics={'time': int, 'value': int},
-            resolution=0.001 * resolution,
+            resolution=resolution,
             unit='mJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='ipmi-get-machine-energy-stat.sh',
@@ -37,7 +37,7 @@ class PsuEnergyAcIpmiMachineProvider(BaseMetricProvider):
         intervals = df['time'].diff()
         intervals[0] = intervals.mean()  # approximate first interval
         df['interval'] = intervals  # in microseconds
-        df['value'] = df.apply(lambda x: x['value'] * x['interval'] / 1_000, axis=1)
+        df['value'] = df.apply(lambda x: x['value'] * x['interval'] / 1_000_000, axis=1)
         df['value'] = df.value.fillna(0) # maybe not needed
         df['value'] = df.value.astype(int)
 

--- a/metric_providers/psu/energy/dc/rapl/msr/machine/README.md
+++ b/metric_providers/psu/energy/dc/rapl/msr/machine/README.md
@@ -6,7 +6,7 @@ It will require `sudo` rights as it will set the UID bit.
 
 # Running
 
-Just run `./metric-provider-binary -d`.
+Just run `./metric-provider-binary -p`.
 
 You can specify a resoltion for the output frequency in *ms* through the `-i` flag.
 


### PR DESCRIPTION
Some reporters where using `-i 0.1` to sleep for 100 ms and some `-i 100` to sleep for 100 ms

This is now normalized.

The initial design decision was to to the least amount possible in the reporters in terms of conversion when collecting data. However we could not measure any difference in energy or time when using the non-conversion approach. So we opted for better consistency.