### PR TITLE
Expires header added to email

### DIFF
--- a/lib/email_helpers.py
+++ b/lib/email_helpers.py
@@ -1,5 +1,6 @@
 import smtplib
 import ssl
+from datetime import datetime, timedelta
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from lib.global_config import GlobalConfig
@@ -22,7 +23,7 @@ def send_email(receiver, subject, message):
     msg["From"] = config['smtp']['sender']
     msg["To"] = receiver
     msg["Subject"] = subject
-
+    msg["Expires"] = (datetime.utcnow() + timedelta(days=7)).strftime('%a, %d %b %Y %H:%M:%S +0000')
 
     if config['admin']['email_bcc']:
         receiver = [receiver] # make a list


### PR DESCRIPTION
Inspired by https://www.zerocarbon.email/ I added an *Expires* header to our email logging option.

At the moment this does not much, as Email Service Providers are not deleting messages yet. But hopefully this is soon to come and we want the GMT to be prepared for this.

The logging mails are by design only transient. Having them auto-deleted after 7 days is very sensible