### PR TITLE
Allowing Deeplinks to specific phases [skip ci]

### DIFF
--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -298,5 +298,19 @@ const displayComparisonMetrics = (phase_stats_object) => {
     // marks the first runtime step and is shown by default
     document.querySelector('a.step[data-tab="[RUNTIME]"').dispatchEvent(new Event('click'));
 
+    // now we override if given
+    let phase_to_display = window.location.hash.split('#')[1];
+    if (phase_to_display != null) {
+        const allowed_phases = ['BASELINE', 'INSTALLATION', 'BOOT', 'IDLE', 'RUNTIME', 'REMOVE'];
+        phase_to_display = phase_to_display.split('__');
+        if (allowed_phases.includes(phase_to_display[0])) {
+            document.querySelector(`a.step[data-tab="[${phase_to_display[0]}]"`).dispatchEvent(new Event('click'));
+        }
+        const sub_phase_regex = /^[\.\s0-9a-zA-Z_\(\)-]+$/; // Matches strings containing only letters and digits
+        if (phase_to_display[1] != null && sub_phase_regex.test(phase_to_display[1])) {
+            document.querySelector(`a.runtime-step[data-tab="${phase_to_display[1]}"`).dispatchEvent(new Event('click'));
+        }
+    }
+
     window.dispatchEvent(new Event('resize'));
 }


### PR DESCRIPTION
This adds a deeplink functionality to GMT in case you want to open a specific phase in the "stats" or "compare" view.

Example: https://metrics.green-coding.io/stats.html?id=1ec10430-a789-44c9-8f7e-c394fc708b25
=> This would always open the *Runtime* phase tab

- https://metrics.green-coding.io/stats.html?id=1ec10430-a789-44c9-8f7e-c394fc708b25#BASELINE
=> This would open the *Baseline* phase tab

- https://metrics.green-coding.io/stats.html?id=1ec10430-a789-44c9-8f7e-c394fc708b25#RUNTIME__Stress
=> This would open the *Runtime* phase tab with the *Stress* sub-phase