### PR TITLE
Adds a script to remove carbonDB duplicates

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -778,13 +778,3 @@ def carbondb_add(client_ip, energydatas):
     columns = ['type', 'company', 'machine', 'project', 'tags', 'time_stamp', 'energy_value', 'co2_value', 'carbon_intensity', 'latitude', 'longitude', 'ip_address']
 
     DB().copy_from(file=data_file, table='carbondb_energy_data', columns=columns, sep='|')
-
-# TODO: Fix dedupliation
-#    DB().query("""
-#        DELETE FROM carbondb_energy_data
-#        WHERE ctid NOT IN (
-#            SELECT min(ctid)
-#            FROM carbondb_energy_data
-#            GROUP BY time_stamp, machine, energy_value
-#        )
-#    """)

--- a/tools/carbondb_remove_dubplicates.py
+++ b/tools/carbondb_remove_dubplicates.py
@@ -1,0 +1,19 @@
+import faulthandler
+faulthandler.enable()  # will catch segfaults and write to stderr
+
+from lib.db import DB
+
+def remove_duplicates():
+    DB().query("""
+       DELETE FROM carbondb_energy_data
+       WHERE ctid NOT IN (
+           SELECT min(ctid)
+           FROM carbondb_energy_data
+           GROUP BY time_stamp, machine, energy_value
+       )
+    """)
+
+
+# pylint: disable=broad-except
+if __name__ == '__main__':
+    remove_duplicates()

--- a/tools/carbondb_remove_duplicates.py
+++ b/tools/carbondb_remove_duplicates.py
@@ -5,12 +5,12 @@ from lib.db import DB
 
 def remove_duplicates():
     DB().query("""
-       DELETE FROM carbondb_energy_data
-       WHERE ctid NOT IN (
-           SELECT min(ctid)
-           FROM carbondb_energy_data
-           GROUP BY time_stamp, machine, energy_value
-       )
+        DELETE FROM carbondb_energy_data a
+        USING carbondb_energy_data b
+        WHERE a.ctid < b.ctid
+        AND a.time_stamp = b.time_stamp
+        AND a.machine = b.machine
+        AND a.energy_value = b.energy_value;
     """)
 
 


### PR DESCRIPTION
I went for a KISS version which needs to be called via `cron`. As we will be reworking carbonDB soonish I didn't want to do something overly complex like copying DBs around. We can call this every `n` minutes. We could consider setting a flag in redis if something has changed but I think we should think about this bigger. Maybe we need a general queuing system like jobs. But more flexible. Not something I see vital for now though