### PR TITLE
Adding network to SCI and clarifications

### DIFF
--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -149,7 +149,7 @@ class PhaseMetrics extends HTMLElement {
                             </div>
                         </div>
                         <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="SCI by the Green Software Foundation">
-                            <u><a href="https://sci-guide.greensoftware.foundation/">via Formula</a></u>
+                            <u><a href="https://docs.green-coding.io/docs/measuring/sci/formula">see Details</a></u>
                             <i class="question circle icon"></i>
                         </div>
                         <div class="ui bottom left attached label">

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -38,7 +38,8 @@ def build_and_store_phase_stats(run_id, sci=None):
     for idx, phase in enumerate(phases[0]):
         network_io_bytes_total = [] # reset; # we use array here and sum later, because checking for 0 alone not enough
 
-        machine_co2 = None # reset
+        machine_co2_in_ug = None # reset
+        network_io_co2_in_ug = None
 
         select_query = """
             SELECT SUM(value), MAX(value), MIN(value), AVG(value), COUNT(value)
@@ -102,8 +103,8 @@ def build_and_store_phase_stats(run_id, sci=None):
                 csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_sum, 'MEAN', power_max, power_min, 'mW'))
 
                 if metric.endswith('_machine'):
-                    machine_co2 = (value_sum / 3_600) * config['sci']['I']
-                    csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_co2_')}", detail_name, f"{idx:03}_{phase['name']}", machine_co2, 'TOTAL', None, None, 'ug'))
+                    machine_co2_in_ug = (value_sum / 3_600) * config['sci']['I']
+                    csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_co2_')}", detail_name, f"{idx:03}_{phase['name']}", machine_co2_in_ug, 'TOTAL', None, None, 'ug'))
 
 
             else:
@@ -119,6 +120,8 @@ def build_and_store_phase_stats(run_id, sci=None):
             # co2 calculations
             network_io_co2_in_ug = network_io_in_kWh * config['sci']['I'] * 1_000_000
             csv_buffer.write(generate_csv_line(run_id, 'network_co2_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_co2_in_ug, 'TOTAL', None, None, 'ug'))
+        else:
+            network_io_co2_in_ug = 0
 
         duration = phase['end']-phase['start']
         csv_buffer.write(generate_csv_line(run_id, 'phase_time_syscall_system', '[SYSTEM]', f"{idx:03}_{phase['name']}", duration, 'TOTAL', None, None, 'us'))
@@ -128,9 +131,9 @@ def build_and_store_phase_stats(run_id, sci=None):
         embodied_carbon_share_ug = decimal.Decimal(embodied_carbon_share_g * 1_000_000)
         csv_buffer.write(generate_csv_line(run_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
-        if phase['name'] == '[RUNTIME]' and machine_co2 is not None and sci is not None \
+        if phase['name'] == '[RUNTIME]' and machine_co2_in_ug is not None and sci is not None \
                          and sci.get('R', None) is not None and sci['R'] != 0:
-            csv_buffer.write(generate_csv_line(run_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
+            csv_buffer.write(generate_csv_line(run_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2_in_ug + embodied_carbon_share_ug + network_io_co2_in_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning


### PR DESCRIPTION
Adding the network CO2 to the calculation of the SCI.

Before network CO2 was treated separately. After a conversation with @mrchrisadams we decided to add it to the default SCI calculation and also make this more clear through a documentation page.

Clicking on "see details" next to the value brings you to https://docs.green-coding.io/docs/measuring/sci/#formula where it is made clear what goes into the SCI.

<img width="536" alt="Screenshot 2024-05-30 at 12 48 44 PM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/a3f265e6-f583-43e8-8169-b20e12bcbced">
