### PR TITLE
Global timeout

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -59,9 +59,12 @@ machine:
 
 measurement:
   system_check_threshold: 3 # Can be 1=INFO, 2=WARN or 3=ERROR
-  idle-time-start: 10
-  idle-time-end: 5
-  flow-process-runtime: 3800
+  pre-test-sleep: 5
+  idle-duration: 5
+  baseline-duration: 5
+  flow-process-duration: 1800 # half hour
+  total-duration: 3600 # one hour
+  post-test-sleep: 5
   phase-transition-time: 1
   boot:
     wait_time_dependencies: 60

--- a/runner.py
+++ b/runner.py
@@ -629,7 +629,8 @@ class Runner:
                                 raise OSError(f"Docker pull failed and image does not exist locally. Is your image name correct and are you connected to the internet: {service['image']}") from subprocess.CalledProcessError
                         else:
                             raise OSError(f"Docker pull failed. Is your image name correct and are you connected to the internet: {service['image']}")
-
+                    else:
+                        raise OSError(f"Docker pull failed. Is your image name correct and are you connected to the internet: {service['image']}")
 
                 # tagging must be done in pull and local case, so we can get the correct container later
                 subprocess.run(['docker', 'tag', service['image'], tmp_img_name], check=True)

--- a/runner.py
+++ b/runner.py
@@ -615,9 +615,23 @@ class Runner:
 
                 if ps.returncode != 0:
                     print(f"Error: {ps.stderr} \n {ps.stdout}")
-                    raise OSError(f"Docker pull failed. Is your image name correct and are you connected to the internet: {service['image']}")
+                    if __name__ == '__main__':
+                        print(TerminalColors.OKCYAN, '\nThe docker image could not be pulled. Since you are working locally we can try looking in your local images. Do you want that? (y/N).', TerminalColors.ENDC)
+                        if sys.stdin.readline().strip().lower() == 'y':
+                            try:
+                                subprocess.run(['docker', 'inspect', '--type=image', service['image']],
+                                                         stdout=subprocess.PIPE,
+                                                         stderr=subprocess.PIPE,
+                                                         encoding='UTF-8',
+                                                         check=True)
+                                print('Docker image found locally. Tagging now for use in cached runs ...')
+                            except subprocess.CalledProcessError:
+                                raise OSError(f"Docker pull failed and image does not exist locally. Is your image name correct and are you connected to the internet: {service['image']}") from subprocess.CalledProcessError
+                        else:
+                            raise OSError(f"Docker pull failed. Is your image name correct and are you connected to the internet: {service['image']}")
 
-                # tagging must be done in pull case, so we can get the correct container later
+
+                # tagging must be done in pull and local case, so we can get the correct container later
                 subprocess.run(['docker', 'tag', service['image'], tmp_img_name], check=True)
 
 

--- a/test-config.yml
+++ b/test-config.yml
@@ -53,12 +53,15 @@ machine:
 
 measurement:
   system_check_threshold: 3
-  idle-time-start: 0
-  idle-time-end: 0
-  flow-process-runtime: 3800
-  phase-transition-time: 1
+  pre-test-sleep: 0
+  idle-duration: 0
+  baseline-duration: 0
+  flow-process-duration: 1800 # half hour
+  total-duration: 3600 # one hour
+  post-test-sleep: 0
+  phase-transition-time: 0
   boot:
-    wait_time_dependencies: 10
+    wait_time_dependencies: 60
   metric-providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:

--- a/test-config.yml
+++ b/test-config.yml
@@ -61,7 +61,7 @@ measurement:
   post-test-sleep: 0
   phase-transition-time: 0
   boot:
-    wait_time_dependencies: 60
+    wait_time_dependencies: 10
   metric-providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:

--- a/tests/data/usage_scenarios/invalid_image.yml
+++ b/tests/data/usage_scenarios/invalid_image.yml
@@ -1,0 +1,17 @@
+---
+name: Image location invalid test
+author: Arne Tarara
+description: Image location invalid test
+
+services:
+  test-service:
+    image: 1j98t3gh4hih8723ztgifuwheksh87t34gt
+
+flow:
+  - name: Small-Stress
+    container: test-service
+    commands:
+      - type: console
+        command: echo "asd"
+        shell: bash
+        note: Starting a little stress

--- a/tests/test_config_opts.py
+++ b/tests/test_config_opts.py
@@ -15,7 +15,7 @@ from runner import Runner
 GlobalConfig().override_config(config_name='test-config.yml')
 config = GlobalConfig().config
 
-def test_global_timeout_short():
+def test_global_timeout():
 
     total_duration = config['measurement']['total-duration']
 

--- a/tests/test_config_opts.py
+++ b/tests/test_config_opts.py
@@ -13,13 +13,12 @@ from runner import Runner
 
 
 GlobalConfig().override_config(config_name='test-config.yml')
-config = GlobalConfig().config
 
 def test_global_timeout():
 
-    total_duration = config['measurement']['total-duration']
-
-    config['measurement']['total-duration'] = 2
+    total_duration_new = 1
+    total_duration_before = GlobalConfig().config['measurement']['total-duration']
+    GlobalConfig().config['measurement']['total-duration'] = total_duration_new
 
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/basic_stress.yml', skip_system_checks=True, dev_no_build=False, dev_no_sleeps=True, dev_no_metrics=True)
 
@@ -29,15 +28,15 @@ def test_global_timeout():
         with redirect_stdout(out), redirect_stderr(err):
             runner.run()
     except subprocess.TimeoutExpired as e:
-        assert str(e).startswith("Command '['docker', 'run', '--rm', '-v',") and f"timed out after {config['measurement']['total-duration']} seconds" in str(e), \
-        Tests.assertion_info('Unknown TimeoutExpired was raised', str(e))
+        assert str(e).startswith("Command '['docker', 'run', '--rm', '-v',") and f"timed out after {total_duration_new} seconds" in str(e), \
+        Tests.assertion_info(f"Command '['docker', 'run', '--rm', '-v', ... timed out after {total_duration_new} seconds", str(e))
         return
     except TimeoutError as e:
-        assert str(e) == f"Timeout of {config['measurement']['total-duration']} s was exceeded. This can be configured in 'total-duration'.", \
-        Tests.assertion_info(f"Timeout of {config['measurement']['total-duration']} s was exceeded. This can be configured in 'total-duration'.", str(e))
+        assert str(e) == f"Timeout of {total_duration_new} s was exceeded. This can be configured in 'total-duration'.", \
+        Tests.assertion_info(f"Timeout of {total_duration_new} s was exceeded. This can be configured in 'total-duration'.", str(e))
         return
     finally:
-        config['measurement']['total-duration'] = total_duration
+        GlobalConfig().config['measurement']['total-duration'] = total_duration_before # reset
 
     assert False, \
         Tests.assertion_info('Timeout was not raised', str(out.getvalue()))
@@ -46,6 +45,7 @@ def test_global_timeout():
 #pylint: disable=unused-argument # unused arguement off for now - because there are no running tests in this file
 @pytest.fixture(name="reset_config")
 def reset_config_fixture():
+    config = GlobalConfig().config
     idle_start_time = config['measurement']['idle-time-start']
     idle_time_end = config['measurement']['idle-time-end']
     flow_process_runtime = config['measurement']['flow-process-runtime']
@@ -56,7 +56,7 @@ def reset_config_fixture():
 
 # Rethink how to do this test entirely
 def wip_test_idle_start_time(reset_config):
-    config['measurement']['idle-time-start'] = 2
+    GlobalConfig().config['measurement']['idle-time-start'] = 2
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/basic_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
     run_id = runner.run()
     query = """
@@ -82,7 +82,7 @@ def wip_test_idle_start_time(reset_config):
 
 # Rethink how to do this test entirely
 def wip_test_idle_end_time(reset_config):
-    config['measurement']['idle-time-end'] = 2
+    GlobalConfig().config['measurement']['idle-time-end'] = 2
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/basic_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
     run_id = runner.run()
     query = """
@@ -106,7 +106,7 @@ def wip_test_idle_end_time(reset_config):
         Tests.assertion_info('2s apart', f"timestamp difference of notes: {diff}s")
 
 def wip_test_process_runtime_exceeded(reset_config):
-    config['measurement']['flow-process-runtime'] = .1
+    GlobalConfig().config['measurement']['flow-process-runtime'] = .1
     runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/basic_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_sleeps=True, dev_no_build=True)
     with pytest.raises(RuntimeError) as err:
         runner.run()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -47,12 +47,12 @@ class RunUntilManager:
             self.__runner.update_and_insert_specs()
 
             self.__runner.start_metric_providers(allow_other=True, allow_container=False)
-            self.__runner.custom_sleep(config['measurement']['idle-time-start'])
+            self.__runner.custom_sleep(config['measurement']['pre-test-sleep'])
 
             self.__runner.start_measurement()
 
             self.__runner.start_phase('[BASELINE]')
-            self.__runner.custom_sleep(5)
+            self.__runner.custom_sleep(config['measurement']['baseline-duration'])
             self.__runner.end_phase('[BASELINE]')
 
             self.__runner.start_phase('[INSTALLATION]')
@@ -71,7 +71,7 @@ class RunUntilManager:
             self.__runner.start_metric_providers(allow_container=True, allow_other=False)
 
             self.__runner.start_phase('[IDLE]')
-            self.__runner.custom_sleep(5)
+            self.__runner.custom_sleep(config['measurement']['idle-duration'])
             self.__runner.end_phase('[IDLE]')
 
             self.__runner.start_phase('[RUNTIME]')
@@ -84,7 +84,7 @@ class RunUntilManager:
 
             self.__runner.end_measurement()
             self.__runner.check_process_returncodes()
-            self.__runner.custom_sleep(config['measurement']['idle-time-end'])
+            self.__runner.custom_sleep(config['measurement']['post-test-sleep'])
             self.__runner.store_phases()
             self.__runner.update_start_and_end_times()
             self.__runner.read_and_cleanup_processes()

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -755,6 +755,27 @@ def test_duplicate_container_name():
         Tests.assertion_info("Container name 'number-1' was already assigned. Please choose unique container names.", str(e.value))
 
 
+def test_failed_pull_does_not_trigger_cli():
+    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/invalid_image.yml', skip_system_checks=True, dev_no_build=True, dev_no_sleeps=True, dev_no_metrics=True)
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err), pytest.raises(Exception) as e:
+        runner.run()
+
+    assert 'Docker pull failed. Is your image name correct and are you connected to the internet: 1j98t3gh4hih8723ztgifuwheksh87t34gt' in str(e.value), \
+        Tests.assertion_info('Docker pull failed. Is your image name correct and are you connected to the internet: 1j98t3gh4hih8723ztgifuwheksh87t34gt', str(e.value))
+
+def test_failed_pull_does_not_trigger_cli_with_build_on():
+    runner = Runner(uri=CURRENT_DIR, uri_type='folder', filename='data/usage_scenarios/invalid_image.yml', skip_system_checks=True, dev_no_build=False, dev_no_sleeps=True, dev_no_metrics=True)
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err), pytest.raises(Exception) as e:
+        runner.run()
+
+    assert 'Docker pull failed. Is your image name correct and are you connected to the internet: 1j98t3gh4hih8723ztgifuwheksh87t34gt' in str(e.value), \
+        Tests.assertion_info('Docker pull failed. Is your image name correct and are you connected to the internet: 1j98t3gh4hih8723ztgifuwheksh87t34gt', str(e.value))
 
     ## rethink this one
 def wip_test_verbose_provider_boot():


### PR DESCRIPTION
A global timeout is added to prevent jobs to run too long in cluster setups.

This is needed as GMT moves towards more unattended automation

closes https://github.com/green-coding-solutions/green-metrics-tool/issues/790
closes https://github.com/green-coding-solutions/green-metrics-tool/issues/23

