### PR TITLE
Fix using depends_on in conjunction with container_name

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -703,16 +703,17 @@ class Runner:
 
             if 'container_name' in service:
                 container_name = service['container_name']
-                print(TerminalColors.HEADER, '\nSetting up container (', container_name, ') for service:', service_name, TerminalColors.ENDC)
             else:
                 container_name = service_name
-                print(TerminalColors.HEADER, '\nSetting up container for service:', service_name, TerminalColors.ENDC)
 
             if container_name in known_container_names:
                 raise RuntimeError(f"Container name '{container_name}' was already assigned. Please choose unique container names.")
 
             known_container_names.append(container_name)
 
+            print(TerminalColors.HEADER, '\nSetting up container for service:', service_name, TerminalColors.ENDC)
+            print('Container name:', container_name)
+            
             print('Resetting container')
             # By using the -f we return with 0 if no container is found
             # we always reset container without checking if something is running, as we expect that a user understands

--- a/tests/data/usage_scenarios/depends_on_custom_container_name.yml
+++ b/tests/data/usage_scenarios/depends_on_custom_container_name.yml
@@ -1,0 +1,20 @@
+---
+name: Test depends_on_container_name
+author: David Kopp
+description: test
+
+services:
+  test-service-1:
+    image: alpine
+    depends_on:
+      - test-service-2
+  test-service-2:
+    container_name: test-service-2-container-name
+    image: alpine
+
+flow:
+  - name: dummy
+    container: test-service-1
+    commands:
+      - type: console
+        command: pwd


### PR DESCRIPTION
If `container_name` was used in a setup with `depends_on` the state and health check did not work. This PR fixes that by using the provided `container_name` in the check.

I also tried to improve the wording in the log messages regarding the terms "service" and "container".

Fixes #859 