### PR TITLE
Fix: metric providers for IO where accumulating instead of echoing

### DIFF
--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -30,9 +30,8 @@ static unsigned int msleep_time=1000;
 
 static disk_io_t get_disk_cgroup(char* filename) {
     long long int rbytes = -1;
-    unsigned long long int rbytes_sum = 0;
     long long int wbytes = -1;
-    unsigned long long int wbytes_sum = 0;
+    disk_io_t disk_io = {0};
 
     FILE * fd = fopen(filename, "r");
     if ( fd == NULL) {
@@ -41,8 +40,8 @@ static disk_io_t get_disk_cgroup(char* filename) {
     }
 
     while (fscanf(fd, "%*u:%*u rbytes=%lld wbytes=%lld rios=%*u wios=%*u dbytes=%*u dios=%*u", &rbytes, &wbytes) == 2) {
-        rbytes_sum += rbytes;
-        wbytes_sum += wbytes;
+        disk_io.rbytes += rbytes;
+        disk_io.wbytes += wbytes;
     }
 
     fclose(fd);
@@ -52,9 +51,6 @@ static disk_io_t get_disk_cgroup(char* filename) {
         exit(1);
     }
 
-    disk_io_t disk_io;
-    disk_io.rbytes = rbytes_sum;
-    disk_io.wbytes = wbytes_sum;
     return disk_io;
 }
 

--- a/metric_providers/disk/io/procfs/system/source.c
+++ b/metric_providers/disk/io/procfs/system/source.c
@@ -50,9 +50,9 @@ static void output_get_disk_procfs() {
         }
 
         printf("%ld%06ld %llu %llu %s\n", now.tv_sec, now.tv_usec, sectors_read, sectors_written, device_name);
-        usleep(msleep_time*1000);
-
     }
+
+    usleep(msleep_time*1000); // after we have looked at all interfaces
 
     fclose(fd);
 }

--- a/metric_providers/disk/io/procfs/system/source.c
+++ b/metric_providers/disk/io/procfs/system/source.c
@@ -31,6 +31,8 @@ static void output_get_disk_procfs() {
         exit(1);
     }
 
+    gettimeofday(&now, NULL); // one call for get time of day for all interfaces is fine. The overhead would be more than the gain in granularity
+
     while (fgets(buf, 1024, fd)) {
         // We are not counting dropped packets, as we believe they will at least show up in the
         // sender side as not dropped.
@@ -47,7 +49,6 @@ static void output_get_disk_procfs() {
             continue; // we skip loop devices
         }
 
-        gettimeofday(&now, NULL);
         printf("%ld%06ld %llu %llu %s\n", now.tv_sec, now.tv_usec, sectors_read, sectors_written, device_name);
         usleep(msleep_time*1000);
 

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -54,7 +54,7 @@ static char *trimwhitespace(char *str) {
 static net_io_t get_network_cgroup(unsigned int pid) {
     char buf[200], ifname[20];
     unsigned long long int r_bytes, t_bytes, r_packets, t_packets;
-    net_io_t net_io;
+    net_io_t net_io = {0};
 
     char ns_path[PATH_MAX];
     snprintf(ns_path, PATH_MAX, "/proc/%u/ns/net", pid);


### PR DESCRIPTION
With the big refactor for 1.0 a bug was introduced that makes the IO provider for Network accumulate rathern than just echo the value.

The reason was a missing initalization of a struct.

For concisement also the disk-io provider is refactored although it did not have this bug.