### PR TITLE
Improve Healthcheck with start-interval parameter

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -105,7 +105,7 @@ class SchemaChecker():
                         Optional('timeout'): str,
                         Optional('retries'): int,
                         Optional('start_period'): str,
-                        # Optional('start_interval'): str, docker CLI does not support this atm
+                        Optional('start_interval'): str,
                         Optional('disable'): bool,
                     },
                     Optional("setup-commands"): [str],

--- a/runner.py
+++ b/runner.py
@@ -864,8 +864,8 @@ class Runner:
                         docker_run_string.append('--health-start-period')
                         docker_run_string.append(service['healthcheck']['start_period'])
                     if 'start_interval' in service['healthcheck']:
-                        raise RuntimeError('start_interval is not supported atm in healthcheck')
-
+                        docker_run_string.append('--health-start-interval')
+                        docker_run_string.append(service['healthcheck']['start_interval'])
 
             docker_run_string.append(self.clean_image_name(service['image']))
 

--- a/test-config.yml
+++ b/test-config.yml
@@ -58,7 +58,7 @@ measurement:
   flow-process-runtime: 3800
   phase-transition-time: 1
   boot:
-    wait_time_dependencies: 20
+    wait_time_dependencies: 5
   metric-providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:

--- a/tests/data/slow-start-application/Dockerfile
+++ b/tests/data/slow-start-application/Dockerfile
@@ -1,9 +1,5 @@
 FROM alpine
 
-# Define health check
-# HEALTHCHECK --interval=1s CMD pgrep 'stress-ng'
-# HEALTHCHECK --start-interval=1s --start-period=10s --interval=1s --timeout=1s --retries=10 CMD pgrep 'stress-ng'
-
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 CMD ["/start.sh"]

--- a/tests/data/slow-start-application/Dockerfile
+++ b/tests/data/slow-start-application/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+# Define health check
+# HEALTHCHECK --interval=1s CMD pgrep 'stress-ng'
+# HEALTHCHECK --start-interval=1s --start-period=10s --interval=1s --timeout=1s --retries=10 CMD pgrep 'stress-ng'
+
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+CMD ["/start.sh"]

--- a/tests/data/slow-start-application/start.sh
+++ b/tests/data/slow-start-application/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "Starting up..."
+sleep 3 # simulting slow start up ...
+echo "Finished startup."
+tail -f /dev/null

--- a/tests/data/usage_scenarios/healthcheck_error_container_unhealthy.yml
+++ b/tests/data/usage_scenarios/healthcheck_error_container_unhealthy.yml
@@ -10,8 +10,7 @@ services:
       test-container-2:
         condition: service_healthy
   test-container-2:
-    build:
-      context: ../slow-start-application
+    image: alpine
     healthcheck:
       test: pgrep 'helloworld' # process never runs, therefore it gets unhealthy
       interval: 1s

--- a/tests/data/usage_scenarios/healthcheck_error_container_unhealthy.yml
+++ b/tests/data/usage_scenarios/healthcheck_error_container_unhealthy.yml
@@ -1,0 +1,25 @@
+---
+name: Test Healthcheck
+author: David Kopp
+description: test
+
+services:
+  test-container-1:
+    image: alpine
+    depends_on:
+      test-container-2:
+        condition: service_healthy
+  test-container-2:
+    build:
+      context: ../slow-start-application
+    healthcheck:
+      test: pgrep 'helloworld' # process never runs, therefore it gets unhealthy
+      interval: 1s
+      retries: 3
+
+flow:
+  - name: dummy
+    container: test-container-1
+    commands:
+      - type: console
+        command: pwd

--- a/tests/data/usage_scenarios/healthcheck_error_max_waiting_time.yml
+++ b/tests/data/usage_scenarios/healthcheck_error_max_waiting_time.yml
@@ -1,0 +1,24 @@
+---
+name: Test Healthcheck
+author: David Kopp
+description: test
+
+services:
+  test-container-1:
+    image: alpine
+    depends_on:
+      test-container-2:
+        condition: service_healthy
+  test-container-2:
+    build:
+      context: ../slow-start-application
+    healthcheck:
+      test: pgrep 'tail'
+      interval: 10s
+
+flow:
+  - name: dummy
+    container: test-container-1
+    commands:
+      - type: console
+        command: pwd

--- a/tests/data/usage_scenarios/healthcheck_missing_start_period.yml
+++ b/tests/data/usage_scenarios/healthcheck_missing_start_period.yml
@@ -1,0 +1,25 @@
+---
+name: Test Healthcheck
+author: David Kopp
+description: test
+
+services:
+  test-container-1:
+    image: alpine
+    depends_on:
+      test-container-2:
+        condition: service_healthy
+  test-container-2:
+    build:
+      context: ../slow-start-application
+    healthcheck:
+      test: pgrep 'tail'
+      start_interval: 1s
+      interval: 1h # should not influence the measurement
+
+flow:
+  - name: dummy
+    container: test-container-1
+    commands:
+      - type: console
+        command: pwd

--- a/tests/data/usage_scenarios/healthcheck_using_interval.yml
+++ b/tests/data/usage_scenarios/healthcheck_using_interval.yml
@@ -1,0 +1,25 @@
+---
+name: Test depends_on
+author: David Kopp
+description: test
+
+services:
+  test-container-1:
+    image: alpine
+    depends_on:
+      test-container-2:
+        condition: service_healthy
+  test-container-2:
+    build:
+      context: ../slow-start-application
+    healthcheck:
+      test: pgrep 'tail'
+      interval: 1s
+      retries: 10
+
+flow:
+  - name: dummy
+    container: test-container-1
+    commands:
+      - type: console
+        command: pwd

--- a/tests/data/usage_scenarios/healthcheck_using_start_interval.yml
+++ b/tests/data/usage_scenarios/healthcheck_using_start_interval.yml
@@ -1,5 +1,5 @@
 ---
-name: Test depends_on
+name: Test Healthcheck
 author: David Kopp
 description: test
 
@@ -10,10 +10,12 @@ services:
       test-container-2:
         condition: service_healthy
   test-container-2:
-    image: alpine
+    build:
+      context: ../slow-start-application
     healthcheck:
-      test: ls
-      interval: 1s
+      test: pgrep 'tail'
+      start_interval: 1s
+      start_period: 5s
 
 flow:
   - name: dummy

--- a/tests/data/usage_scenarios/healthcheck_using_start_interval.yml
+++ b/tests/data/usage_scenarios/healthcheck_using_start_interval.yml
@@ -16,6 +16,7 @@ services:
       test: pgrep 'tail'
       start_interval: 1s
       start_period: 5s
+      interval: 1h # should not influence the measurement
 
 flow:
   - name: dummy

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -405,6 +405,19 @@ Health of dependent container 'test-container-2': healthy
 """
     assert message in out.getvalue(), Tests.assertion_info(message, out.getvalue())
 
+def test_depends_on_healthcheck_missing_start_period():
+    # Test setup: Container would be healthy after 3 seconds, however, no start_period is set (default 0s), therefore start_interval is not used.
+    # Because max waiting time is configured to be 5s (test_config.yml), exception is raised after 5s.
+    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_missing_start_period.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
+
+    with pytest.raises(RuntimeError) as e:
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    expected_exception = "Dependent container 'test-container-2' of 'test-container-1' is not healthy but 'starting' after waiting for 5 sec"
+    assert str(e.value).startswith(expected_exception),\
+        Tests.assertion_info(f"Exception: {expected_exception}", str(e.value))
+
 def test_depends_on_healthcheck_error_missing():
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_missing.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
 

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -371,7 +371,8 @@ def test_depends_on_long_form():
         Tests.assertion_info(message, out.getvalue())
 
 def test_depends_on_healthcheck_using_interval():
-    # Test setup: Container becomes healthy after 3 seconds, interval is set to 1s, retries is set to number bigger than 3.
+    # Test setup: Container has a startup time of 3 seconds, interval is set to 1s, retries is set to a number bigger than 3.
+    # Container should become healthy after 3 seconds.
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_using_interval.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
     out = io.StringIO()
     err = io.StringIO()
@@ -385,7 +386,8 @@ def test_depends_on_healthcheck_using_interval():
 
 def test_depends_on_healthcheck_using_start_interval():
     # Using start_interval is preferable (available since Docker Engine version 25)
-    # Test setup: Container becomes healthy after 3 seconds, start_interval is set to 1s, start_period to 5s.
+    # Test setup: Container has a startup time of 3 seconds, start_interval is set to 1s, start_period to 5s
+    # Container should become healthy after 3 seconds.
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_using_start_interval.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
     out = io.StringIO()
     err = io.StringIO()
@@ -401,7 +403,6 @@ Health of dependent container 'test-container-2': starting
 Health of dependent container 'test-container-2': starting
 Health of dependent container 'test-container-2': healthy
 """
-    # Expected is that the startup takes 3 seconds (therefore 3 times the message with 'starting')
     assert message in out.getvalue(), Tests.assertion_info(message, out.getvalue())
 
 def test_depends_on_healthcheck_error_missing():
@@ -415,7 +416,8 @@ def test_depends_on_healthcheck_error_missing():
         Tests.assertion_info(f"Exception: {expected_exception}", str(e.value))
 
 def test_depends_on_healthcheck_error_container_unhealthy():
-    # Test setup: Container becomes unhealthy after 3 seconds, because interval is set to 1s and retries to 3s
+    # Test setup: Healthcheck test will never be successful, interval is set to 1s and retries to 3.
+    # Container should become unhealthy after 3 seconds.
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_container_unhealthy.yml', 
                     skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
 
@@ -428,7 +430,7 @@ def test_depends_on_healthcheck_error_container_unhealthy():
         Tests.assertion_info(f"Exception: {expected_exception}", str(e.value))
 
 def test_depends_on_healthcheck_error_max_waiting_time():
-    # Test setup: Container becomes healthy after 3 seconds, however, interval is set to 10s and there is no start interval.
+    # Test setup: Container would be healthy after 3 seconds, however, interval is set to 10s and there is no start interval.
     # Because max waiting time is configured to be 5s (test_config.yml), the healthcheck at 10s will never be executed.
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_max_waiting_time.yml', 
                     skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -418,8 +418,7 @@ def test_depends_on_healthcheck_error_missing():
 def test_depends_on_healthcheck_error_container_unhealthy():
     # Test setup: Healthcheck test will never be successful, interval is set to 1s and retries to 3.
     # Container should become unhealthy after 3 seconds.
-    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_container_unhealthy.yml', 
-                    skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
+    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_container_unhealthy.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
 
     with pytest.raises(RuntimeError) as e:
         with Tests.RunUntilManager(runner) as context:
@@ -432,8 +431,7 @@ def test_depends_on_healthcheck_error_container_unhealthy():
 def test_depends_on_healthcheck_error_max_waiting_time():
     # Test setup: Container would be healthy after 3 seconds, however, interval is set to 10s and there is no start interval.
     # Because max waiting time is configured to be 5s (test_config.yml), the healthcheck at 10s will never be executed.
-    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_max_waiting_time.yml', 
-                    skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
+    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/healthcheck_error_max_waiting_time.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
 
     with pytest.raises(RuntimeError) as e:
         with Tests.RunUntilManager(runner) as context:
@@ -444,7 +442,7 @@ def test_depends_on_healthcheck_error_max_waiting_time():
         Tests.assertion_info(f"Exception: {expected_exception}", str(e.value))
 
 def test_network_created():
-    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/network_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True)
+    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/network_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
     with Tests.RunUntilManager(runner) as context:
         context.run_until('setup_services')
         ps = subprocess.run(

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -366,7 +366,7 @@ def test_depends_on_long_form():
 
     with redirect_stdout(out), redirect_stderr(err):
         runner.run()
-    message = 'State of container'
+    message = 'State of dependent container'
     assert message in out.getvalue(), \
         Tests.assertion_info(message, out.getvalue())
 
@@ -377,7 +377,7 @@ def test_depends_on_healthcheck():
 
     with redirect_stdout(out), redirect_stderr(err):
         runner.run()
-    message = 'Health of container \'test-container-2\': healthy'
+    message = 'Health of dependent container \'test-container-2\': healthy'
     assert message in out.getvalue(), Tests.assertion_info(message, out.getvalue())
 
 def test_depends_on_healthcheck_error_missing():
@@ -386,7 +386,7 @@ def test_depends_on_healthcheck_error_missing():
     with pytest.raises(RuntimeError) as e:
         runner.run()
 
-    expected_exception = "Health check for dependent_container 'test-container-2' was requested, but container has no healthcheck implemented!"
+    expected_exception = "Health check for dependent container 'test-container-2' was requested by 'test-container-1', but container has no healthcheck implemented!"
     assert str(e.value).startswith(expected_exception),\
         Tests.assertion_info(f"Exception: {expected_exception}", str(e.value))
 


### PR DESCRIPTION
As discussed in #781 this PR implements the healthcheck parameter `start-interval`. In addition to that the logging around the healthcheck functionality is improved.

After some testing I came to the conclusion, that it is sufficient to just check every second what the health of the dependent container is without any additional logic.
There are 3 possible outcomes:
- container health becomes `healthy` -> pass
- container health becomes `unhealthy` -> exception
- configured max waiting time is reached -> exception

As proposed in #781 the default max waiting time should be increased (20 seconds is too short).

A compose file using the `start-interval` parameter can be found [here](https://github.com/t2-project/devops/blob/main/energy-tests/gmt/microservices-compose.yml). Currently, I have defined the healthcheck configurations with the following parameters:
```yaml
start_period: "30s"
start_interval: "1s"
interval: "1h"
```