### PR TITLE
Making Workload Validation also accept absolute values

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -44,13 +44,32 @@ cluster:
       filename: "usage_scenario.yml"
       branch: "event-bound"
       comparison_window: 5
-      threshold: 0.01
       phase: "004_[RUNTIME]"
       metrics:
-        - "psu_energy_ac_mcp_machine"
-        - "psu_power_ac_mcp_machine"
-        - "cpu_power_rapl_msr_component"
-        - "cpu_energy_rapl_msr_component"
+        psu_energy_ac_mcp_machine:
+          threshold: 0.01 # 1%
+          type: stddev_rel
+        psu_power_ac_mcp_machine:
+          threshold: 0.01 # 1%
+          type: stddev_rel
+        cpu_power_rapl_msr_component:
+          threshold: 0.01 # 1%
+          type: stddev_rel
+        cpu_energy_rapl_msr_component:
+          threshold: 0.01 # 1%
+          type: stddev_rel
+        cpu_energy_rapl_msr_component:
+          threshold: 0.01 # 1%
+          type: stddev_rel
+        psu_co2_ac_mcp_machine:
+          threshold: 0.01 # 1%
+          type: stddev_rel
+        network_total_cgroup_container:
+          threshold: 10000 # 10 kB
+          type: stddev
+        phase_time_syscall_system:
+          threshold: 0.01 # 1%
+          type: stddev_rel
 
 machine:
   id: 1

--- a/cron/client.py
+++ b/cron/client.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
                 print('get_workload_stddev returned: ', stddev_data)
 
                 try:
-                    message = validate.validate_workload_stddev(stddev_data, cwl['threshold'])
+                    message = validate.validate_workload_stddev(stddev_data, cwl['metrics'])
                     if client_main['send_control_workload_status_mail'] and config_main['admin']['notification_email']:
                         Job.insert(
                             'email',


### PR DESCRIPTION
This PR enhanches the Workload Validation when the GMT is run in cluster mode.

Previous only the relative STDDEV could be checked.

This was problematic as workloads that have close to zero network traffic and then by chance have because of network issues 2-3 more TCP packets will directly incur + 100% network traffic.

By using absolute values this can now be better controlled. 

Furthermore one can also make relative AND absolute values ... although this makes no sense for the network case in particular.

## Secondly

Also I added more providers to the recommended to check when operating such a cluster. Network and phase time have been added