### PR TITLE
Checks for duplicate flow names

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -152,6 +152,11 @@ class SchemaChecker():
             if 'cmd' in service:
                 raise SchemaError(f"The 'cmd' key for service '{service_name}' is not supported anymore. Please migrate to 'command'")
 
+        # Ensure that flow names are unique
+        flow_names = [flow['name'] for flow in usage_scenario['flow']]
+        if len(flow_names) != len(set(flow_names)):
+            raise SchemaError("The 'name' field in 'flow' must be unique.")
+
         usage_scenario_schema.validate(usage_scenario)
 
 


### PR DESCRIPTION
Flow names need to be unique. This is something we check while executing the flow but it will fail quite late, once the second flow name is encountered. This adds a check when parsing the yml file