### PR TITLE
Calling fixture

### DIFF
--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -24,8 +24,9 @@ RUN_NAME = 'test_' + utils.randomword(12)
 def cleanup_after_test():
     pass
 
-#pylint: disable=unused-argument # unused arguement off for now - because there are no running tests in this file
-def cleanup_after_module(autouse=True, scope="module"):
+#pylint: disable=unused-argument
+@pytest.fixture(autouse=True, scope='module')
+def cleanup_after_module():
     yield
     tables = DB().fetch_all("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
     for table in tables:


### PR DESCRIPTION
This PR is a wild one.

1. Somehow the pytest fixture command got lost in a prior change leading to a non-complete cleaning of the database. Thus some old runs could be in there.


2. The code in `test_usage_scenario.py::test_uri_github_repo_branch` was starting a run with a different branch and then checking if that run was in the DB.
Since we now use pytest's randomization feature it seems like it does "fix" the random number generator for every module.

I am not sure if that should be called poisoning ... as in the end it makes tests still random over time but repeatable for a specific instance. 
In any case it leads to the fact that `smoke_test.py` and also `test_usage_scenario.py::test_uri_github_repo_branch` will generate the same random name for the run when calling `utils.randomword(12)`.

This behaviour is now NOT altered but rather the DB correctly cleaned. However it should hopefully serve as some reminder or debug context when we run into fixed random numbers again in the future.
