### PR TITLE
Security fix for python interpreter replacement

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -154,14 +154,13 @@ make -C lib/sgx-software-enable
 mv lib/sgx-software-enable/sgx_enable tools/
 rm lib/sgx-software-enable/sgx_enable.o
 
-print_message "Adding hardware_info_root.py to sudoers file"
-PYTHON_PATH=$(which python3)
-PWD=$(pwd)
-echo "ALL ALL=(ALL) NOPASSWD:$PYTHON_PATH $PWD/lib/hardware_info_root.py" | sudo tee /etc/sudoers.d/green-coding-hardware-info
+print_message "Adding python3 lib.hardware_info_root to sudoers file"
+# Please note the -m as here we will later call python3 without venv. It must understand the .lib imports
+# and not depend on venv installed packages
+echo "ALL ALL=(ALL) NOPASSWD:/usr/bin/python3 -m lib.hardware_info_root" | sudo tee /etc/sudoers.d/green-coding-hardware-info
 sudo chmod 500 /etc/sudoers.d/green-coding-hardware-info
 # remove old file name
 sudo rm -f /etc/sudoers.d/green_coding_hardware_info
-
 
 print_message "Setting the hardare hardware_info to be owned by root"
 sudo cp -f $PWD/lib/hardware_info_root_original.py $PWD/lib/hardware_info_root.py
@@ -236,6 +235,8 @@ if [[ $no_python != true ]] ; then
     python3 -m pip install -r metric_providers/psu/energy/ac/xgboost/machine/model/requirements.txt
 fi
 
+# kill the sudo timestamp
+sudo -k
 
 echo ""
 echo -e "${GREEN}Successfully installed Green Metrics Tool!${NC}"

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -106,10 +106,10 @@ source venv/bin/activate
 print_message "Setting GMT in include path for python via .pth file"
 find venv -type d -name "site-packages" -exec sh -c 'echo $PWD > "$0/gmt-lib.pth"' {} \;
 
-print_message "Adding hardware_info_root.py to sudoers file"
-PYTHON_PATH=$(which python3)
-PWD=$(pwd)
-echo "ALL ALL=(ALL) NOPASSWD:$PYTHON_PATH $PWD/lib/hardware_info_root.py" | sudo tee /etc/sudoers.d/green_coding_hardware_info
+print_message "Adding python3 lib.hardware_info_root to sudoers file"
+echo "ALL ALL=(ALL) NOPASSWD:/usr/bin/python3 -m lib.hardware_info_root" | sudo tee /etc/sudoers.d/green_coding_hardware_info
+# remove old file name
+sudo rm -f /etc/sudoers.d/green_coding_hardware_info
 
 print_message "Setting the hardare hardware_info to be owned by root"
 sudo cp -f $PWD/lib/hardware_info_root_original.py $PWD/lib/hardware_info_root.py

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -15,6 +15,37 @@ function generate_random_password() {
     echo
 }
 
+function check_file_permissions() {
+    local file=$1
+
+    # Check if the file exists
+    if [ ! -e "$file" ]; then
+        echo "File '$file' does not exist."
+        return 1
+    fi
+
+    # Check if the file is owned by root
+    if [ "$(stat -f %Su "$file")" != "root" ]; then
+        echo "File '$file' is not owned by root."
+        return 1
+    fi
+
+    # Check if the file permissions are read-only for group and others using regex
+    permissions=$(stat -f %Sp "$file")
+    if [ -L "$file" ]; then
+        echo "File '$file' is a symbolic link. Following ..."
+        check_file_permissions $(readlink -f $file)
+        return $?
+    elif [[ ! $permissions =~ ^-r..r-.r-.$ ]]; then
+        echo "File '$file' is not read-only for group and others or not a regular file"
+        return 1
+    fi
+
+    echo "File $file is save to create sudoers entry for"
+
+    return 0
+}
+
 db_pw=''
 api_url=''
 metrics_url=''
@@ -107,6 +138,7 @@ print_message "Setting GMT in include path for python via .pth file"
 find venv -type d -name "site-packages" -exec sh -c 'echo $PWD > "$0/gmt-lib.pth"' {} \;
 
 print_message "Adding python3 lib.hardware_info_root to sudoers file"
+check_file_permissions "/usr/bin/python3"
 echo "ALL ALL=(ALL) NOPASSWD:/usr/bin/python3 -m lib.hardware_info_root" | sudo tee /etc/sudoers.d/green_coding_hardware_info
 # remove old file name
 sudo rm -f /etc/sudoers.d/green_coding_hardware_info
@@ -116,7 +148,9 @@ sudo cp -f $PWD/lib/hardware_info_root_original.py $PWD/lib/hardware_info_root.p
 sudo chown root: $PWD/lib/hardware_info_root.py
 sudo chmod 755 $PWD/lib/hardware_info_root.py
 
+
 print_message "Adding powermetrics to sudoers file"
+check_file_permissions "/usr/bin/powermetrics"
 echo "ALL ALL=(ALL) NOPASSWD:/usr/bin/powermetrics" | sudo tee /etc/sudoers.d/green_coding_powermetrics
 echo "ALL ALL=(ALL) NOPASSWD:/usr/bin/killall powermetrics" | sudo tee /etc/sudoers.d/green_coding_kill_powermetrics
 echo "ALL ALL=(ALL) NOPASSWD:/usr/bin/killall -9 powermetrics" | sudo tee /etc/sudoers.d/green_coding_kill_powermetrics_sigkill

--- a/lib/hardware_info.py
+++ b/lib/hardware_info.py
@@ -6,69 +6,13 @@ import re
 import os
 import platform
 import pprint
-import subprocess
 import psutil
 import sys
+from lib.hardware_info_root_original import rdr, rpwr, rfwr, cf, get_values
 
 REGEX_PARAMS = re.MULTILINE | re.IGNORECASE
 
 CURRENT_PATH = os.path.dirname(__file__)
-
-def call_function(func, arguments=None, attribute=None):
-    if arguments is None:
-        arguments = []
-    if attribute:
-        return getattr(func(*arguments), attribute)
-    return func(*arguments)
-
-def read_file_with_regex(file, regex, params=REGEX_PARAMS):
-    '''Reads the content of a file and then tries to match the regex and returns the match described by 'o' '''
-
-    try:
-        with open(file, 'r', encoding='utf8') as file_ptr:
-            file_data = file_ptr.read()
-    except FileNotFoundError:
-        return 'File not found'
-
-    match = re.search(regex, file_data, params)
-
-    return match.group('o') if match is not None else 'Unknown'
-
-
-def read_process_with_regex(path, regex, params=REGEX_PARAMS):
-    '''Reads the data from a process and then matches the output. The process must terminate and not require user
-       input! The matching character for the regex is a 'o'. If the process fails (exit val not 0) an exception
-       is thrown.'''
-    result = subprocess.run(path, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        shell=True, encoding='UTF-8', check=False)
-    if result.returncode != 0:
-        return 'Unknown'
-
-    match = re.search(regex, result.stdout, params)
-
-    return match.group('o') if match is not None else 'Unknown'
-
-
-def read_directory_recursive(directory):
-    '''Reads all the files in a directory recursively and adds them to the return dict. We ignore most errors.'''
-    output_dic = {}
-
-    dir_path = directory
-    for (dir_path, _, file_names) in os.walk(dir_path):
-        for filename in file_names:
-            try:
-                with open(os.path.join(dir_path, filename), 'r', encoding='utf8') as file_ptr:
-                    output_dic[os.path.join(dir_path, filename)] = file_ptr.read()
-            except (FileNotFoundError, PermissionError, OSError):
-                continue
-    return output_dic
-
-
-# Defining shortcuts to make the lines shorter
-rfwr = read_file_with_regex
-rpwr = read_process_with_regex
-rdr = read_directory_recursive
-cf = call_function
 
 # pylint: disable=unnecessary-lambda-assignment
 # read_process_with_regex with duplicates removed (single)
@@ -103,7 +47,7 @@ linux_info_list = [
         re.IGNORECASE | re.DOTALL,
     ],
     [rfwr, 'Hyper Threading', '/sys/devices/system/cpu/smt/active', r'(?P<o>.*)'],
-    [rdr, 'CPU complete dump', '/sys/devices/system/cpu/'],
+    [rdr, 'CPU Complete Dump', '/sys/devices/system/cpu/'],
     # This is also listed in the complete dump but we include it here again so it is more visible in the listing
 
     # Note that this information is only accurate if intel_pstate is in active mode
@@ -115,7 +59,7 @@ linux_info_list = [
     [rfwr, 'Turbo Boost (Legacy non intel_pstate)', '/sys/devices/system/cpu/cpufreq/boost', r'(?P<o>.*)'],
     [rfwr, 'Virtualization', '/proc/cpuinfo', r'(?P<o>hypervisor)'],
     [rpwrs, 'SGX', f"{os.path.join(CURRENT_PATH, '../tools/sgx_enable')} -s", r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
-    [rfwr, 'IO scheduling', '/sys/block/sda/queue/scheduler', r'(?P<o>.*)'],
+    [rfwr, 'IO Scheduling', '/sys/block/sda/queue/scheduler', r'(?P<o>.*)'],
     [rpwr, 'Network Interfaces', 'ip addr | grep ether -B 1', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rfwr, 'Current Clocksource', '/sys/devices/system/clocksource/clocksource0/current_clocksource', r'(?P<o>.*)'],
 
@@ -147,11 +91,6 @@ def get_list():
         return mac_info_list
 
     return linux_info_list
-
-
-def get_values(list_of_tasks):
-    '''Creates an object with all the data populated'''
-    return {x[1]: x[0](*x[2:]) for x in list_of_tasks}
 
 def get_default_values():
     return get_values(get_list())

--- a/lib/hardware_info_root_original.py
+++ b/lib/hardware_info_root_original.py
@@ -7,11 +7,77 @@ sudo. This is why the output is json and not a nice representation as it needs t
 import json
 import platform
 import re
-from lib.hardware_info import rdr, rpwr, get_values
+import subprocess
+import os
+
+# We can NEVER include non system packages here, as we rely on them all being writeable by root only.
+# This will only be true for non-venv pure system packages coming with the python distribution of the OS
+
+REGEX_PARAMS = re.MULTILINE | re.IGNORECASE
+
+def call_function(func, arguments=None, attribute=None):
+    if arguments is None:
+        arguments = []
+    if attribute:
+        return getattr(func(*arguments), attribute)
+    return func(*arguments)
+
+def read_file_with_regex(file, regex, params=REGEX_PARAMS):
+    '''Reads the content of a file and then tries to match the regex and returns the match described by 'o' '''
+
+    try:
+        with open(file, 'r', encoding='utf8') as file_ptr:
+            file_data = file_ptr.read()
+    except FileNotFoundError:
+        return 'File not found'
+
+    match = re.search(regex, file_data, params)
+
+    return match.group('o') if match is not None else 'Unknown'
+
+
+def read_process_with_regex(path, regex, params=REGEX_PARAMS):
+    '''Reads the data from a process and then matches the output. The process must terminate and not require user
+       input! The matching character for the regex is a 'o'. If the process fails (exit val not 0) an exception
+       is thrown.'''
+    result = subprocess.run(path, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        shell=True, encoding='UTF-8', check=False)
+    if result.returncode != 0:
+        return 'Unknown'
+
+    match = re.search(regex, result.stdout, params)
+
+    return match.group('o') if match is not None else 'Unknown'
+
+
+def read_directory_recursive(directory):
+    '''Reads all the files in a directory recursively and adds them to the return dict. We ignore most errors.'''
+    output_dic = {}
+
+    dir_path = directory
+    for (dir_path, _, file_names) in os.walk(dir_path):
+        for filename in file_names:
+            try:
+                with open(os.path.join(dir_path, filename), 'r', encoding='utf8') as file_ptr:
+                    output_dic[os.path.join(dir_path, filename)] = file_ptr.read()
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+    return output_dic
+
+def get_values(list_of_tasks):
+    '''Creates an object with all the data populated'''
+    return {x[1]: x[0](*x[2:]) for x in list_of_tasks}
+
+
+# Defining shortcuts to make the lines shorter
+rfwr = read_file_with_regex
+rpwr = read_process_with_regex
+rdr = read_directory_recursive
+cf = call_function
 
 root_info_list = [
     [rdr, 'Power Limits', '/sys/devices/virtual/powercap/intel-rapl'],
-    [rdr, 'CPU scheduling', '/sys/kernel/debug/sched'],
+    [rdr, 'CPU Scheduling', '/sys/kernel/debug/sched'],
     [rpwr, 'Hardware Details', 'lshw', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
 ]
 

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -27,8 +27,6 @@ GMT_Resources = {
     'free_memory':  1024 ** 3, # 1GB in bytes
 }
 
-
-
 ######## CHECK FUNCTIONS ########
 def check_db():
     try:

--- a/runner.py
+++ b/runner.py
@@ -440,12 +440,9 @@ class Runner:
         machine_specs = hardware_info.get_default_values()
 
         if len(hardware_info_root.get_root_list()) > 0:
-            python_file = os.path.abspath(os.path.join(CURRENT_DIR, 'lib/hardware_info_root.py'))
-            ps = subprocess.run(['sudo', sys.executable, python_file], stdout=subprocess.PIPE, check=True, encoding='UTF-8')
+            ps = subprocess.run(['sudo', '/usr/bin/python3', '-m', 'lib.hardware_info_root'], stdout=subprocess.PIPE, cwd=CURRENT_DIR, check=True, encoding='UTF-8')
             machine_specs_root = json.loads(ps.stdout)
-
             machine_specs.update(machine_specs_root)
-
 
         keys = ["measurement", "sci"]
         measurement_config = {key: config.get(key, None) for key in keys}


### PR DESCRIPTION
It was possible to replace the `python3` interpreter at the venv location with a malicious file.

Since we were giving access to the interpreter via a sudoers entry this would open a privilege escalation.

It is recommended to update to the newest version of the GMT and just re-run the `install_linux.sh` or `install_mac.sh` file. The fix will be applied then.