### PR TITLE
Added DiskIO Reporter

### DIFF
--- a/metric_providers/cpu/energy/rapl/msr/component/source.c
+++ b/metric_providers/cpu/energy/rapl/msr/component/source.c
@@ -408,13 +408,13 @@ static int check_system() {
     int fd = open_msr(0);
     if (fd < 0) {
         fprintf(stderr, "Couldn't open MSR 0\n");
-        exit(127);
+        exit(1);
     }
     long long msr_data = read_msr(fd, energy_status);
 
     if(msr_data <= 0) {
         fprintf(stderr, "rapl MSR had 0 or negative values: %lld\n", msr_data);
-        exit(127);
+        exit(1);
     }
     close(fd);
     return 0;

--- a/metric_providers/cpu/energy/rapl/msr/component/source.c
+++ b/metric_providers/cpu/energy/rapl/msr/component/source.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
+#include <limits.h>
 
 
 /* AMD Support */
@@ -91,7 +92,7 @@
 
 static int open_msr(int core) {
 
-    char msr_filename[BUFSIZ];
+    char msr_filename[PATH_MAX];
     int fd;
 
     sprintf(msr_filename, "/dev/cpu/%d/msr", core);
@@ -174,7 +175,7 @@ static int detect_cpu(void) {
 
     int vendor=-1,family,model=-1;
     char buffer[BUFSIZ],*result;
-    char vendor_string[BUFSIZ];
+    char vendor_string[1024];
 
     fff=fopen("/proc/cpuinfo","r");
     if (fff==NULL) return -1;
@@ -242,7 +243,7 @@ static int package_map[MAX_PACKAGES];
 
 static int detect_packages(void) {
 
-    char filename[BUFSIZ];
+    char filename[PATH_MAX];
     FILE *fff;
     int package;
     int i;

--- a/metric_providers/cpu/energy/rapl/msr/component/source.c
+++ b/metric_providers/cpu/energy/rapl/msr/component/source.c
@@ -95,7 +95,7 @@ static int open_msr(int core) {
     char msr_filename[PATH_MAX];
     int fd;
 
-    sprintf(msr_filename, "/dev/cpu/%d/msr", core);
+    snprintf(msr_filename, PATH_MAX, "/dev/cpu/%d/msr", core);
     fd = open(msr_filename, O_RDONLY);
     if ( fd < 0 ) {
         if ( errno == ENXIO ) {
@@ -251,7 +251,7 @@ static int detect_packages(void) {
     for(i=0;i<MAX_PACKAGES;i++) package_map[i]=-1;
 
     for(i=0;i<MAX_CPUS;i++) {
-        sprintf(filename,"/sys/devices/system/cpu/cpu%d/topology/physical_package_id",i);
+        snprintf(filename, PATH_MAX, "/sys/devices/system/cpu/cpu%d/topology/physical_package_id",i);
         fff=fopen(filename,"r");
         if (fff==NULL) break;
         fscanf(fff,"%d",&package);

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -59,11 +59,13 @@ static int parse_containers(container_t** containers, char* containers_string, i
         *containers = realloc(*containers, length * sizeof(container_t));
         (*containers)[length-1].id = id;
         if(rootless_mode) {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/user.slice/user-%d.slice/user@%d.service/user.slice/docker-%s.scope/cpu.stat",
                 user_id, user_id, id);
         } else {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/system.slice/docker-%s.scope/cpu.stat",
                 id);
         }

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -50,6 +50,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
     }
 
     *containers = malloc(sizeof(container_t));
+    if (!containers) {
+        fprintf(stderr, "Could not allocate memory for containers string\n");
+        exit(1);
+    }
     char *id = strtok(containers_string,",");
     int length = 0;
 
@@ -57,6 +61,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
         //printf("Token: %s\n", id);
         length++;
         *containers = realloc(*containers, length * sizeof(container_t));
+        if (!containers) {
+            fprintf(stderr, "Could not allocate memory for containers string\n");
+            exit(1);
+        }
         (*containers)[length-1].id = id;
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
@@ -146,6 +154,10 @@ int main(int argc, char **argv) {
             break;
         case 's':
             containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            if (!containers_string) {
+                fprintf(stderr, "Could not allocate memory for containers string\n");
+                exit(1);
+            }
             strncpy(containers_string, optarg, strlen(optarg));
             break;
         case 'c':

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -8,9 +8,11 @@
 #include <getopt.h>
 #include <limits.h>
 
+#define DOCKER_CONTAINER_ID_BUFFER 65 // Docker container ID size is 64 + 1 byte for NUL termination
+
 typedef struct container_t { // struct is a specification and this static makes no sense here
     char path[PATH_MAX];
-    char *id;
+    char id[DOCKER_CONTAINER_ID_BUFFER];
 } container_t;
 
 // All variables are made static, because we believe that this will
@@ -65,7 +67,9 @@ static int parse_containers(container_t** containers, char* containers_string, i
             fprintf(stderr, "Could not allocate memory for containers string\n");
             exit(1);
         }
-        (*containers)[length-1].id = id;
+        strncpy((*containers)[length-1].id, id, DOCKER_CONTAINER_ID_BUFFER - 1);
+        (*containers)[length-1].id[DOCKER_CONTAINER_ID_BUFFER - 1] = '\0';
+
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
                 PATH_MAX,
@@ -159,6 +163,7 @@ int main(int argc, char **argv) {
                 exit(1);
             }
             strncpy(containers_string, optarg, strlen(optarg));
+            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -6,9 +6,10 @@
 #include <time.h>
 #include <string.h> // for strtok
 #include <getopt.h>
+#include <limits.h>
 
 typedef struct container_t { // struct is a specification and this static makes no sense here
-    char path[BUFSIZ];
+    char path[PATH_MAX];
     char *id;
 } container_t;
 

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -33,7 +33,7 @@ static long int read_cpu_cgroup(char* filename) {
     return cpu_usage;
 }
 
-static int output_stats(container_t *containers, int length) {
+static void output_stats(container_t *containers, int length) {
     struct timeval now;
     gettimeofday(&now, NULL);
 
@@ -41,8 +41,6 @@ static int output_stats(container_t *containers, int length) {
         printf("%ld%06ld %ld %s\n", now.tv_sec, now.tv_usec, read_cpu_cgroup(containers[i].path), containers[i].id);
     }
     usleep(msleep_time*1000);
-
-    return 1;
 }
 
 static int parse_containers(container_t** containers, char* containers_string, int rootless_mode) {

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -90,7 +90,7 @@ static int check_system(int rootless_mode) {
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open cpu.stat file at %s\n", check_path);
-        exit(127);
+        exit(1);
     }
     fclose(fd);
     return 0;

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -22,8 +22,7 @@ static unsigned int msleep_time=1000;
 
 static long int read_cpu_cgroup(char* filename) {
     long int cpu_usage = -1;
-    FILE* fd = NULL;
-    fd = fopen(filename, "r");
+    FILE* fd = fopen(filename, "r");
     if ( fd == NULL) {
         fprintf(stderr, "Error - Could not open path for reading: %s. Maybe the container is not running anymore? Are you using --rootless mode? Errno: %d\n", filename, errno);
         exit(1);
@@ -85,8 +84,7 @@ static int check_system(int rootless_mode) {
         check_path = "/sys/fs/cgroup/system.slice/cpu.stat";
     }
     
-    FILE* fd = NULL;
-    fd = fopen(check_path, "r");
+    FILE* fd = fopen(check_path, "r");
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open cpu.stat file at %s\n", check_path);

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -16,7 +16,7 @@ typedef struct container_t { // struct is a specification and this static makes 
 // keep them local in scope to the file and not make them persist in state
 // between Threads.
 // in any case, none of these variables should change between threads
-static int user_id = 0;
+static int user_id = -1;
 static long int user_hz;
 static unsigned int msleep_time=1000;
 

--- a/metric_providers/cpu/time/cgroup/system/source.c
+++ b/metric_providers/cpu/time/cgroup/system/source.c
@@ -18,8 +18,7 @@ static unsigned int msleep_time=1000;
 static long int read_cpu_cgroup() {
 
     long int cpu_usage = -1;
-    FILE* fd = NULL;
-    fd = fopen("/sys/fs/cgroup/cpu.stat", "r"); // check for general readability only once
+    FILE* fd = fopen("/sys/fs/cgroup/cpu.stat", "r"); // check for general readability only once
     fscanf(fd, "usage_usec %ld", &cpu_usage);
     fclose(fd);
     return cpu_usage;
@@ -36,8 +35,7 @@ static void output_stats() {
 
 static int check_system() {
     const char check_path[] = "/sys/fs/cgroup/cpu.stat";
-    FILE* fd = NULL;
-    fd = fopen(check_path, "r");
+    FILE* fd = fopen(check_path, "r");
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open cpu.stat file at %s\n", check_path);

--- a/metric_providers/cpu/time/cgroup/system/source.c
+++ b/metric_providers/cpu/time/cgroup/system/source.c
@@ -41,7 +41,7 @@ static int check_system() {
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open cpu.stat file at %s\n", check_path);
-        exit(127);
+        exit(1);
     }
     fclose(fd);
     return 0;

--- a/metric_providers/cpu/time/cgroup/system/source.c
+++ b/metric_providers/cpu/time/cgroup/system/source.c
@@ -25,15 +25,13 @@ static long int read_cpu_cgroup() {
     return cpu_usage;
 }
 
-static int output_stats() {
+static void output_stats() {
 
     struct timeval now;
     gettimeofday(&now, NULL);
 
     printf("%ld%06ld %ld\n", now.tv_sec, now.tv_usec, read_cpu_cgroup());
     usleep(msleep_time*1000);
-
-    return 1;
 }
 
 static int check_system() {

--- a/metric_providers/cpu/time/procfs/system/source.c
+++ b/metric_providers/cpu/time/procfs/system/source.c
@@ -17,10 +17,8 @@ static long int user_hz;
 static unsigned int msleep_time=1000;
 
 static long int read_cpu_proc() {
-    FILE* fd = NULL;
     long int user_time, nice_time, system_time, idle_time, iowait_time, irq_time, softirq_time, steal_time;
-
-    fd = fopen("/proc/stat", "r");
+    FILE* fd = fopen("/proc/stat", "r");
 
     fscanf(fd, "cpu %ld %ld %ld %ld %ld %ld %ld %ld", &user_time, &nice_time, &system_time, &idle_time, &iowait_time, &irq_time, &softirq_time, &steal_time);
 
@@ -46,8 +44,7 @@ static void output_stats() {
 static int check_system() {
     const char check_path[] = "/proc/stat";
     
-    FILE* fd = NULL;
-    fd = fopen(check_path, "r");
+    FILE* fd = fopen(check_path, "r");
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open /proc/stat file\n");

--- a/metric_providers/cpu/time/procfs/system/source.c
+++ b/metric_providers/cpu/time/procfs/system/source.c
@@ -51,7 +51,7 @@ static int check_system() {
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open /proc/stat file\n");
-        exit(127);
+        exit(1);
     }
     fclose(fd);
     return 0;

--- a/metric_providers/cpu/time/procfs/system/source.c
+++ b/metric_providers/cpu/time/procfs/system/source.c
@@ -34,17 +34,13 @@ static long int read_cpu_proc() {
     return ((user_time+nice_time+system_time+idle_time+iowait_time+irq_time+softirq_time+steal_time)*1000000)/user_hz;
 }
 
-
-
-static int output_stats() {
+static void output_stats() {
 
     struct timeval now;
 
     gettimeofday(&now, NULL);
     printf("%ld%06ld %ld\n", now.tv_sec, now.tv_usec, read_cpu_proc());
     usleep(msleep_time*1000);
-
-    return 1;
 }
 
 static int check_system() {

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -132,11 +132,13 @@ static int parse_containers(container_t** containers, char* containers_string, i
         *containers = realloc(*containers, length * sizeof(container_t));
         (*containers)[length-1].id = id;
         if(rootless_mode) {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/user.slice/user-%d.slice/user@%d.service/user.slice/docker-%s.scope/cpu.stat",
                 user_id, user_id, id);
         } else {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/system.slice/docker-%s.scope/cpu.stat",
                 id);
         }

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -181,7 +181,7 @@ static int check_system(int rootless_mode) {
     }
 
     if(found_error) {
-        exit(127);
+        exit(1);
     }
 
     return 0;

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -6,9 +6,10 @@
 #include <time.h>
 #include <string.h> // for strtok
 #include <getopt.h>
+#include <limits.h>
 
 typedef struct container_t { // struct is a specification and this static makes no sense here
-    char path[BUFSIZ];
+    char path[PATH_MAX];
     char *id;
 } container_t;
 

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -62,7 +62,7 @@ static long int get_cpu_stat(char* filename, int mode) {
 }
 
 
-static int output_stats(container_t* containers, int length) {
+static void output_stats(container_t* containers, int length) {
 
     long int main_cpu_reading_before, main_cpu_reading_after, main_cpu_reading;
     long int cpu_readings_before[length];
@@ -71,7 +71,6 @@ static int output_stats(container_t* containers, int length) {
 
     struct timeval now;
     int i;
-
 
     // Get Energy Readings, set timestamp mark
     gettimeofday(&now, NULL);
@@ -116,7 +115,6 @@ static int output_stats(container_t* containers, int length) {
 
         printf("%ld%06ld %ld %s\n", now.tv_sec, now.tv_usec, reading, containers[i].id);
     }
-    return 1;
 }
 
 static int parse_containers(container_t** containers, char* containers_string, int rootless_mode) {

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -8,9 +8,11 @@
 #include <getopt.h>
 #include <limits.h>
 
+#define DOCKER_CONTAINER_ID_BUFFER 65 // Docker container ID size is 64 + 1 byte for NUL termination
+
 typedef struct container_t { // struct is a specification and this static makes no sense here
     char path[PATH_MAX];
-    char *id;
+    char id[DOCKER_CONTAINER_ID_BUFFER];
 } container_t;
 
 // All variables are made static, because we believe that this will
@@ -138,7 +140,9 @@ static int parse_containers(container_t** containers, char* containers_string, i
             fprintf(stderr, "Could not allocate memory for containers string\n");
             exit(1);
         }
-        (*containers)[length-1].id = id;
+        strncpy((*containers)[length-1].id, id, DOCKER_CONTAINER_ID_BUFFER - 1);
+        (*containers)[length-1].id[DOCKER_CONTAINER_ID_BUFFER - 1] = '\0';
+
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
                 PATH_MAX,
@@ -248,6 +252,7 @@ int main(int argc, char **argv) {
                 exit(1);
             }
             strncpy(containers_string, optarg, strlen(optarg));
+            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -123,6 +123,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
     }
 
     *containers = malloc(sizeof(container_t));
+    if (!containers) {
+        fprintf(stderr, "Could not allocate memory for containers string\n");
+        exit(1);
+    }
     char *id = strtok(containers_string,",");
     int length = 0;
 
@@ -130,6 +134,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
         //printf("Token: %s\n", id);
         length++;
         *containers = realloc(*containers, length * sizeof(container_t));
+        if (!containers) {
+            fprintf(stderr, "Could not allocate memory for containers string\n");
+            exit(1);
+        }
         (*containers)[length-1].id = id;
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
@@ -235,6 +243,10 @@ int main(int argc, char **argv) {
             break;
         case 's':
             containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            if (!containers_string) {
+                fprintf(stderr, "Could not allocate memory for containers string\n");
+                exit(1);
+            }
             strncpy(containers_string, optarg, strlen(optarg));
             break;
         case 'c':

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -16,7 +16,7 @@ typedef struct container_t { // struct is a specification and this static makes 
 // keep them local in scope to the file and not make them persist in state
 // between Threads.
 // in any case, none of these variables should change between threads
-static int user_id = 0;
+static int user_id = -1;
 static long int user_hz;
 static unsigned int msleep_time=1000;
 

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -41,10 +41,8 @@ static long int read_cpu_cgroup(FILE *fd) {
 }
 
 static long int get_cpu_stat(char* filename, int mode) {
-    FILE* fd = NULL;
     long int result=-1;
-
-    fd = fopen(filename, "r");
+    FILE* fd = fopen(filename, "r");
 
     if ( fd == NULL) {
         fprintf(stderr, "Error - Could not open path for reading: %s. Maybe the container is not running anymore? Are you using --rootless mode? Errno: %d\n", filename, errno);
@@ -162,9 +160,7 @@ static int check_system(int rootless_mode) {
     }
     file_path_proc_stat = "/proc/stat";
     
-    FILE* fd = NULL;
-
-    fd = fopen(file_path_cpu_stat, "r");
+    FILE* fd = fopen(file_path_cpu_stat, "r");
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open cpu.stat file at %s\n", file_path_cpu_stat);
         found_error = 1;

--- a/metric_providers/cpu/utilization/procfs/system/source.c
+++ b/metric_providers/cpu/utilization/procfs/system/source.c
@@ -52,7 +52,7 @@ static void read_cpu_proc(procfs_time_t* procfs_time_struct) {
 }
 
 
-static int output_stats() {
+static void output_stats() {
 
     long int  idle_reading, compute_time_reading;
     procfs_time_t main_cpu_reading_before;
@@ -75,8 +75,6 @@ static int output_stats() {
 
     // main output to Stdout
     printf("%ld%06ld %ld\n", now.tv_sec, now.tv_usec, (compute_time_reading*10000) / (compute_time_reading+idle_reading) ); // Deliberate integer conversion. Precision with 0.01% is good enough
-
-    return 1;
 }
 
 static int check_system() {

--- a/metric_providers/cpu/utilization/procfs/system/source.c
+++ b/metric_providers/cpu/utilization/procfs/system/source.c
@@ -85,7 +85,7 @@ static int check_system() {
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open %s file\n", check_path);
-        exit(127);
+        exit(1);
     }
     fclose(fd);
     return 0;

--- a/metric_providers/cpu/utilization/procfs/system/source.c
+++ b/metric_providers/cpu/utilization/procfs/system/source.c
@@ -29,9 +29,7 @@ static unsigned int msleep_time=1000;
 
 static void read_cpu_proc(procfs_time_t* procfs_time_struct) {
 
-    FILE* fd = NULL;
-
-    fd = fopen("/proc/stat", "r");
+    FILE* fd = fopen("/proc/stat", "r");
     if ( fd == NULL) {
         fprintf(stderr, "Error - file %s failed to open: errno: %d\n", "/proc/stat/", errno);
         exit(1);
@@ -80,8 +78,7 @@ static void output_stats() {
 static int check_system() {
     const char check_path[] = "/proc/stat";
     
-    FILE* fd = NULL;
-    fd = fopen(check_path, "r");
+    FILE* fd = fopen(check_path, "r");
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open %s file\n", check_path);

--- a/metric_providers/disk/io/cgroup/container/Makefile
+++ b/metric_providers/disk/io/cgroup/container/Makefile
@@ -1,0 +1,4 @@
+CFLAGS = -o3 -Wall
+
+metric-provider-binary: source.c
+	gcc $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/container/README.md
+++ b/metric_providers/disk/io/cgroup/container/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/disk-io-cgroup-container/ for details

--- a/metric_providers/disk/io/cgroup/container/provider.py
+++ b/metric_providers/disk/io/cgroup/container/provider.py
@@ -1,0 +1,15 @@
+import os
+
+from metric_providers.base import BaseMetricProvider
+
+class DiskIoCgroupContainerProvider(BaseMetricProvider):
+    def __init__(self, resolution, rootless=False, skip_check=False):
+        super().__init__(
+            metric_name='disk_io_cgroup_container',
+            metrics={'time': int, 'value': int, 'container_id': str},
+            resolution=resolution,
+            unit='Bytes',
+            current_dir=os.path.dirname(os.path.abspath(__file__)),
+            skip_check=skip_check,
+        )
+        self._rootless = rootless

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -1,0 +1,189 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <string.h> // for strtok
+#include <getopt.h>
+
+typedef struct container_t { // struct is a specification and this static makes no sense here
+    char path[BUFSIZ];
+    char *id;
+} container_t;
+
+typedef struct disk_io_t { // struct is a specification and this static makes no sense here
+    long int rbytes;
+    long int wbytes;
+} disk_io_t;
+
+
+// All variables are made static, because we believe that this will
+// keep them local in scope to the file and not make them persist in state
+// between Threads.
+// in any case, none of these variables should change between threads
+static int user_id = 0;
+static unsigned int msleep_time=1000;
+
+
+static disk_io_t get_disk_cgroup(char* filename) {
+    long int rbytes = -1;
+    long int rbytes_sum = 0;
+    long int wbytes = -1;
+    long int wbytes_sum = 0;
+
+    FILE * fd = fopen(filename, "r");
+    if ( fd == NULL) {
+        fprintf(stderr, "Error - Could not open path for reading: %s. Maybe the container is not running anymore? Are you using --rootless mode? Errno: %d\n", filename, errno);
+        exit(1);
+    }
+
+    while (fscanf(fd, "%*u:%*u rbytes=%ld wbytes=%ld rios=%*u wios=%*u dbytes=%*u dios=%*u", &rbytes, &wbytes) == 2) {
+        rbytes_sum += rbytes;
+        wbytes_sum += wbytes;
+    }
+    ;
+
+    fclose(fd);
+
+    if(rbytes < 0 || wbytes < 0) {
+        fprintf(stderr, "Error - io.stat could not be read or was < 0.");
+        exit(1);
+    }
+
+    disk_io_t disk_io;
+    disk_io.rbytes = rbytes_sum;
+    disk_io.wbytes = wbytes_sum;
+    return disk_io;
+}
+
+static int output_stats(container_t *containers, int length) {
+
+    struct timeval now;
+    int i;
+
+    gettimeofday(&now, NULL);
+    for(i=0; i<length; i++) {
+        disk_io_t disk_io = get_disk_cgroup(containers[i].path);
+        printf("%ld%06ld %ld %s\n", now.tv_sec, now.tv_usec, disk_io.rbytes+disk_io.wbytes, containers[i].id);
+    }
+    usleep(msleep_time*1000);
+
+    return 1;
+}
+
+static int parse_containers(container_t** containers, char* containers_string, int rootless_mode) {
+    if(containers_string == NULL) {
+        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        exit(1);
+    }
+
+    *containers = malloc(sizeof(container_t));
+    char *id = strtok(containers_string,",");
+    int length = 0;
+
+    for (; id != NULL; id = strtok(NULL, ",")) {
+        //printf("Token: %s\n", id);
+        length++;
+        *containers = realloc(*containers, length * sizeof(container_t));
+        (*containers)[length-1].id = id;
+        if(rootless_mode) {
+            sprintf((*containers)[length-1].path,
+                "/sys/fs/cgroup/user.slice/user-%d.slice/user@%d.service/user.slice/docker-%s.scope/io.stat",
+                user_id, user_id, id);
+        } else {
+            sprintf((*containers)[length-1].path,
+                "/sys/fs/cgroup/system.slice/docker-%s.scope/io.stat",
+                id);
+        }
+    }
+
+    if(length == 0) {
+        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        exit(1);
+    }
+    return length;
+}
+
+static int check_system(int rootless_mode) {
+    const char* check_path;
+
+    if(rootless_mode) {
+        check_path = "/sys/fs/cgroup/user.slice/io.stat";
+    } else {
+        check_path = "/sys/fs/cgroup/system.slice/io.stat";
+    }
+
+    FILE* fd = NULL;
+    fd = fopen(check_path, "r");
+
+    if (fd == NULL) {
+        fprintf(stderr, "Couldn't open io.stat file at %s\n", check_path);
+        exit(127);
+    }
+    fclose(fd);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+
+    int c;
+    int check_system_flag = 0;
+    int rootless_mode = 0; // docker root is default
+    char *containers_string = NULL;  // Dynamic buffer to store optarg
+    container_t *containers = NULL;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+    user_id = getuid();
+
+    static struct option long_options[] =
+    {
+        {"rootless", no_argument, NULL, 'r'},
+        {"help", no_argument, NULL, 'h'},
+        {"interval", no_argument, NULL, 'i'},
+        {"containers", no_argument, NULL, 's'},
+        {"check", no_argument, NULL, 'c'},
+        {NULL, 0, NULL, 0}
+    };
+
+    while ((c = getopt_long(argc, argv, "ri:s:hc", long_options, NULL)) != -1) {
+        switch (c) {
+        case 'h':
+            printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
+            printf("\t-h      : displays this help\n");
+            printf("\t-s      : string of container IDs separated by comma\n");
+            printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
+            printf("\t-c      : check system and exit\n\n");
+            exit(0);
+        case 'i':
+            msleep_time = atoi(optarg);
+            break;
+        case 'r':
+            rootless_mode = 1;
+            break;
+        case 's':
+            containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            strncpy(containers_string, optarg, strlen(optarg));
+            break;
+        case 'c':
+            check_system_flag = 1;
+            break;
+        default:
+            fprintf(stderr,"Unknown option %c\n",c);
+            exit(-1);
+        }
+    }
+
+    if(check_system_flag){
+        exit(check_system(rootless_mode));
+    }
+
+    int length = parse_containers(&containers, containers_string, rootless_mode);
+
+    while(1) {
+        output_stats(containers, length);
+    }
+
+    free(containers); // since tools is only aborted by CTRL+C this is never called, but memory is freed on program end
+
+    return 0;
+}

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -7,9 +7,11 @@
 #include <getopt.h>
 #include <limits.h>
 
+#define DOCKER_CONTAINER_ID_BUFFER 65 // Docker container ID size is 64 + 1 byte for NUL termination
+
 typedef struct container_t { // struct is a specification and this static makes no sense here
     char path[PATH_MAX];
-    char *id;
+    char id[DOCKER_CONTAINER_ID_BUFFER];
 } container_t;
 
 typedef struct disk_io_t { // struct is a specification and this static makes no sense here
@@ -90,7 +92,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
             fprintf(stderr, "Could not allocate memory for containers string\n");
             exit(1);
         }
-        (*containers)[length-1].id = id;
+
+        strncpy((*containers)[length-1].id, id, DOCKER_CONTAINER_ID_BUFFER - 1);
+        (*containers)[length-1].id[DOCKER_CONTAINER_ID_BUFFER - 1] = '\0';
+
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
                 PATH_MAX,
@@ -173,6 +178,7 @@ int main(int argc, char **argv) {
                 exit(1);
             }
             strncpy(containers_string, optarg, strlen(optarg));
+            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -21,7 +21,7 @@ typedef struct disk_io_t { // struct is a specification and this static makes no
 // keep them local in scope to the file and not make them persist in state
 // between Threads.
 // in any case, none of these variables should change between threads
-static int user_id = 0;
+static int user_id = -1;
 static unsigned int msleep_time=1000;
 
 

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -77,6 +77,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
     }
 
     *containers = malloc(sizeof(container_t));
+    if (!containers) {
+        fprintf(stderr, "Could not allocate memory for containers string\n");
+        exit(1);
+    }
     char *id = strtok(containers_string,",");
     int length = 0;
 
@@ -84,6 +88,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
         //printf("Token: %s\n", id);
         length++;
         *containers = realloc(*containers, length * sizeof(container_t));
+        if (!containers) {
+            fprintf(stderr, "Could not allocate memory for containers string\n");
+            exit(1);
+        }
         (*containers)[length-1].id = id;
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
@@ -162,6 +170,10 @@ int main(int argc, char **argv) {
             break;
         case 's':
             containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            if (!containers_string) {
+                fprintf(stderr, "Could not allocate memory for containers string\n");
+                exit(1);
+            }
             strncpy(containers_string, optarg, strlen(optarg));
             break;
         case 'c':

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -86,11 +86,13 @@ static int parse_containers(container_t** containers, char* containers_string, i
         *containers = realloc(*containers, length * sizeof(container_t));
         (*containers)[length-1].id = id;
         if(rootless_mode) {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/user.slice/user-%d.slice/user@%d.service/user.slice/docker-%s.scope/io.stat",
                 user_id, user_id, id);
         } else {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/system.slice/docker-%s.scope/io.stat",
                 id);
         }

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -5,9 +5,10 @@
 #include <sys/time.h>
 #include <string.h> // for strtok
 #include <getopt.h>
+#include <limits.h>
 
 typedef struct container_t { // struct is a specification and this static makes no sense here
-    char path[BUFSIZ];
+    char path[PATH_MAX];
     char *id;
 } container_t;
 

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -56,7 +56,7 @@ static disk_io_t get_disk_cgroup(char* filename) {
     return disk_io;
 }
 
-static int output_stats(container_t *containers, int length) {
+static void output_stats(container_t *containers, int length) {
 
     struct timeval now;
     int i;
@@ -67,8 +67,6 @@ static int output_stats(container_t *containers, int length) {
         printf("%ld%06ld %ld %s\n", now.tv_sec, now.tv_usec, disk_io.rbytes+disk_io.wbytes, containers[i].id);
     }
     usleep(msleep_time*1000);
-
-    return 1;
 }
 
 static int parse_containers(container_t** containers, char* containers_string, int rootless_mode) {

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -111,8 +111,7 @@ static int check_system(int rootless_mode) {
         check_path = "/sys/fs/cgroup/system.slice/io.stat";
     }
 
-    FILE* fd = NULL;
-    fd = fopen(check_path, "r");
+    FILE* fd = fopen(check_path, "r");
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open io.stat file at %s\n", check_path);

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -25,7 +25,6 @@ typedef struct disk_io_t { // struct is a specification and this static makes no
 static int user_id = -1;
 static unsigned int msleep_time=1000;
 
-
 static disk_io_t get_disk_cgroup(char* filename) {
     long int rbytes = -1;
     long int rbytes_sum = 0;
@@ -42,7 +41,6 @@ static disk_io_t get_disk_cgroup(char* filename) {
         rbytes_sum += rbytes;
         wbytes_sum += wbytes;
     }
-    ;
 
     fclose(fd);
 

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -116,7 +116,7 @@ static int check_system(int rootless_mode) {
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open io.stat file at %s\n", check_path);
-        exit(127);
+        exit(1);
     }
     fclose(fd);
     return 0;

--- a/metric_providers/lm_sensors/source.c
+++ b/metric_providers/lm_sensors/source.c
@@ -298,7 +298,7 @@ int main(int argc, char *argv[]) {
                             if (g_ascii_strncasecmp(feature_iterator->data, label, strlen(feature_iterator->data)) ==
                                 0) {
                                 Output_Mapping *to_add_to_list = malloc(sizeof(Output_Mapping));
-                                if (!Output_Mapping) {
+                                if (!to_add_to_list) {
                                     fprintf(stderr, "Could not allocate memory\n");
                                     exit(1);
                                 }

--- a/metric_providers/lm_sensors/source.c
+++ b/metric_providers/lm_sensors/source.c
@@ -298,6 +298,10 @@ int main(int argc, char *argv[]) {
                             if (g_ascii_strncasecmp(feature_iterator->data, label, strlen(feature_iterator->data)) ==
                                 0) {
                                 Output_Mapping *to_add_to_list = malloc(sizeof(Output_Mapping));
+                                if (!Output_Mapping) {
+                                    fprintf(stderr, "Could not allocate memory\n");
+                                    exit(1);
+                                }
                                 to_add_to_list->chip_name = chip_name;
                                 to_add_to_list->feature = feature;
 

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -94,8 +94,7 @@ static int check_system(int rootless_mode) {
         check_path = "/sys/fs/cgroup/system.slice/memory.current";
     }
 
-    FILE* fd = NULL;
-    fd = fopen(check_path, "r");
+    FILE* fd = fopen(check_path, "r");
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open memory.current file at %s\n", check_path);

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -5,9 +5,11 @@
 #include <sys/time.h>
 #include <string.h> // for strtok
 #include <getopt.h>
+#include <limits.h>
+
 
 typedef struct container_t { // struct is a specification and this static makes no sense here
-    char path[BUFSIZ];
+    char path[PATH_MAX];
     char *id;
 } container_t;
 

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -61,6 +61,11 @@ static int parse_containers(container_t** containers, char* containers_string, i
     }
 
     *containers = malloc(sizeof(container_t));
+    if (!containers) {
+        fprintf(stderr, "Could not allocate memory for containers string\n");
+        exit(1);
+    }
+
     char *id = strtok(containers_string,",");
     int length = 0;
 
@@ -68,6 +73,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
         //printf("Token: %s\n", id);
         length++;
         *containers = realloc(*containers, length * sizeof(container_t));
+        if (!containers) {
+            fprintf(stderr, "Could not allocate memory for containers string\n");
+            exit(1);
+        }
         (*containers)[length-1].id = id;
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -15,7 +15,7 @@ typedef struct container_t { // struct is a specification and this static makes 
 // keep them local in scope to the file and not make them persist in state
 // between Threads.
 // in any case, none of these variables should change between threads
-static int user_id = 0;
+static int user_id = -1;
 static unsigned int msleep_time=1000;
 
 static long int get_memory_cgroup(char* filename) {

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -7,10 +7,11 @@
 #include <getopt.h>
 #include <limits.h>
 
+#define DOCKER_CONTAINER_ID_BUFFER 65 // Docker container ID size is 64 + 1 byte for NUL termination
 
 typedef struct container_t { // struct is a specification and this static makes no sense here
     char path[PATH_MAX];
-    char *id;
+    char id[DOCKER_CONTAINER_ID_BUFFER];
 } container_t;
 
 // All variables are made static, because we believe that this will
@@ -77,7 +78,9 @@ static int parse_containers(container_t** containers, char* containers_string, i
             fprintf(stderr, "Could not allocate memory for containers string\n");
             exit(1);
         }
-        (*containers)[length-1].id = id;
+        strncpy((*containers)[length-1].id, id, DOCKER_CONTAINER_ID_BUFFER - 1);
+        (*containers)[length-1].id[DOCKER_CONTAINER_ID_BUFFER - 1] = '\0';
+
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
                 PATH_MAX,
@@ -160,6 +163,7 @@ int main(int argc, char **argv) {
                 exit(1);
             }
             strncpy(containers_string, optarg, strlen(optarg));
+            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -70,11 +70,13 @@ static int parse_containers(container_t** containers, char* containers_string, i
         *containers = realloc(*containers, length * sizeof(container_t));
         (*containers)[length-1].id = id;
         if(rootless_mode) {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/user.slice/user-%d.slice/user@%d.service/user.slice/docker-%s.scope/memory.current",
                 user_id, user_id, id);
         } else {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/system.slice/docker-%s.scope/memory.current",
                 id);
         }

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -99,7 +99,7 @@ static int check_system(int rootless_mode) {
 
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open memory.current file at %s\n", check_path);
-        exit(127);
+        exit(1);
     }
     fclose(fd);
     return 0;

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -40,7 +40,7 @@ static long int get_memory_cgroup(char* filename) {
 
 }
 
-static int output_stats(container_t *containers, int length) {
+static void output_stats(container_t *containers, int length) {
 
     struct timeval now;
     int i;
@@ -50,8 +50,6 @@ static int output_stats(container_t *containers, int length) {
         printf("%ld%06ld %ld %s\n", now.tv_sec, now.tv_usec, get_memory_cgroup(containers[i].path), containers[i].id);
     }
     usleep(msleep_time*1000);
-
-    return 1;
 }
 
 static int parse_containers(container_t** containers, char* containers_string, int rootless_mode) {

--- a/metric_providers/memory/total/cgroup/container/source.c
+++ b/metric_providers/memory/total/cgroup/container/source.c
@@ -155,6 +155,10 @@ int main(int argc, char **argv) {
             break;
         case 's':
             containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            if (!containers_string) {
+                fprintf(stderr, "Could not allocate memory for containers string\n");
+                exit(1);
+            }
             strncpy(containers_string, optarg, strlen(optarg));
             break;
         case 'c':

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -48,7 +48,7 @@ static unsigned long int get_network_cgroup(unsigned int pid) {
     unsigned long int r_bytes, t_bytes, r_packets, t_packets;
 
     char ns_path[PATH_MAX];
-    sprintf(ns_path, "/proc/%u/ns/net",pid);
+    snprintf(ns_path, PATH_MAX, "/proc/%u/ns/net", pid);
 
     int fd_ns = open(ns_path, O_RDONLY);   /* Get descriptor for namespace */
     if (fd_ns == -1) {
@@ -124,11 +124,13 @@ static int parse_containers(container_t** containers, char* containers_string, i
         *containers = realloc(*containers, length * sizeof(container_t));
         (*containers)[length-1].id = id;
         if(rootless_mode) {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/user.slice/user-%d.slice/user@%d.service/user.slice/docker-%s.scope/cgroup.procs",
                 user_id, user_id, id);
         } else {
-            sprintf((*containers)[length-1].path,
+            snprintf((*containers)[length-1].path,
+                PATH_MAX,
                 "/sys/fs/cgroup/system.slice/docker-%s.scope/cgroup.procs",
                 id);
         }

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -9,9 +9,10 @@
 #include <sys/time.h>
 #include <ctype.h>
 #include <getopt.h>
+#include <limits.h>
 
 typedef struct container_t { // struct is a specification and this static makes no sense here
-    char path[BUFSIZ];
+    char path[PATH_MAX];
     char *id;
     unsigned int pid;
 } container_t;
@@ -46,8 +47,7 @@ static unsigned long int get_network_cgroup(unsigned int pid) {
     char buf[200], ifname[20];
     unsigned long int r_bytes, t_bytes, r_packets, t_packets;
 
-
-    char ns_path[BUFSIZ];
+    char ns_path[PATH_MAX];
     sprintf(ns_path, "/proc/%u/ns/net",pid);
 
     int fd_ns = open(ns_path, O_RDONLY);   /* Get descriptor for namespace */

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -20,7 +20,7 @@ typedef struct container_t { // struct is a specification and this static makes 
 // keep them local in scope to the file and not make them persist in state
 // between Threads.
 // in any case, none of these variables should change between threads
-static int user_id = 0;
+static int user_id = -1;
 static unsigned int msleep_time=1000;
 
 static char *trimwhitespace(char *str) {

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -115,6 +115,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
     }
 
     *containers = malloc(sizeof(container_t));
+    if (!containers) {
+        fprintf(stderr, "Could not allocate memory for containers string\n");
+        exit(1);
+    }
     char *id = strtok(containers_string,",");
     int length = 0;
 
@@ -122,6 +126,10 @@ static int parse_containers(container_t** containers, char* containers_string, i
         //printf("Token: %s\n", id);
         length++;
         *containers = realloc(*containers, length * sizeof(container_t));
+        if (!containers) {
+            fprintf(stderr, "Could not allocate memory for containers string\n");
+            exit(1);
+        }
         (*containers)[length-1].id = id;
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
@@ -223,6 +231,10 @@ int main(int argc, char **argv) {
             break;
         case 's':
             containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            if (!containers_string) {
+                fprintf(stderr, "Could not allocate memory for containers string\n");
+                exit(1);
+            }
             strncpy(containers_string, optarg, strlen(optarg));
             break;
         case 'c':

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -132,8 +132,7 @@ static int parse_containers(container_t** containers, char* containers_string, i
                 "/sys/fs/cgroup/system.slice/docker-%s.scope/cgroup.procs",
                 id);
         }
-        FILE* fd = NULL;
-        fd = fopen((*containers)[length-1].path, "r"); // check for general readability only once
+        FILE* fd = fopen((*containers)[length-1].path, "r"); // check for general readability only once
         if ( fd == NULL) {
                 fprintf(stderr, "Error - cgroup.procs file %s failed to open: errno: %d\n", (*containers)[length-1].path, errno);
                 exit(1);
@@ -161,9 +160,7 @@ static int check_system(int rootless_mode) {
         file_path_cgroup_procs = "/sys/fs/cgroup/system.slice/cgroup.procs";
     }
     
-    FILE* fd = NULL;
-
-    fd = fopen(file_path_cgroup_procs, "r");
+    FILE* fd = fopen(file_path_cgroup_procs, "r");
     if (fd == NULL) {
         fprintf(stderr, "Couldn't open cgroup.procs file at %s\n", file_path_cgroup_procs);
         found_error = 1;

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -180,7 +180,7 @@ static int check_system(int rootless_mode) {
     }
 
     if(found_error) {
-        exit(127);
+        exit(1);
     }
 
     return 0;

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -11,9 +11,11 @@
 #include <getopt.h>
 #include <limits.h>
 
+#define DOCKER_CONTAINER_ID_BUFFER 65 // Docker container ID size is 64 + 1 byte for NUL termination
+
 typedef struct container_t { // struct is a specification and this static makes no sense here
     char path[PATH_MAX];
-    char *id;
+    char id[DOCKER_CONTAINER_ID_BUFFER];
     unsigned int pid;
 } container_t;
 
@@ -130,7 +132,9 @@ static int parse_containers(container_t** containers, char* containers_string, i
             fprintf(stderr, "Could not allocate memory for containers string\n");
             exit(1);
         }
-        (*containers)[length-1].id = id;
+        strncpy((*containers)[length-1].id, id, DOCKER_CONTAINER_ID_BUFFER - 1);
+        (*containers)[length-1].id[DOCKER_CONTAINER_ID_BUFFER - 1] = '\0';
+
         if(rootless_mode) {
             snprintf((*containers)[length-1].path,
                 PATH_MAX,
@@ -236,6 +240,7 @@ int main(int argc, char **argv) {
                 exit(1);
             }
             strncpy(containers_string, optarg, strlen(optarg));
+            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -96,7 +96,7 @@ static unsigned long int get_network_cgroup(unsigned int pid) {
 
 }
 
-static int output_stats(container_t *containers, int length) {
+static void output_stats(container_t *containers, int length) {
 
     struct timeval now;
     int i;
@@ -106,8 +106,6 @@ static int output_stats(container_t *containers, int length) {
         printf("%ld%06ld %lu %s\n", now.tv_sec, now.tv_usec, get_network_cgroup(containers[i].pid), containers[i].id);
     }
     usleep(msleep_time*1000);
-
-    return 1;
 }
 
 static int parse_containers(container_t** containers, char* containers_string, int rootless_mode) {


### PR DESCRIPTION
This PR adds a Disk I/O reporter.

To make it container agnostic the data is pulled directly from the `sysfs`. This needs the IO delegator to be set as specified in the documentation.

I am currently under the assumption that this controller is always active for docker in root mode, but will double check soon.

The approach here is similar to the other cgroup reading metric providers. However while crafting this the idea came up to actually split Input and Output and not supply the value as a cumulated number.

I see here two options:
- Making the reporter something like a base reporter that always reads everything and then only a part of the value gets extracted
- Making a shallow reporter that works like the SDIA or XGBoost one and actually relies on another reporter to be present on the system.

Here I think @ribalba it makes sense to discuss how this was solved in the lm_sensors