### PR TITLE
Fix print of docker run string when using integer parameter

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -97,7 +97,7 @@ class SchemaChecker():
                     Optional("build"): Or(Or({str:str},list),str),
                     Optional("networks"): self.single_or_list(Use(self.contains_no_invalid_chars)),
                     Optional("environment"): self.single_or_list(Or(dict,str)),
-                    Optional("ports"): self.single_or_list(Or(str, int)),
+                    Optional("ports"): self.single_or_list(str),
                     Optional("depends_on"): Or([str],dict),
                     Optional("healthcheck"): {
                         Optional('test'): Or(list, str),

--- a/runner.py
+++ b/runner.py
@@ -859,7 +859,7 @@ class Runner:
                         docker_run_string.append(service['healthcheck']['timeout'])
                     if 'retries' in service['healthcheck']:
                         docker_run_string.append('--health-retries')
-                        docker_run_string.append(service['healthcheck']['retries'])
+                        docker_run_string.append(str(service['healthcheck']['retries']))
                     if 'start_period' in service['healthcheck']:
                         docker_run_string.append('--health-start-period')
                         docker_run_string.append(service['healthcheck']['start_period'])

--- a/tests/data/usage_scenarios/healthcheck.yml
+++ b/tests/data/usage_scenarios/healthcheck.yml
@@ -14,6 +14,7 @@ services:
     healthcheck:
       test: ls
       interval: 1s
+      retries: 1
 
 flow:
   - name: dummy


### PR DESCRIPTION
Using the `retries` parameter of the healthcheck feature led to the following error:

```
Error: Base exception occured in runner.py

Exception (<class 'TypeError'>): sequence item 21: expected str instance, int found
Run_id (<class 'uuid.UUID'>): fb0156a1-df46-42b9-85fc-6a94eb6f157b
```

This PR fixes that by converting the `retries` parameter to a string.

While inspecting the issue I'm noticed that the same error could occur when using a single port definition ([ephemeral ports](https://docs.docker.com/guides/docker-concepts/running-containers/publishing-ports/#publishing-to-ephemeral-ports)). I think it makes sense to forbid using single port definitions.