### PR TITLE
Hog upload fix

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -678,8 +678,7 @@ async def hog_add(measurements: List[HogMeasurement]):
         try:
             _ = Measurement(**measurement_data)
         except (ValidationError, RequestValidationError) as exc:
-            print('Caught Exception in Measurement()', exc.__class__.__name__, exc)
-            print('Hog parsing error. Missing expected, but non critical key', str(exc))
+            error_helpers.log_error('Caught Exception in Measurement(), but not critical', exception_class=exc.__class__.__name__, exception=exc)
             # Output is extremely verbose. Please only turn on if debugging manually
             # print(f"Errors are: {exc.errors()}")
 

--- a/api/main.py
+++ b/api/main.py
@@ -678,7 +678,7 @@ async def hog_add(measurements: List[HogMeasurement]):
         try:
             _ = Measurement(**measurement_data)
         except (ValidationError, RequestValidationError) as exc:
-            if len(exc.errors()) != 1 or exc.errors()['loc'] != ('disk',):
+            if len(exc.errors()) != 1 or exc.errors()[0]['loc'] != ('disk',):
                 error_helpers.log_error('Caught Exception in Measurement(), but not critical', exception_class=exc.__class__.__name__, exception=exc)
             # Output is extremely verbose. Please only turn on if debugging manually
             # print(f"Errors are: {exc.errors()}")

--- a/api/main.py
+++ b/api/main.py
@@ -678,7 +678,8 @@ async def hog_add(measurements: List[HogMeasurement]):
         try:
             _ = Measurement(**measurement_data)
         except (ValidationError, RequestValidationError) as exc:
-            error_helpers.log_error('Caught Exception in Measurement(), but not critical', exception_class=exc.__class__.__name__, exception=exc)
+            if len(exc.errors()) != 1 or exc.errors()['loc'] != ('disk',):
+                error_helpers.log_error('Caught Exception in Measurement(), but not critical', exception_class=exc.__class__.__name__, exception=exc)
             # Output is extremely verbose. Please only turn on if debugging manually
             # print(f"Errors are: {exc.errors()}")
 

--- a/api/main.py
+++ b/api/main.py
@@ -122,6 +122,10 @@ app.add_middleware(
 async def home():
     return RedirectResponse(url='/docs')
 
+# It is unclear why currently this route is so often accessed. We block it for now
+@app.get('/v1/hog/add')
+async def hog_block():
+    pass
 
 # A route to return all of the available entries in our catalog.
 @app.get('/v1/notes/{run_id}')

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -23,6 +23,8 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
+    client_max_body_size 3M;
+
     keepalive_timeout  65;
 
     gzip on;


### PR DESCRIPTION
This is currently a draft PR to make the [PowerHog](https://github.com/green-coding-solutions/hog) data upload usable again.

It was deactivated as we were seeing regular errors.

It has now been deactivated with some learnings. More are to come in this PR.

## Learnings
- PowerHog is posting often frames larger than 1 MB
  - NGINX POST body size was increased to 3 MB. Not too large to block the server, but a bit of headroom
- For reasons unknown many requests where issued to `GET /v1/hog/add`. Since we monitor 404s this was clogging up our logs. I have deactivated the route for now ... but why is this happening?