### PR TITLE
Gitignore improvements

### DIFF
--- a/.devcontainer/codespace-setup.sh
+++ b/.devcontainer/codespace-setup.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-# we have to rename this makefile as it doesn't compile in Codespaces
-if [ -f /workspaces/green-metrics-tool/metric_providers/lm_sensors/Makefile ]; then
-    mv /workspaces/green-metrics-tool/metric_providers/lm_sensors/Makefile /workspaces/green-metrics-tool/metric_providers/lm_sensors/Makefile.bak
-    git update-index --assume-unchanged /workspaces/green-metrics-tool/metric_providers/lm_sensors/Makefile
-fi
-
 /workspaces/green-metrics-tool/install_linux.sh -p testpw -a "https://${CODESPACE_NAME}-9142.app.github.dev" -m "https://${CODESPACE_NAME}-9143.app.github.dev" -t -i -s -l
 source venv/bin/activate
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ static-binary
 /venv/
 /docker/test-compose.yml
 /tests/structure.sql
+tools/sgx_enable

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ static-binary
 /lib/hardware_info_root.py
 /tools/cluster/cleanup.sh
 /node_modules/
-/lib/c/parse_int.o
+/lib/c/*.o
 /tools/backup
 /manager-config.yml
 /venv/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ static-binary
 /tools/backup
 /manager-config.yml
 /venv/
-Makefile.bak
 /docker/test-compose.yml
 /tests/structure.sql


### PR DESCRIPTION
Some minor improvements on how some files are ignored by Git:

- Ignore `sgx_enable` in tools directory (is a copy of the submodule that gets created during install)
- Ignore all output files in `lib/c` (`/detect_cgroup_path.o` was not ignored)
- Because the exclusion of the lmsensors build happens now in `install_shared.py` if the argument `install_sensors` is set to false, the old workaround in `codespace-setup.sh` is not relevant anymore → ignore of `Makefile.bak` is not relevant anymore