### PR TITLE
Moving int to str

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -97,7 +97,7 @@ class SchemaChecker():
                     Optional("build"): Or(Or({str:str},list),str),
                     Optional("networks"): self.single_or_list(Use(self.contains_no_invalid_chars)),
                     Optional("environment"): self.single_or_list(Or(dict,str)),
-                    Optional("ports"): self.single_or_list(Or(str, int)),
+                    Optional("ports"): self.single_or_list(str),
                     Optional("depends_on"): Or([str],dict),
                     Optional("healthcheck"): {
                         Optional('test'): Or(list, str),

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -97,7 +97,7 @@ class SchemaChecker():
                     Optional("build"): Or(Or({str:str},list),str),
                     Optional("networks"): self.single_or_list(Use(self.contains_no_invalid_chars)),
                     Optional("environment"): self.single_or_list(Or(dict,str)),
-                    Optional("ports"): self.single_or_list(str),
+                    Optional("ports"): self.single_or_list(Or(str, int)),
                     Optional("depends_on"): Or([str],dict),
                     Optional("healthcheck"): {
                         Optional('test'): Or(list, str),

--- a/runner.py
+++ b/runner.py
@@ -767,7 +767,7 @@ class Runner:
                     for ports in service['ports']:
                         print('Setting ports: ', service['ports'])
                         docker_run_string.append('-p')
-                        docker_run_string.append(ports)
+                        docker_run_string.append(str(ports)) # Ports can also be an int according to schema checker, but needs to be a string when we use subprocess
                 elif self._skip_unsafe:
                     print(TerminalColors.WARNING, arrows('Found ports entry but not running in unsafe mode. Skipping'), TerminalColors.ENDC)
                 else:
@@ -859,7 +859,7 @@ class Runner:
                         docker_run_string.append(service['healthcheck']['timeout'])
                     if 'retries' in service['healthcheck']:
                         docker_run_string.append('--health-retries')
-                        docker_run_string.append(str(service['healthcheck']['retries']))
+                        docker_run_string.append(str(service['healthcheck']['retries'])) # we need a str to pass to subprocess
                     if 'start_period' in service['healthcheck']:
                         docker_run_string.append('--health-start-period')
                         docker_run_string.append(service['healthcheck']['start_period'])

--- a/runner.py
+++ b/runner.py
@@ -859,7 +859,7 @@ class Runner:
                         docker_run_string.append(service['healthcheck']['timeout'])
                     if 'retries' in service['healthcheck']:
                         docker_run_string.append('--health-retries')
-                        docker_run_string.append(service['healthcheck']['retries'])
+                        docker_run_string.append(str(service['healthcheck']['retries']))
                     if 'start_period' in service['healthcheck']:
                         docker_run_string.append('--health-start-period')
                         docker_run_string.append(service['healthcheck']['start_period'])

--- a/tests/data/usage_scenarios/healthcheck.yml
+++ b/tests/data/usage_scenarios/healthcheck.yml
@@ -14,6 +14,7 @@ services:
     healthcheck:
       test: ls
       interval: 1s
+      retries: 1
 
 flow:
   - name: dummy


### PR DESCRIPTION
This PR superseeds https://github.com/green-coding-solutions/green-metrics-tool/pull/780 and adds more str conversion for parameters that are allowed as `int` but must be `str` due to the nature of GMT shell outs.

Also some comments are added for clarity.

P.S.: This behaviour might be obsolte if we switch to an API based docker container orchestration contrary to the CLI atm