### PR TITLE
Raising errors and applying caching

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1290,8 +1290,16 @@ async def post_ci_measurement_add(
             'tags': f"{measurement.label},{measurement.repo},{measurement.branch},{measurement.workflow}"
         }
 
-        # If there is an error the function will raise an Error
-        carbondb_add(client_ip, [energydata], user._id)
+        try:
+            carbondb_add(client_ip, [energydata], user._id)
+        #pylint: disable=broad-except
+        except Exception as exc:
+            error_helpers.log_error('CI Measurement was successfully added, but CarbonDB did failed', exception=exc)
+            return ORJSONResponse({
+                'success': False,
+                'err': f"CI Measurement was successfully added, but CarbonDB did respond with exception: {str(exc)}"},
+                status_code=207
+            )
 
     return ORJSONResponse({'success': True}, status_code=201)
 


### PR DESCRIPTION
@ribalba 

I am currently trying to investigate an error we are seeing with the API when adding CarbonDB entries alongside CI measurements.

```
File "/var/www/startup/venv/lib/python3.12/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/green-metrics-tool/api/main.py", line 1300, in post_ci_measurement_add
    carbondb_add(client_ip, [energydata], user._id)
  File "/var/www/green-metrics-tool/api/api_helpers.py", line 762, in carbondb_add
    co2_value = energy_kwh * carbon_intensity # results in g
                ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'


<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 0_o >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Error: Error in API call - catch_exceptions_middleware

Url (): http://api.green-coding.io/v1/ci/measurement/add
Query_params (): 
Client (): None
Headers (): MutableHeaders({'host': '[api.green-coding.io](http://api.green-coding.io/)', 'x-real-ip': '172.18.0.1', 'x-forwarded-for': '20.172.29.181, 172.18.0.1', 'x-forwarded-proto': 'http', 'connection': 'close', 'content-length': '954', 'accept-encoding': 'gzip, br', 'cf-ray': '8c372eaceb6d7d71-LAX', 'cf-visitor': '{"scheme":"https"}', 'user-agent': 'curl/7.81.0', 'accept': '*/*', 'content-type': 'application/json', 'cf-connecting-ip': '20.172.29.181', 'cdn-loop': 'cloudflare; loops=1', 'cf-ipcountry': 'US'})
Body (): b'{\n                "energy_value":"200379",\n                "energy_unit":"mJ",\n                "cpu":"EPYC_7763",\n                "commit_hash":"***REDACTED***",\n                "repo":"***REDACTED***",\n                "branch":"master",\n                "workflow":"***REDACTED***",\n                "run_id":"***REDACTED***",\n                "project_id":"",\n                "label":"argopy APIstatus",\n                "source":"github",\n                "cpu_util_avg":"16.2454",\n                "duration":"58",\n                "workflow_name":"api-status",\n                "cb_company_uuid":"***REDACTED***",\n                "cb_project_uuid":"***REDACTED***",\n                "cb_machine_uuid":"***REDACTED***",\n                "lat":"",\n                "lon":"",\n                "city":"",\n                "co2i":"",\n                "co2eq":""\n            }'
Exception (): unsupported operand type(s) for *: 'float' and 'NoneType'

<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 0_o >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
```

As seen the value for carbon_intensity is empty.

## What I did
- I applied more error handling
- I error now when `get_geo()` or `get_carbon_intensity()` fail. This was not in your code. Can you state why? What is the intention of proceeding with a None value?
- I think I spotted a bug:
  - You precompute some values here: https://github.com/green-coding-solutions/green-metrics-tool/blob/7a0d9ea531a8db5f13f23ce11d886e3f8222b684/api/api_helpers.py#L734
  - Then you overload the values in case they are in the POST body here: https://github.com/green-coding-solutions/green-metrics-tool/blob/7a0d9ea531a8db5f13f23ce11d886e3f8222b684/api/api_helpers.py#L757
  - However I believe different to your intention if some frame in the POST body does not have the IP key set it will not fallback to the pre-set carbon_intensity at the beginning of the function but rather use the value from the last frame in the POST data. This I believe is a bug. Can you confirm?
  - What I implemented is a LRU caching. Through `@cache` I call the functions in an else block and thus achieve that the API is not constantly polled again for identical submissions. The `@cache` should only be valid for the request and no longer.
- Furthermore I do not fail the whole `/v1/ci/measurement/add` call when CarbonDB fails, but rather return a HTTP 207. What do you think of this solution? 