### PR TITLE
Proposal: Increase default wait time for dependencies

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -64,7 +64,7 @@ measurement:
   flow-process-runtime: 3800
   phase-transition-time: 1
   boot:
-    wait_time_dependencies: 20
+    wait_time_dependencies: 60
   metric-providers:
 
   # Please select the needed providers according to the working ones on your system


### PR DESCRIPTION
I'm currently adding the healthcheck feature to my microservices reference application.
Compose file: https://github.com/t2-project/devops/blob/main/energy-tests/gmt/microservices-compose.yml

Unfortunately, the configured 20 second wait time for dependencies is not sufficient on my machine. The `inventory` service (Spring Boot) needs more than 20 seconds to become healthy.

Of course on my local machine I can change the config on my own. However, that would not be possible using the measurement cluster.
An workaround is to use a sleep in `setup-command`, how I did it already in the past without the healthcheck feature.

I think it makes sense to increase the configured default wait time for dependencies, because 20 seconds seems to be too short for some Spring Boot applications in a microservices system to become healthy.