### PR TITLE
Power per container

### DIFF
--- a/frontend/js/helpers/config.js.example
+++ b/frontend/js/helpers/config.js.example
@@ -9,6 +9,19 @@ METRICS_URL = "__METRICS_URL__"
 
 METRIC_MAPPINGS = {
 
+
+    'psu_energy_cgroup_container': {
+        'clean_name': 'Container Energy',
+        'source': 'estimation',
+        'explanation': 'Container energy estimated via CPU-% share',
+    },
+
+    'psu_power_cgroup_container': {
+        'clean_name': 'Container Power',
+        'source': 'estimation',
+        'explanation': 'Container power estimated via CPU-% share',
+    },
+
     'psu_co2_dc_rapl_msr_machine': {
         'clean_name': 'Machine CO2',
         'source': 'RAPL',

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -116,7 +116,7 @@ def build_and_store_phase_stats(run_id, sci=None):
                 csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_avg, 'MEAN', power_max, power_min, 'mW'))
 
                 if metric.endswith('_machine'):
-                    machine_co2_in_ug = (value_sum / 3_600) * config['sci']['I']
+                    machine_co2_in_ug = decimal.Decimal((value_sum / 3_600) * config['sci']['I'])
                     csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_co2_')}", detail_name, f"{idx:03}_{phase['name']}", machine_co2_in_ug, 'TOTAL', None, None, 'ug'))
 
                     if phase['name'] == '[IDLE]':
@@ -137,10 +137,10 @@ def build_and_store_phase_stats(run_id, sci=None):
             network_io_in_mJ = network_io_in_kWh * 3_600_000_000
             csv_buffer.write(generate_csv_line(run_id, 'network_energy_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_in_mJ, 'TOTAL', None, None, 'mJ'))
             # co2 calculations
-            network_io_co2_in_ug = network_io_in_kWh * config['sci']['I'] * 1_000_000
+            network_io_co2_in_ug = decimal.Decimal(network_io_in_kWh * config['sci']['I'] * 1_000_000)
             csv_buffer.write(generate_csv_line(run_id, 'network_co2_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_co2_in_ug, 'TOTAL', None, None, 'ug'))
         else:
-            network_io_co2_in_ug = 0
+            network_io_co2_in_ug = decimal.Decimal(0)
 
 
         if machine_power_idle and cpu_utilization_machine and cpu_utilization_containers:

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -155,7 +155,7 @@ def build_and_store_phase_stats(run_id, sci=None):
 
         if (phase['name'] == '[RUNTIME]') and machine_power_idle and cpu_utilization_machine and cpu_utilization_containers:
             surplus_power_runtime = machine_power_runtime - machine_power_idle
-            surplus_energy_runtime = machine_energy_runtime - (machine_power_idle * (duration / 10**6))
+            surplus_energy_runtime = machine_energy_runtime - (machine_power_idle * decimal.Decimal(duration / 10**6))
             total_container_utilization = sum(cpu_utilization_containers.values())
 
             for detail_name, container_utilization in cpu_utilization_containers.items():


### PR DESCRIPTION
This PR brings a power estimation feature per container to the GMT.

The approach is similar in it's idea on how Scaphandre does it:
- We use the CPU Utilization to derive a share of the containers given the total CPU Utilization of the system
- Different to Scaphandre we subtract the Idle power and thus only show the "overhead" that the containers have on the host system.

@mrchrisadams - Is that what you were looking for?

@davidkopp - Also would love your feedback on this as we have talked about this before.

A bit more context: Initially the philosphy of the GMT is not to have these values in as they provide limited insights. We have written are more detailed piece on this here: 
- https://docs.green-coding.io/docs/prologue/philosophy-methodology/#granularity-of-energy-data
- https://github.com/green-coding-solutions/green-metrics-tool/discussions/562

Since some of you know we have been funded by Mozilla to make a kernel Energy Plugin - https://github.com/orgs/green-kernel/discussions/1 - Say hi in the thread if you like!

Since the plugin is coming soon we wanted to have some comparative functionality already in GMT to see how heaviliy the values will deviate.
Still the given caveats apply. We will also add some documenation on this soon.

Love your feedback on this!

## Demo measurement
- https://metrics.green-coding.io/stats.html?id=f3eaba7c-0338-4c61-932d-fd48475b641c
<img width="1213" alt="Screenshot 2024-05-30 at 4 22 00 PM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/1c4f2e28-455d-458e-9156-91860b17794f">
