### PR TITLE
head -1 could lead to SIGPIPE 124

### DIFF
--- a/metric_providers/psu/energy/ac/ipmi/machine/ipmi-get-machine-energy-stat.sh
+++ b/metric_providers/psu/energy/ac/ipmi/machine/ipmi-get-machine-energy-stat.sh
@@ -17,7 +17,7 @@ done
 i=$(bc <<< "scale=3; $i / 1000")
 
 if $check_system; then
-    first_line=$(sudo /usr/sbin/ipmi-dcmi --get-system-power-statistics | head -1)
+    first_line=$(sudo /usr/sbin/ipmi-dcmi --get-system-power-statistics | sed -n 1p)
     if ! [[ "$first_line" =~ ^"Current Power" ]]; then
         echo "Unable to find 'Current Power' in the output of 'sudo /usr/sbin/ipmi-dcmi --get-system-power-statistics' command. Found $first_line instead">&2
         exit 1


### PR DESCRIPTION
A never before seen behaviour happened on one machine where the output of IPMI became so large that it apparently filled a buffer and the pipe was closed prematurely so a `head -1` failed with SIGPIPE (124).

Using sed fixes it. Inspired by Stackoverflow: https://unix.stackexchange.com/questions/736743/getting-first-line-of-piped-output-sets-exist-status-141-which-fails-bash-script