### PR TITLE
Added sorting by date and unified ci and measurement runs frontend

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -174,12 +174,15 @@ async def get_machines():
     return ORJSONResponse({'success': True, 'data': data})
 
 @app.get('/v1/repositories')
-async def get_repositories(uri: str | None = None, branch: str | None = None, machine_id: int | None = None, machine: str | None = None, filename: str | None = None, ):
+async def get_repositories(uri: str | None = None, branch: str | None = None, machine_id: int | None = None, machine: str | None = None, filename: str | None = None, sort_by: str = 'name'):
     query = """
-            SELECT DISTINCT(r.uri)
+            SELECT
+                r.uri,
+                MAX(r.created_at) as last_run
             FROM runs as r
             LEFT JOIN machines as m on r.machine_id = m.id
             WHERE 1=1
+            GROUP BY r.uri
             """
     params = []
 
@@ -203,8 +206,10 @@ async def get_repositories(uri: str | None = None, branch: str | None = None, ma
         query = f"{query} AND m.description LIKE %s \n"
         params.append(f"%{machine}%")
 
-
-    query = f"{query} ORDER BY r.uri ASC"
+    if sort_by == 'name':
+        query = f"{query} ORDER BY r.uri ASC"
+    else:
+        query = f"{query} ORDER BY last_run DESC"
 
     data = DB().fetch_all(query, params=tuple(params))
     if data is None or data == []:
@@ -1267,10 +1272,40 @@ async def get_ci_measurements(repo: str, branch: str, workflow: str, start_date:
 
     return ORJSONResponse({'success': True, 'data': data})
 
-@app.get('/v1/ci/projects')
-async def get_ci_projects():
+@app.get('/v1/ci/repositories')
+async def get_ci_repositories(repo: str | None = None, sort_by: str = 'name'):
+
+    params = []
     query = """
-        SELECT repo, branch, workflow_id, source, MAX(created_at),
+        SELECT repo, source, MAX(created_at) as last_run
+        FROM ci_measurements
+        WHERE 1=1
+    """
+
+    if repo: # filter is currently not used, but may be a feature in the future
+        query = f"{query} AND ci_measurements.repo = %s  \n"
+        params.append(repo)
+
+    query = f"{query} GROUP BY repo, source"
+
+    if sort_by == 'date':
+        query = f"{query} ORDER BY last_run DESC"
+    else:
+        query = f"{query} ORDER BY repo ASC"
+
+    data = DB().fetch_all(query, params=tuple(params))
+    if data is None or data == []:
+        return Response(status_code=204) # No-Content
+
+    return ORJSONResponse({'success': True, 'data': data}) # no escaping needed, as it happend on ingest
+
+
+@app.get('/v1/ci/runs')
+async def get_ci_runs(repo: str, sort_by: str = 'name'):
+
+    params = []
+    query = """
+        SELECT repo, branch, workflow_id, source, MAX(created_at) as last_run,
                 (SELECT workflow_name FROM ci_measurements AS latest_workflow
                 WHERE latest_workflow.repo = ci_measurements.repo
                 AND latest_workflow.branch = ci_measurements.branch
@@ -1278,15 +1313,23 @@ async def get_ci_projects():
                 ORDER BY latest_workflow.created_at DESC
                 LIMIT 1) AS workflow_name
         FROM ci_measurements
-        GROUP BY repo, branch, workflow_id, source
-        ORDER BY repo ASC
+        WHERE 1=1
     """
 
-    data = DB().fetch_all(query)
+    query = f"{query} AND ci_measurements.repo = %s  \n"
+    params.append(repo)
+    query = f"{query} GROUP BY repo, branch, workflow_id, source"
+
+    if sort_by == 'date':
+        query = f"{query} ORDER BY last_run DESC"
+    else:
+        query = f"{query} ORDER BY repo ASC"
+
+    data = DB().fetch_all(query, params=tuple(params))
     if data is None or data == []:
         return Response(status_code=204) # No-Content
 
-    return ORJSONResponse({'success': True, 'data': data})
+    return ORJSONResponse({'success': True, 'data': data}) # no escaping needed, as it happend on ingest
 
 @app.get('/v1/ci/badge/get')
 async def get_ci_badge_get(repo: str, branch: str, workflow:str):

--- a/frontend/ci-index.html
+++ b/frontend/ci-index.html
@@ -14,6 +14,7 @@
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="description" content="Measuring the energy of your software" />
     <script src="/dist/js/jquery.min.js" defer></script>
+    <script src="/dist/js/datatables.min.js" defer></script>
     <script src="/dist/js/accordion.min.js" defer></script>
     <script src="/dist/js/tablesort.min.js" defer></script>
     <script src="/dist/js/transition.min.js" defer></script>
@@ -23,6 +24,8 @@
     <script src="/js/ci-index.js" defer></script>
     <link rel="stylesheet" type="text/css" class="ui" href="/dist/css/semantic_reduced.min.css">
     <link rel="stylesheet" type="text/css" href="/css/green-coding.css">
+    <link rel="stylesheet" type="text/css" href="/dist/css/datatables.min.css">
+
 </head>
 <body class="preload">
     <gmt-menu></gmt-menu>
@@ -40,10 +43,13 @@
             <div class="results"></div>
         </div>
 -->
-        <table id="projects-table" class="ui celled striped table">
+        <table id="repositories-table" class="ui celled striped table">
             <thead>
                 <tr>
-                    <th>Repository (<i class="icon code github"></i> / <i class="icon code gitlab"></i>)</th>
+                    <th>
+                        Repository (<i class="icon code github"></i> / <i class="icon code gitlab"></i>)
+                        <button id="sort-button" class="ui small button right purple"><i class="clock icon"></i><span>Sort date</span></button>
+                    </th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/frontend/ci-index.html
+++ b/frontend/ci-index.html
@@ -48,7 +48,7 @@
                 <tr>
                     <th>
                         Repository (<i class="icon code github"></i> / <i class="icon code gitlab"></i>)
-                        <button id="sort-button" class="ui small button right purple"><i class="clock icon"></i><span>Sort date</span></button>
+                        <button id="sort-button" class="ui small button right purple"><i class="font icon"></i><span>Sort name</span></button>
                     </th>
                 </tr>
             </thead>

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -270,10 +270,14 @@ a,
     overflow: scroll;
 }
 
-#compare-button {
+#compare-button, #sort-button {
     float: right;
 }
 
 .wide.card {
     width: 400px !important;
+}
+
+.float-right {
+    float: right;
 }

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -190,17 +190,17 @@ let closeMenu = function(e){
 
 async function sortDate() {
     const button = document.querySelector('#sort-button')
-    button.addEventListener('click', sortName);
     button.removeEventListener('click', sortDate);
-    button.querySelector('span').textContent = 'Sort name';
+    button.addEventListener('click', sortName);
+    button.innerHTML = '<i class="font icon"></i>Sort name';
     await getRepositories('date');
 }
 
 async function sortName() {
     const button = document.querySelector('#sort-button')
-    button.addEventListener('click', sortDate);
     button.removeEventListener('click', sortName);
-    button.querySelector('span').textContent = 'Sort date';
+    button.addEventListener('click', sortDate);
+    button.innerHTML = '<i class="clock icon"></i>Sort date';
     await getRepositories('name');
 }
 

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -188,6 +188,22 @@ let closeMenu = function(e){
     localStorage.setItem('menu_closed', true)
 }
 
+async function sortDate() {
+    const button = document.querySelector('#sort-button')
+    button.addEventListener('click', sortName);
+    button.removeEventListener('click', sortDate);
+    button.querySelector('span').textContent = 'Sort name';
+    await getRepositories('date');
+}
+
+async function sortName() {
+    const button = document.querySelector('#sort-button')
+    button.addEventListener('click', sortDate);
+    button.removeEventListener('click', sortName);
+    button.querySelector('span').textContent = 'Sort date';
+    await getRepositories('name');
+}
+
 $(document).ready(function () {
     $(document).on('click','#menu-toggle.closed', openMenu);
     $(document).on('click','#menu-toggle.opened', closeMenu);

--- a/frontend/js/repositories.js
+++ b/frontend/js/repositories.js
@@ -7,7 +7,7 @@ async function getRepositories(sort_by = 'date') {
     }
 
     const table_body = document.querySelector('#repositories-table tbody')
-    table_body = .innerHTML = '';
+    table_body.innerHTML = '';
 
     api_data.data.forEach(el => {
 

--- a/frontend/js/repositories.js
+++ b/frontend/js/repositories.js
@@ -1,30 +1,31 @@
-(async () => {
-
+async function getRepositories(sort_by = 'date') {
     try {
-
-        var api_data = await makeAPICall(`/v1/repositories?${getFilterQueryStringFromURI()}`)
+        var api_data = await makeAPICall(`/v1/repositories?${getFilterQueryStringFromURI()}&sort_by=${sort_by}`)
     } catch (err) {
         showNotification('Could not get data from API', err);
         return
     }
 
+    const table_body = document.querySelector('#repositories-table tbody')
+    table_body = .innerHTML = '';
 
     api_data.data.forEach(el => {
 
-        const uri = el[0]
+        const uri = el[0];
+        const last_run = el[1];
         let uri_link = replaceRepoIcon(uri);
 
         if (uri.startsWith("http")) {
             uri_link = `${uri_link} <a href="${uri}"><i class="icon external alternate"></i></a>`;
         }
 
-
-        let row = document.querySelector('#repositories-table tbody').insertRow()
+        let row = table_body.insertRow()
         row.innerHTML = `
             <td>
                 <div class="ui accordion" style="width: 100%;">
                   <div class="title">
                     <i class="dropdown icon"></i> ${uri_link}
+                    <span class="ui label float-right"><i class="clock icon"></i> ${dateToYMD(new Date(last_run), short=true)}</span>
                   </div>
                   <div class="content" data-uri="${uri}">
                       <table class="ui celled striped table"></table>
@@ -41,4 +42,8 @@
                 getRunsTable($(table), `${API_URL}/v1/runs?uri=${uri}`, false, false, true)
             }
     }});
+}
+
+(async () => {
+    await sortDate();
 })();

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -62,7 +62,7 @@
                     <th>
                         Repositories (<i class="icon code github"></i> / <i class="icon code gitlab"></i> / <i class="icon code folder"></i> etc.)
                         <button id="compare-button" onclick="compareButton()" class="ui small button blue right">Compare: 0 Run(s)</button>
-                        <button id="sort-button" class="ui small button right purple"><i class="clock icon"></i><span>Sort date</span></button>
+                        <button id="sort-button" class="ui small button right purple"><i class="text icon"></i><span>Sort name</span></button>
                     </th>
                 </tr>
             </thead>

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -61,7 +61,9 @@
                 <tr>
                     <th>
                         Repositories (<i class="icon code github"></i> / <i class="icon code gitlab"></i> / <i class="icon code folder"></i> etc.)
-                        <button id="compare-button" onclick="compareButton()" class="ui small button blue right">Compare: 0 Run(s)</button></th>
+                        <button id="compare-button" onclick="compareButton()" class="ui small button blue right">Compare: 0 Run(s)</button>
+                        <button id="sort-button" class="ui small button right purple"><i class="clock icon"></i><span>Sort date</span></button>
+                    </th>
                 </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
CI Runs and Measurement runs can now be sorted by date and show directly when the last run happened.

Since the list became quite long this feature is needed for us to have an overview quickly which repos are active and receiving current runs.

Also sorting by name was made optional through an extra button
<img width="1128" alt="Screenshot 2024-05-12 at 1 22 53 PM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/e82d5c51-943a-47a3-b2a8-8b65664535c1">
