### PR TITLE
Toggle for AVG in Timeline Charts

### DIFF
--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -11,18 +11,28 @@ var fetch_time_series = localStorage.getItem('fetch_time_series');
 if(fetch_time_series == 'true') fetch_time_series = true;
 else fetch_time_series = false;
 
-let toggleWatts = () => {
+var time_series_avg = localStorage.getItem('time_series_avg');
+if(time_series_avg == 'true') time_series_avg = true;
+else time_series_avg = false;
+
+
+const toggleWatts = () => {
     localStorage.setItem('display_in_watts', !display_in_watts);
     window.location.reload();
 }
 
-let toggleUnits = () => {
+const toggleUnits = () => {
     localStorage.setItem('display_in_metric_units', !display_in_metric_units);
     window.location.reload();
 }
 
-let toggleTimeSeries = () => {
+const toggleTimeSeries = () => {
     localStorage.setItem('fetch_time_series', !fetch_time_series);
+    window.location.reload();
+}
+
+const toggleTimeSeriesAVG = () => {
+    localStorage.setItem('time_series_avg', !time_series_avg);
     window.location.reload();
 }
 
@@ -40,6 +50,9 @@ let toggleTimeSeries = () => {
 
       if(fetch_time_series) $("#fetch-time-series-display").text("Currently fetching time series by default");
       else $("#fetch-time-series-display").text("Currently not fetching time series by default");
+
+      if(time_series_avg) $("#time-series-avg-display").text("Currently showing AVG time series");
+      else $("#time-series-avg-display").text("Currently not showing AVG in time series");
 
 
     });

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -223,6 +223,15 @@ const displayTimelineCharts = (metrics, notes) => {
     const chart_instances = [];
     const t0 = performance.now();
 
+    let time_series_avg = localStorage.getItem('time_series_avg');
+    let markline = {};
+    if(time_series_avg == 'true') {
+        markline = {
+                    precision: 4, // generally annoying that precision is by default 2. Wrong AVG if values are smaller than 0.001 and no autoscaling!
+                    data: [ {type: "average",label: {formatter: "AVG\n(selection):\n{c}"}}]
+        }
+    }
+
     for (const metric_name in metrics) {
 
         const element = createChartContainer("#chart-container", `${getPretty(metric_name, 'clean_name')} via ${getPretty(metric_name, 'source')} <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
@@ -239,10 +248,7 @@ const displayTimelineCharts = (metrics, notes) => {
                 symbol: 'none',
                 areaStyle: {},
                 data: metrics[metric_name].series[detail_name].data,
-                markLine: {
-                    precision: 4, // generally annoying that precision is by default 2. Wrong AVG if values are smaller than 0.001 and no autoscaling!
-                    data: [ {type: "average",label: {formatter: "AVG:\n{c}"}}]
-                }
+                markLine: markline,
             });
         }
         // now we add all notes to every chart

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -54,6 +54,11 @@
                           <td><span id="fetch-time-series-display"></span></td>
                           <td><button class="ui positive ui small button" onclick="toggleTimeSeries();">Toggle</button></td>
                         </tr>
+                        <tr>
+                          <td>Show AVG in time series<br><span><small><i class="question circle icon"></i>Note: AVG line is dynamic to current view of the chart<br> and counts ALL datapoints and not only the phase you are looking at</small></span></td>
+                          <td><span id="time-series-avg-display"></span></td>
+                          <td><button class="ui positive ui small button" onclick="toggleTimeSeriesAVG();">Toggle</button></td>
+                        </tr>
                       </tbody>
                     </table>
 


### PR DESCRIPTION
TImeline Charts have now a toggleable AVG in the settings.

Also it is now clearer that the AVG always shows the AVG of the selection and not of the phase currently looked at

<img width="479" alt="Screenshot 2024-10-08 at 10 15 50 AM" src="https://github.com/user-attachments/assets/f00712ef-ad63-4c5a-98dc-17b515fbf4e7">
