### PR TITLE
pip timeouts and retries increased

### DIFF
--- a/docker/Dockerfile-gunicorn
+++ b/docker/Dockerfile-gunicorn
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /var/www/startup/
 COPY requirements.txt requirements.txt
 RUN python -m venv venv
-RUN venv/bin/pip install --upgrade pip
-RUN --mount=type=cache,target=/root/.cache/pip venv/bin/pip install -r requirements.txt
+RUN venv/bin/pip install --timeout 100 --retries 10 --upgrade pip
+RUN --mount=type=cache,target=/root/.cache/pip venv/bin/pip install --timeout 100 --retries 10 -r requirements.txt
 
 # This sets the include path for python, so we can use a module like include syntax in our files
 RUN find venv -type d -name "site-packages" -exec sh -c 'echo /var/www/green-metrics-tool > "$0/gmt-lib.pth"' {} \;

--- a/docker/auxiliary-containers/gcb_playwright/Dockerfile
+++ b/docker/auxiliary-containers/gcb_playwright/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/playwright/python:v1.46.0-jammy
 RUN apt-get update && apt-get install -y  curl  wget  gnupg  && rm -rf /var/lib/apt/lists/*
 
 # Install Playwright
-RUN pip install playwright
+RUN pip install --timeout 100 --retries 10 playwright
 
 # Set up Playwright dependencies for Chromium, Firefox and Webkit
 RUN playwright install

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -193,10 +193,10 @@ function setup_python() {
 
     if [[ $install_python_packages == true ]] ; then
         print_message "Updating python requirements"
-        python3 -m pip install --upgrade pip
-        python3 -m pip install -r requirements.txt
-        python3 -m pip install -r docker/requirements.txt
-        python3 -m pip install -r metric_providers/psu/energy/ac/xgboost/machine/model/requirements.txt
+        python3 -m pip install --timeout 100 --retries 10 --upgrade pip
+        python3 -m pip install --timeout 100 --retries 10 -r requirements.txt
+        python3 -m pip install --timeout 100 --retries 10 -r docker/requirements.txt
+        python3 -m pip install --timeout 100 --retries 10 -r metric_providers/psu/energy/ac/xgboost/machine/model/requirements.txt
     fi
 
 }


### PR DESCRIPTION
Probably a fix only for me but on my horrible Telekom peering I am seeing constant issues with python package downloads ala:

`pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.`

This PR tries to combat that without hopefully any downsided for anybody else