### PR TITLE
Carbondb unique

### DIFF
--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -365,7 +365,6 @@ CREATE TABLE carbondb_energy_data_day (
     co2_sum FLOAT,
     carbon_intensity_avg FLOAT,
     record_count INT,
-
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone
 );
@@ -378,10 +377,7 @@ CREATE TRIGGER carbondb_energy_data_day_moddatetime
 CREATE INDEX idx_carbondb_hour_company ON carbondb_energy_data_day(company);
 CREATE INDEX idx_carbondb_hour_machine ON carbondb_energy_data_day(machine);
 CREATE INDEX idx_carbondb_hour_project ON carbondb_energy_data_day(project);
-
-
-ALTER TABLE IF EXISTS public.carbondb_energy_data_day
-    ADD CONSTRAINT unique_machine_project_date UNIQUE (machine, date);
+CREATE UNIQUE INDEX unique_entry ON carbondb_energy_data_day (type, company, machine, project, tags, date) NULLS NOT DISTINCT;
 
 CREATE TABLE ip_data (
     ip_address INET,

--- a/migrations/2024_08_26_carbondb_unique.sql
+++ b/migrations/2024_08_26_carbondb_unique.sql
@@ -1,0 +1,3 @@
+ALTER TABLE carbondb_energy_data_day drop constraint unique_machine_project_date;
+TRUNCATE carbondb_energy_data_day;
+CREATE UNIQUE INDEX unique_entry ON carbondb_energy_data_day (type, company, machine, project, tags, date) NULLS NOT DISTINCT;

--- a/tools/carbondb_compress.py
+++ b/tools/carbondb_compress.py
@@ -41,7 +41,7 @@ def compress_data():
             e.project,
             e.tags,
             DATE_TRUNC('day', TO_TIMESTAMP(e.time_stamp / 1000000))
-        ON CONFLICT (machine, date) DO UPDATE
+        ON CONFLICT (type, company, machine, project, tags, date) DO UPDATE
         SET
             energy_sum = EXCLUDED.energy_sum,
             co2_sum = EXCLUDED.co2_sum,


### PR DESCRIPTION
The constraint for the uniqueness in CarbonDB was not looking at all relevant rows.

We had this already implemented on our live system but not backported it to the repository.

The implementation so far was however not respecting NULL values correctly. The new unique index now treats two NULL values as identical and will trigger now.

@ribalba Data volume is now down from 13 GB to 9 MB