### PR TITLE
Carbondb 2.0

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1427,8 +1427,8 @@ class EnergyData(BaseModel):
     machine: UUID
     project: Optional[str] = None
     tags: Optional[str] = None
-    time_stamp: str # is expected to be in microseconds
-    energy_value: str # is expected to be in mJ
+    time_stamp: str # value is in microseconds
+    energy_value: str # value is in Joules
 
     @field_validator('company', 'project', 'tags')
     @classmethod

--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -151,7 +151,7 @@
                     <th>Commit Hash</th>
                     <th>Location</th>
                     <th>Grid Intensity</th>
-                    <th>CO2eq of run</th>
+                    <th>gCO2eq of run</th>
                 </tr>
             </thead>
             <tbody id="ci-table"></tbody>

--- a/migrations/2024_05_19_carbondb.sql
+++ b/migrations/2024_05_19_carbondb.sql
@@ -1,0 +1,2 @@
+ALTER TABLE carbondb_energy_data_day DROP CONSTRAINT unique_machine_project_date;
+CREATE UNIQUE INDEX idx_carbondb_unique_entry ON carbondb_energy_data_day(type, company, machine, project, tags, date );


### PR DESCRIPTION
I toyed around with CarbonDB over the weekend and we now have the solar panel in CarbonDB reporting!

- Panel: https://metrics.green-coding.io/carbondb-lists.html?company_uuid=20b269ce-cd67-4788-8614-030eaf5a0b47&tag=GCS%20HQ%20Solar%20Panel&tag=GCS%20HQ%20Solar%20Panel
- Company total: https://metrics.green-coding.io/carbondb-lists.html?company_uuid=20b269ce-cd67-4788-8614-030eaf5a0b47

I integrated it in that form that the resulting CO2e is negative. This is debateable, but gives us a better view on generation vs. consumption vs. reduction.
<img width="831" alt="Screenshot 2024-05-19 at 4 42 28 PM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/ecc98d7f-d6fa-4d77-92d4-a012621f8406">

In any case: The sun is shining today and in the 1 hour I am working here we have already saved 5 g of CO2. Yay!

## In this PR I did:
- Make clear in frontend which dimension the values have
- Updated compress constraints, as it can happen that machines switch their tags, project etc. and this was not represented in the unique constraint which was only for day and machine (@ribalba  - Please confirm that change is valid!)

## TODO

CarbonDB is great but in the current form still too raw. Many things came to my attention that this draft PR shall discuss
- Having the values for intensity and energy string I thing is the wrong approach. First of all it is different to all the other tables. Then also we do sums and averages and float math are inaccurate. I would vote for making this uniform
- Grouping on these fields however introduces an error which is when fields can be `NULL`. CarbonDB creates duplicate rows then, see https://metrics.green-coding.io/carbondb-details.html?machine_uuid=e732e9b9-2daa-4177-a5c3-20af79567a66 for `2024-05-19 `
- Having the API consume energy as Joules is also peculiuar. Why not mJ like all the other API endpoints? Or am I mistaken? Internally we use mJ
- Having three UUIDs flying around feels very confusing to work with. In the overview shoing the UUID of the machine does not tell me anything and my human eye cannot discern which is which even if I see the number in another tab. I think having UUIDs internally is fine, but not for display
- CarbonDB cannot really handle when additions to it are reporting different tags for the same machine and project. However this can really be, as a machine can switch project and tags dynamically. atm the filtering is not working correctly and also sums are wrong. When I put two entries in the DB with a tag and without and then filter by the tag it will still show me the sum of all
- In Summary I think I would resort to a mechansim that completely kills company_uuid, machine_uuid, project_uuid and just has a `token`, which is what the user can get beforehand and then the user can just send data with different tags. The user can then make this 3-fold granularity of wished by himself. This has more potential for mis-configuration and shoving all data into one bin, but allows for less confusing display. I would maybe keep the machine_uuid as auto just to split stuff up correctly, but I def. would kill company_uuid and project_uuid. 

Happy to discuss now :)
