### PR TITLE
Added taskset directive

### DIFF
--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -168,6 +168,8 @@ class BaseMetricProvider:
 
         call_string += f" > {self._filename}"
 
+        call_string = f"taskset -c 0 {call_string}"
+
         if self._disable_buffer:
             call_string = f"stdbuf -o0 {call_string}"
 


### PR DESCRIPTION
Metric reporters will here always be placed on core 0.

Making this CPU pinning decreases system energy use through the fact that the other cores can stay in deeper C-States.

Following scripts illustrate the concept:

# Code with taskset
```bash
#!/bin/bash
set -euo pipefail

pgrep -f metric_providers | xargs kill -9

taskset -c 0 ~/green-metrics-tool/metric_providers/cpu/energy/rapl/msr/component/metric-provider-binary -i 10 > /tmp/cpu-read &
taskset -c 0 ~/green-metrics-tool/metric_providers/memory/energy/rapl/msr/component/metric-provider-binary -i 10 > /tmp/memory-read &
taskset -c 0 ~/green-metrics-tool/metric_providers/psu/energy/dc/rapl/msr/machine/metric-provider-binary -i 10 > /tmp/psys-read &
taskset -c 0 ~/green-metrics-tool/metric_providers/psu/energy/dc/rapl/msr/machine/metric-provider-binary -i 10 > /tmp/psys-read &
taskset -c 0 ~/green-metrics-tool/metric_providers/cpu/frequency/sysfs/core/get-scaling-cur-freq.sh -i 1 > /tmp/freq-read &
taskset -c 0 ~/green-metrics-tool/metric_providers/cpu/utilization/procfs/system/metric-provider-binary -i 10 > /tmp/procfs-read &


sudo perf stat -a -r 10 -e power/energy-pkg/,power/energy-psys/ sleep 10

echo "power for taskset"

pgrep -f metric_providers | xargs kill -9

# Performance counter stats for 'system wide' (10 runs):

#             24.92 Joules power/energy-pkg/                                                       ( +-  0.44% )
#             46.60 Joules power/energy-psys/                                                      ( +-  0.82% )

#        10.0009528 +- 0.0000196 seconds time elapsed  ( +-  0.00% )
```

# Code without taskset

```bash
#!/bin/bash
set -euo pipefail

pgrep -f metric_providers | xargs kill -9

~/green-metrics-tool/metric_providers/cpu/energy/rapl/msr/component/metric-provider-binary -i 10 > /tmp/cpu-read &
~/green-metrics-tool/metric_providers/memory/energy/rapl/msr/component/metric-provider-binary -i 10 > /tmp/memory-read &
~/green-metrics-tool/metric_providers/psu/energy/dc/rapl/msr/machine/metric-provider-binary -i 10 > /tmp/psys-read &
~/green-metrics-tool/metric_providers/psu/energy/dc/rapl/msr/machine/metric-provider-binary -i 10 > /tmp/psys-read &
~/green-metrics-tool/metric_providers/cpu/frequency/sysfs/core/get-scaling-cur-freq.sh -i 1 > /tmp/freq-read &
~/green-metrics-tool/metric_providers/cpu/utilization/procfs/system/metric-provider-binary -i 10 > /tmp/procfs-read &

sudo perf stat -a -r 10 -e power/energy-pkg/,power/energy-psys/ sleep 10

echo "power without taskset"

pgrep -f metric_providers | xargs kill -9


# Data from Arne
# Performance counter stats for 'system wide' (10 runs):

#             36.25 Joules power/energy-pkg/                                                       ( +-  0.79% )
#             71.82 Joules power/energy-psys/                                                      ( +-  0.87% )

#         10.001778 +- 0.000540 seconds time elapsed  ( +-  0.01% )

```

The gain on an idle system is around 50%. However absolute gain is still very low, as the reporters are already very efficient. 
Please note that these micro-benchmarks have been done with 10 ms sampling interval which anyway is not recommended and puts a high strain on the CPU.

## Caveats / System Checks

At first we thought of implementing a system check to determine if any other processes are maybe already pinned onto core 0 that might induce a problem with too many tasks on the core.

However linux already pins many tasks to core 0 and we anyway check for high base utilization, so we opted against it.

Here an example output of set core affinities in a Ubuntu Linux 22.04. The number in the brackets at the beginning shows the allowed cores.

```console
[0, 1, 2, 3, 4, 5, 6, 7] psutil.Process(pid=2209, name='snapd-desktop-integration', status='sleeping', started='17:56:51')
[0, 1, 2, 3, 4, 5, 6, 7] psutil.Process(pid=2217, name='sshd', status='sleeping', started='17:56:55')
[0, 1, 2, 3, 4, 5, 6, 7] psutil.Process(pid=2254, name='sshd', status='sleeping', started='17:56:56')
[0, 1, 2, 3, 4, 5, 6, 7] psutil.Process(pid=2255, name='bash', status='sleeping', started='17:56:56')
[0] psutil.Process(pid=2431, name='kworker/0:4-kacpi_notify', status='idle', started='17:59:22')
[0] psutil.Process(pid=2432, name='kworker/0:5-kacpi_notify', status='idle', started='17:59:22')
[0] psutil.Process(pid=2433, name='kworker/0:6-pm', status='idle', started='17:59:22')
[0] psutil.Process(pid=2434, name='kworker/0:7-pm', status='idle', started='17:59:22')
[0] psutil.Process(pid=2435, name='kworker/0:8-kacpi_notify', status='idle', started='17:59:22')
[0] psutil.Process(pid=2436, name='kworker/0:9-pm', status='idle', started='17:59:22')
[0] psutil.Process(pid=2437, name='kworker/0:10-events_freezable', status='idle', started='17:59:22')
[4] psutil.Process(pid=2871, name='kworker/4:2-events', status='idle', started='18:01:47')
[5] psutil.Process(pid=2876, name='kworker/5:0-cgroup_destroy', status='idle', started='18:01:55')
[7] psutil.Process(pid=2877, name='kworker/7:0-events', status='idle', started='18:01:55')
[7] psutil.Process(pid=3077, name='kworker/7:3', status='idle', started='18:02:47')
[0] psutil.Process(pid=3078, name='kworker/0:11-pm', status='idle', started='18:03:10')
[2] psutil.Process(pid=3153, name='kworker/2:0+events', status='disk-sleep', started='18:04:13')
[1] psutil.Process(pid=3154, name='kworker/1:0-events', status='idle', started='18:04:36')
[1] psutil.Process(pid=3156, name='kworker/1:1-events', status='idle', started='18:04:54')
[3] psutil.Process(pid=3249, name='kworker/3:1', status='idle', started='18:05:05')
```

