### PR TITLE
Co2eq totals and Co2i totals

### DIFF
--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -21,6 +21,7 @@
     <script src="/js/helpers/converters.js" defer></script>
     <script src="/dist/js/math.min.js" defer></script>
     <script src="/dist/js/popup.min.js" defer></script>
+    <script src="/dist/js/tab.min.js" defer></script>
     <script src="/dist/js/tablesort.min.js" defer></script>
     <script src="/dist/js/toast.min.js" defer></script>
     <script src="/dist/js/transition.min.js" defer></script>
@@ -98,39 +99,46 @@
                     <h3>Pipeline stats</h3>
                 </a></div>
                 <br/>
-            <div class="ui right floated icon">
+            <div class="ui secondary menu">
+                <a class="item active" data-tab="one">Averages</a>
+                <a class="item" data-tab="two">Totals</a>
+            </div>
+            <div class="ui tab active right icon" data-tab="one">
                 <table class="ui sortable celled striped table">
                     <thead>
                         <tr>
-                            <th rowspan="2">Label</th>
-                            <th colspan="3">Energy</th>
-                            <th colspan="3">Time</th>
-                            <th rowspan="2"> <div data-tooltip="Only accurate for runs after Aug 15, 2023. If '--%', you likely have no runs after that date.">Avg. CPU Util. <i class="question circle icon "></i> </div></th>
-                            <th colspan="3">Total</th>
-                        </tr>
-                        <tr>
-                            <th>Average</th>
-                            <th>Std Dev</th>
-                            <th>Std Dev %</th>
-                            <th>Average</th>
-                            <th>Std Dev</th>
-                            <th>Std Dev %</th>
-                            <th>Energy</th>
-                            <th>Time</th>
+                            <th>Label</th>
+                            <th>Energy Avg. (± StdDev.)</th>
+                            <th>Time Avg. (± StdDev.)</th>
+                            <th> <div data-tooltip="Only accurate for runs after Aug 15, 2023. If '--%', you likely have no runs after that date.">CPU Util. Avg. (± StdDev.)<i class="question circle icon "></i> </div></th>
+                            <th>Grid Intensity Avg. (± StdDev.)</th>
+                            <th>Carbon Avg. (± StdDev.)</th>
                             <th>Count</th>
                         </tr>
                     </thead>
-                    <tbody id="label-stats-table"></tbody>
+                    <tbody id="label-stats-table-avg"></tbody>
+                </table>
+            </div>
+            <div class="ui tab right icon" data-tab="two">
+                <table class="ui sortable celled striped table">
+                    <thead>
+                        <tr>
+                            <th>Label</th>
+                            <th>Energy Total</th>
+                            <th>Time Total</th>
+                            <th>Carbon Total</th>
+                            <th>Count</th>
+                        </tr>
+                    </thead>
+                    <tbody id="label-stats-table-total"></tbody>
                 </table>
             </div>
         </div>
         <div class="ui segment" id="runs-table">
-            <div class="content">
-            </div>
             <div class="header"><a class="ui teal ribbon label" href="#">
                     <h3 data-tooltip="The runs table shows all measurements your pipeline has made in the selected timeframe" data-position="top left">Runs Table <i class="question circle icon "></i> </h3>
                 </a></div>
-            <table class="ui sortable celled striped table" id="table">
+            <table class="ui sortable celled striped table">
             <thead>
                 <tr>
                     <th>Run ID</th>

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -3,7 +3,13 @@ const numberFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 2,
 });
 
-const calculateStats = (energy_measurements, time_measurements, cpu_util_measurements) => {
+const numberFormatterLong = new Intl.NumberFormat('en-US', {
+  style: 'decimal',
+  maximumFractionDigits: 4,
+});
+
+const calculateStats = (energy_measurements, co2eq_measurements, co2i_measurements, time_measurements, cpu_util_measurements) => {
+
     let energyAverage = '--'
     let energyStdDeviation = '--'
     let energyStdDevPercent = '--'
@@ -14,28 +20,50 @@ const calculateStats = (energy_measurements, time_measurements, cpu_util_measure
     let timeStdDevPercent = '--'
     let timeSum = '--';
 
+    let co2eqAverage = '--'
+    let co2eqStdDeviation = '--'
+    let co2eqStdDevPercent = '--'
+    let co2eqSum = '--';
+
+    let co2iAverage = '--'
+    let co2iStdDeviation = '--'
+    let co2iStdDevPercent = '--'
+
     let cpuUtilStdDeviation = '--'
     let cpuUtilAverage = '--'
     let cpuUtilStdDevPercent = '--'
 
     if (energy_measurements.length > 0) {
-        energyStdDeviation = Math.round(math.std(energy_measurements, normalization="uncorrected"));
-        energyAverage = Math.round(math.mean(energy_measurements));
-        energyStdDevPercent = Math.round((energyStdDeviation / energyAverage) * 100);
-        energySum = Math.round(math.sum(energy_measurements));
+        energyStdDeviation = (math.std(energy_measurements, normalization="uncorrected"));
+        energyAverage = (math.mean(energy_measurements));
+        energyStdDevPercent = ((energyStdDeviation / energyAverage) * 100);
+        energySum = (math.sum(energy_measurements));
     }
 
     if (time_measurements.length > 0) {
-        timeStdDeviation = Math.round(math.std(time_measurements, normalization="uncorrected"));
-        timeAverage = Math.round(math.mean(time_measurements));
-        timeStdDevPercent = Math.round((timeStdDeviation / timeAverage) * 100);
-        timeSum = Math.round(math.sum(time_measurements));
+        timeStdDeviation = (math.std(time_measurements, normalization="uncorrected"));
+        timeAverage = (math.mean(time_measurements));
+        timeStdDevPercent = ((timeStdDeviation / timeAverage) * 100);
+        timeSum = (math.sum(time_measurements));
+    }
+
+    if (co2eq_measurements.length > 0) {
+        co2eqStdDeviation = (math.std(co2eq_measurements, normalization="uncorrected"));
+        co2eqAverage = (math.mean(co2eq_measurements));
+        co2eqStdDevPercent = ((co2eqStdDeviation / co2eqAverage) * 100);
+        co2eqSum = (math.sum(co2eq_measurements));
+    }
+
+    if (co2i_measurements.length > 0) {
+        co2iStdDeviation = (math.std(co2i_measurements, normalization="uncorrected"));
+        co2iAverage = (math.mean(co2i_measurements));
+        co2iStdDevPercent = ((co2iStdDeviation / co2iAverage) * 100);
     }
 
     if (cpu_util_measurements.length > 0) {
-        cpuUtilStdDeviation = Math.round(math.std(cpu_util_measurements, normalization="uncorrected"));
-        cpuUtilAverage = Math.round(math.mean(cpu_util_measurements));
-        cpuUtilStdDevPercent = Math.round((cpuUtilStdDeviation / cpuUtilAverage) * 100);
+        cpuUtilStdDeviation = (math.std(cpu_util_measurements, normalization="uncorrected"));
+        cpuUtilAverage = (math.mean(cpu_util_measurements));
+        cpuUtilStdDevPercent = ((cpuUtilStdDeviation / cpuUtilAverage) * 100);
     }
 
     return {
@@ -51,6 +79,17 @@ const calculateStats = (energy_measurements, time_measurements, cpu_util_measure
             stdDevPercent: timeStdDevPercent,
             total: timeSum
         },
+        co2eq: {
+            average: co2eqAverage,
+            stdDeviation: co2eqStdDeviation,
+            stdDevPercent: co2eqStdDevPercent,
+            total: co2eqSum
+        },
+        co2i: {
+            average: co2iAverage,
+            stdDeviation: co2iStdDeviation,
+            stdDevPercent: co2iStdDevPercent
+        },
         cpu_util: {
             average: cpuUtilAverage,
             stdDeviation: cpuUtilStdDeviation,
@@ -63,16 +102,29 @@ const createStatsArrays = (measurements) => {  // iterates 2n times (1 full, 1 b
     const measurementsByRun = {}
     const measurementsByLabel = {}
 
+    const measurementsForFullRun = {
+        energy: [],
+        co2eq: [],
+        co2i: [],
+        time: [],
+        cpu_util: [],
+        count: 0
+    };
+
     measurements.forEach(measurement => {
         const run_id = measurement[2]
-        const energy = measurement[0]
+        const energy = measurement[0] / 1000 // will make J
         const time = measurement[7]
         const cpuUtil = measurement[9]
         const label = measurement[4]
+        const co2i = parseInt(measurement[14])
+        const co2eq = parseFloat(measurement[15])
 
         if (!measurementsByLabel[label]) {
             measurementsByLabel[label] = {
                 energy: [],
+                co2eq: [],
+                co2i: [],
                 time: [],
                 cpu_util: [],
                 count: 0
@@ -80,39 +132,46 @@ const createStatsArrays = (measurements) => {  // iterates 2n times (1 full, 1 b
         }
         if (!measurementsByRun[run_id]) {
             measurementsByRun[run_id] = {
-                energy: 0,
-                time: 0,
+                energy: [],
+                co2eq: [],
+                co2i: [],
+                time: [],
                 cpu_util: []
             };
         }
 
         if (energy != null) {
             measurementsByLabel[label].energy.push(energy);
-            measurementsByRun[run_id].energy += energy;
+            measurementsByRun[run_id].energy.push(energy);
         }
         if (time != null) {
             measurementsByLabel[label].time.push(time);
-            measurementsByRun[run_id].time += time;
+            measurementsByRun[run_id].time.push(time);
         }
         if (cpuUtil != null) {
             measurementsByLabel[label].cpu_util.push(cpuUtil);
             measurementsByRun[run_id].cpu_util.push(cpuUtil);
         }
+        if (co2eq != null) {
+            measurementsByLabel[label].co2eq.push(co2eq);
+            measurementsByRun[run_id].co2eq.push(co2eq);
+        }
+        if (co2i != null) {
+            measurementsByLabel[label].co2i.push(co2i);
+            measurementsByRun[run_id].co2i.push(co2i);
+        }
         measurementsByLabel[label].count += 1;
+        measurementsForFullRun.count += 1;
     });
 
-    const measurementsForFullRun = {
-        energy: [],
-        time: [],
-        cpu_util: [],
-        count: 0
-    };
+
 
    for (const run_id in measurementsByRun) {
         if (measurementsByRun[run_id].energy) measurementsForFullRun.energy.push(measurementsByRun[run_id].energy);
+        if (measurementsByRun[run_id].co2eq) measurementsForFullRun.co2eq.push(measurementsByRun[run_id].co2eq);
         if (measurementsByRun[run_id].time) measurementsForFullRun.time.push(measurementsByRun[run_id].time);
-        if (measurementsByRun[run_id].cpu_util.length > 0) measurementsForFullRun.cpu_util.push(math.mean(measurementsByRun[run_id].cpu_util));
-        measurementsForFullRun.count += 1;
+        if (measurementsByRun[run_id].cpu_util) measurementsForFullRun.cpu_util.push(measurementsByRun[run_id].cpu_util);
+        if (measurementsByRun[run_id].co2i) measurementsForFullRun.co2i.push(measurementsByRun[run_id].co2i);
     }
 
     return [measurementsForFullRun, measurementsByLabel];
@@ -244,44 +303,58 @@ const displayGraph = (chart_instance, measurements) => {
 const displayStatsTable = (measurements) => {
     const [fullRunArray, labelsArray] = createStatsArrays(measurements); // iterates 2n times
 
-    const tableBody = document.querySelector("#label-stats-table");
-    tableBody.innerHTML = "";
+    const total_table = document.querySelector("#label-stats-table-total");
+    const avg_table = document.querySelector("#label-stats-table-avg");
 
-    const full_run_stats_node = document.createElement("tr")
-    full_run_stats = calculateStats(fullRunArray.energy, fullRunArray.time, fullRunArray.cpu_util)
+    total_table.innerHTML = "";
+    avg_table.innerHTML = "";
 
-    full_run_stats_node.innerHTML += `
+    const full_run_stats = calculateStats(fullRunArray.energy, fullRunArray.co2eq, fullRunArray.co2i, fullRunArray.time, fullRunArray.cpu_util)
+
+    const full_run_stats_avg_node = document.createElement("tr")
+    full_run_stats_avg_node.innerHTML += `
                             <td class="td-index" data-tooltip="Stats for the series of runs (labels aggregated for each pipeline run)" data-position="top left">All steps <i class="question circle icon small"></i> </td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.energy.average)} mJ</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.energy.stdDeviation)} mJ</td>
-                            <td class="td-index">${full_run_stats.energy.stdDevPercent}%</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.time.average)}s</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.time.stdDeviation)}s</td>
-                            <td class="td-index">${full_run_stats.time.stdDevPercent}%</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.cpu_util.average)}%</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.energy.total)} mJ</td>
+                            <td class="td-index">${numberFormatter.format(full_run_stats.energy.average)} J (± ${numberFormatter.format(full_run_stats.energy.stdDevPercent)}%)</td>
+                            <td class="td-index">${numberFormatter.format(full_run_stats.time.average)}s (± ${numberFormatter.format(full_run_stats.time.stdDevPercent)}%)</td>
+                            <td class="td-index">${numberFormatter.format(full_run_stats.cpu_util.average)}% (± ${numberFormatter.format(full_run_stats.cpu_util.stdDevPercent)}%%)</td>
+                            <td class="td-index">${numberFormatter.format(full_run_stats.co2i.average)} gCO2/kWh (± ${numberFormatter.format(full_run_stats.co2i.stdDevPercent)}%)</td>
+                            <td class="td-index">${numberFormatterLong.format(full_run_stats.co2eq.average)} gCO2e (± ${numberFormatter.format(full_run_stats.co2eq.stdDevPercent)}%)</td>
+                            <td class="td-index">${numberFormatter.format(fullRunArray.count)}</td>`;
+
+    avg_table.appendChild(full_run_stats_avg_node);
+
+    const full_run_stats_total_node = document.createElement("tr")
+    full_run_stats_total_node.innerHTML += `
+                            <td class="td-index" data-tooltip="Stats for the series of runs (labels aggregated for each pipeline run)" data-position="top left">All steps <i class="question circle icon small"></i> </td>
+                            <td class="td-index">${numberFormatter.format(full_run_stats.energy.total)} J</td>
                             <td class="td-index">${numberFormatter.format(full_run_stats.time.total)}s</td>
-                            <td class="td-index">${numberFormatter.format(fullRunArray.count)}</td>
-                            `
-    tableBody.appendChild(full_run_stats_node);
+                            <td class="td-index">${numberFormatterLong.format(full_run_stats.co2eq.total)} gCO2e</td>
+                            <td class="td-index">${numberFormatter.format(fullRunArray.count)}</td>`;
+    total_table.appendChild(full_run_stats_total_node)
 
     for (const label in labelsArray) {
-        const label_stats = calculateStats(labelsArray[label].energy, labelsArray[label].time, labelsArray[label].cpu_util)
-        const label_stats_node = document.createElement("tr")
-        label_stats_node.innerHTML += `
+        const label_stats = calculateStats(labelsArray[label].energy, labelsArray[label].co2eq, labelsArray[label].co2i, labelsArray[label].time, labelsArray[label].cpu_util)
+        const label_stats_avg_node = document.createElement("tr")
+        label_stats_avg_node.innerHTML += `
                                         <td class="td-index" data-tooltip="stats for the series of steps represented by the ${label} label"  data-position="top left">${label} <i class="question circle icon small"></i></td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.energy.average)} mJ</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.energy.stdDeviation)} mJ</td>
-                                        <td class="td-index">${label_stats.energy.stdDevPercent}%</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.time.average)}s</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.time.stdDeviation)}s</td>
-                                        <td class="td-index">${label_stats.time.stdDevPercent}%</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.cpu_util.average)}%</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.energy.total)} mJ</td>
+                                        <td class="td-index">${numberFormatter.format(label_stats.energy.average)} J (± ${numberFormatter.format(label_stats.energy.stdDevPercent)}%)</td>
+                                        <td class="td-index">${numberFormatter.format(label_stats.time.average)}s (± ${numberFormatter.format(label_stats.time.stdDevPercent)}%)</td>
+                                        <td class="td-index">${numberFormatter.format(label_stats.cpu_util.average)}% (± ${numberFormatter.format(label_stats.cpu_util.stdDevPercent)}%%)</td>
+                                        <td class="td-index">${numberFormatter.format(label_stats.co2i.average)} gCO2/kWh (± ${numberFormatter.format(label_stats.co2i.stdDevPercent)}%)</td>
+                                        <td class="td-index">${numberFormatterLong.format(label_stats.co2eq.average)} gCO2e (± ${numberFormatter.format(label_stats.co2eq.stdDevPercent)}%)</td>
+                                        <td class="td-index">${numberFormatter.format(labelsArray[label].count)}</td>`;
+
+        avg_table.appendChild(label_stats_avg_node);
+
+        const label_stats_total_node = document.createElement("tr")
+        label_stats_total_node.innerHTML += `
+                                        <td class="td-index" data-tooltip="stats for the series of steps represented by the ${label} label"  data-position="top left">${label} <i class="question circle icon small"></i></td>
+                                        <td class="td-index">${numberFormatter.format(label_stats.energy.total)} J</td>
                                         <td class="td-index">${numberFormatter.format(label_stats.time.total)}s</td>
-                                        <td class="td-index">${numberFormatter.format(labelsArray[label].count)}</td>
-                                        `
-        document.querySelector("#label-stats-table").appendChild(label_stats_node);
+                                        <td class="td-index">${numberFormatterLong.format(label_stats.co2eq.total)} gCO2e</td>
+                                        <td class="td-index">${numberFormatter.format(labelsArray[label].count)}</td>`;
+        total_table.appendChild(label_stats_total_node);
+
     };
 }
 
@@ -292,9 +365,7 @@ const displayCITable = (measurements, repo) => {
     measurements.forEach(el => {
         const li_node = document.createElement("tr");
 
-        const [energy_value, energy_unit] = convertValue(el[0], el[1])
-        const value = `${energy_value} ${energy_unit}`;
-
+        const energy_value = el[0] / 1000;
         const run_id = el[2];
         const cpu = el[5];
         const commit_hash = el[6];
@@ -329,19 +400,18 @@ const displayCITable = (measurements, repo) => {
         const label = el[4]
         const duration = el[7]
 
-
         li_node.innerHTML = `
                             <td class="td-index">${run_link_node}</td>\
                             <td class="td-index">${escapeString(label)}</td>\
                             <td class="td-index"><span title="${escapeString(created_at)}">${dateToYMD(new Date(created_at))}</span></td>\
-                            <td class="td-index">${escapeString(`${numberFormatter.format(energy_value)} ${energy_unit}`)}</td>\
+                            <td class="td-index">${numberFormatter.format(energy_value)} J</td>\
                             <td class="td-index">${escapeString(cpu)}</td>\
                             <td class="td-index">${escapeString(cpu_avg)}%</td>
-                            <td class="td-index">${escapeString(duration)} seconds</td>
+                            <td class="td-index">${escapeString(duration)} s</td>
                             <td class="td-index" ${escapeString(tooltip)}>${escapeString(short_hash)}</td>\
                             <td class="td-index">${city_string}</td>
-                            <td class="td-index">${escapeString(co2i)}</td>
-                            <td class="td-index">${escapeString(co2eq)}</td>
+                            <td class="td-index">${escapeString(co2i)} gCO2/kWh</td>
+                            <td class="td-index" title="${escapeString(co2eq)}">${escapeString(numberFormatterLong.format(co2eq))} gCO2e</td>
                             `;
         document.querySelector("#ci-table").appendChild(li_node);
     });
@@ -493,6 +563,8 @@ $(document).ready((e) => {
 
             displayStatsTable(filteredMeasurements);
         });
+
+        $('.ui.secondary.menu .item').tab();
 
         setTimeout(function(){console.log("Resize"); window.dispatchEvent(new Event('resize'))}, 500);
     })();

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -152,11 +152,11 @@ const createStatsArrays = (measurements) => {  // iterates 2n times (1 full, 1 b
             measurementsByLabel[label].cpu_util.push(cpuUtil);
             measurementsByRun[run_id].cpu_util.push(cpuUtil);
         }
-        if (co2eq != null) {
+        if (co2eq != null && !isNaN(co2eq)) {
             measurementsByLabel[label].co2eq.push(co2eq);
             measurementsByRun[run_id].co2eq.push(co2eq);
         }
-        if (co2i != null) {
+        if (co2i != null && !isNaN(co2i)) {
             measurementsByLabel[label].co2i.push(co2i);
             measurementsByRun[run_id].co2i.push(co2i);
         }


### PR DESCRIPTION

<img width="1457" alt="Screenshot 2024-06-29 at 5 45 58 PM" src="https://github.com/green-coding-solutions/green-metrics-tool/assets/250671/c6c7d16b-efb4-47aa-98f1-c39b0aadb31d">


This PR also normalizes the display of CO2eq values, smoothens the table styling a bit and fixes a slight error with the CPU util avg. It was calculating an average of averages, which can be slightly higher or lower and is inaccurate.

Also showing the count for the totals as all steps, not as all measurements as the table claims.