### PR TITLE
Quick Access for timeline added

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -264,7 +264,7 @@ async def get_repositories(uri: str | None = None, branch: str | None = None, ma
 async def get_runs(uri: str | None = None, branch: str | None = None, machine_id: int | None = None, machine: str | None = None, filename: str | None = None, limit: int | None = None, uri_mode = 'none'):
 
     query = """
-            SELECT r.id, r.name, r.uri, r.branch, r.created_at, r.invalid_run, r.filename, m.description, r.commit_hash, r.end_measurement, r.failed
+            SELECT r.id, r.name, r.uri, r.branch, r.created_at, r.invalid_run, r.filename, m.description, r.commit_hash, r.end_measurement, r.failed, r.machine_id
             FROM runs as r
             LEFT JOIN machines as m on r.machine_id = m.id
             WHERE 1=1

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -282,6 +282,10 @@ a,
     float: right;
 }
 
+.no-wrap {
+    white-space: nowrap;
+}
+
 /* PRINT STYLESHEETS */
 @media print {
   .print-page-break {

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -139,7 +139,7 @@ const getRunsTable = (el, url, include_uri=true, include_button=true, searching=
 
     columns.push({ data: 6, title: '<i class="icon file alternate"></i>Filename', });
     columns.push({ data: 7, title: '<i class="icon laptop code"></i>Machine</th>' });
-    columns.push({ data: 4, title: '<i class="icon calendar"></i>Last run</th>', render: (el) => el == null ? '-' : dateToYMD(new Date(el)) });
+    columns.push({ data: 4, title: '<i class="icon calendar"></i>Last run</th>', render: (el, type, row) => el == null ? '-' : `${dateToYMD(new Date(el))}<br><a href="/timeline.html?uri=${row[2]}&branch=${row[3]}&machine_id=${row[11]}&filename=${row[6]}&metrics=key" class="ui green horizontal label  no-wrap"><i class="ui icon clock"></i>History &nbsp;</a>` });
 
     const button_title = include_button ? '<button id="compare-button" onclick="compareButton()" class="ui small button blue right">Compare: 0 Run(s)</button>' : '';
 

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -139,7 +139,7 @@ const getRunsTable = (el, url, include_uri=true, include_button=true, searching=
 
     columns.push({ data: 6, title: '<i class="icon file alternate"></i>Filename', });
     columns.push({ data: 7, title: '<i class="icon laptop code"></i>Machine</th>' });
-    columns.push({ data: 4, title: '<i class="icon calendar"></i>Last run</th>', render: (el, type, row) => el == null ? '-' : `${dateToYMD(new Date(el))}<br><a href="/timeline.html?uri=${row[2]}&branch=${row[3]}&machine_id=${row[11]}&filename=${row[6]}&metrics=key" class="ui green horizontal label  no-wrap"><i class="ui icon clock"></i>History &nbsp;</a>` });
+    columns.push({ data: 4, title: '<i class="icon calendar"></i>Last run</th>', render: (el, type, row) => el == null ? '-' : `${dateToYMD(new Date(el))}<br><a href="/timeline.html?uri=${row[2]}&branch=${row[3]}&machine_id=${row[11]}&filename=${row[6]}&metrics=key" class="ui teal horizontal label  no-wrap"><i class="ui icon clock"></i>History &nbsp;</a>` });
 
     const button_title = include_button ? '<button id="compare-button" onclick="compareButton()" class="ui small button blue right">Compare: 0 Run(s)</button>' : '';
 


### PR DESCRIPTION
Timeline can now be quickly access from the Home or Repositories view even without knowing the URL or having a project listed in "Timeline View"
<img width="772" alt="Screenshot 2024-10-11 at 9 28 57 AM" src="https://github.com/user-attachments/assets/f31d6777-4c68-45fe-9ce1-c4f9b57731e7">
