### PR TITLE
Clickable Comparsion Charts + Display Missing Values

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -250,7 +250,7 @@ def get_comparison_details(ids, comparison_db_key):
     ''').format(sql.Identifier(comparison_db_key))
 
     data = DB().fetch_all(query, (ids, ))
-    if data is None or data == [] or data[1] is None: # special check for data[1] as this is aggregate query which always returns result
+    if data is None or data == []:
         raise RuntimeError('Could not get comparison details')
 
     comparison_details = OrderedDict()

--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -4,6 +4,7 @@ faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to st
 
 from urllib.parse import urlparse
 
+from collections import OrderedDict
 from functools import cache
 from html import escape as html_escape
 import typing
@@ -17,6 +18,7 @@ import numpy as np
 import scipy.stats
 from pydantic import BaseModel
 
+from psycopg import sql
 
 from lib.global_config import GlobalConfig
 from lib.db import DB
@@ -237,6 +239,43 @@ def get_timeline_query(uri, filename, machine_id, branch, metrics, phase, start_
 
     return (query, params)
 
+def get_comparison_details(ids, comparison_db_key):
+
+    query = sql.SQL('''
+        SELECT
+            id, name, created_at, commit_hash, commit_timestamp, gmt_hash, {}
+        FROM runs
+        WHERE id = ANY(%s::uuid[])
+        ORDER BY created_at  -- Must be same order as in get_phase_stats
+    ''').format(sql.Identifier(comparison_db_key))
+
+    data = DB().fetch_all(query, (ids, ))
+    if data is None or data == [] or data[1] is None: # special check for data[1] as this is aggregate query which always returns result
+        raise RuntimeError('Could not get comparison details')
+
+    comparison_details = OrderedDict()
+
+    for row in data:
+        comparison_key = row[6]
+        run_id = str(row[0]) # UUID must be converted
+        if comparison_key not in comparison_details:
+            comparison_details[comparison_key] = OrderedDict()
+        comparison_details[comparison_key][run_id] = {
+            'run_id': run_id,
+            'name': row[1],
+            'created_at': row[2],
+            'commit_hash': row[3],
+            'commit_timestamp': row[4],
+            'gmt_hash': row[5],
+        }
+
+    # to back-fill None values later we need to index every element
+    for item in comparison_details.values():
+        for index, inner_item in enumerate(item.values()):
+            inner_item['index'] = index
+
+    return comparison_details
+
 def determine_comparison_case(ids):
 
     query = '''
@@ -271,7 +310,7 @@ def determine_comparison_case(ids):
     # case = 'Repeated Run' # Case A: Blue Angel
     # case = 'Multi-Commit' # Case D: Evolution of repo over time
 
-
+    #pylint: disable=no-else-raise,no-else-return
     if repos == 2: # diff repos
         if usage_scenarios <= 2: # diff repo, diff usage scenarios. diff usage scenarios are NORMAL for now
             if machine_ids == 2: # diff repo, diff usage scenarios, diff machine_ids
@@ -281,7 +320,7 @@ def determine_comparison_case(ids):
                     if commit_hashes <= 2: # diff repo, diff usage scenarios, same machine_ids,  same branches, diff/same commits_hashes
                         # for two repos we expect two different hashes, so this is actually a normal case
                         # even if they are identical we do not care, as the repos are different anyway
-                        case = 'Repository' # Case D
+                        return ('Repository', 'uri') # Case D
                     else:
                         raise RuntimeError('Different repos & more than 2 different commits commits not supported')
                 else:
@@ -296,7 +335,7 @@ def determine_comparison_case(ids):
                 raise RuntimeError('Different usage scenarios & machines not supported')
             if branches <= 1:
                 if commit_hashes == 1: # same repo, diff usage scenarios, same machines, same branches, same commit hashes
-                    case = 'Usage Scenario' # Case C_2
+                    return ('Usage Scenario', 'filename') # Case C_2
                 else: # same repo, diff usage scenarios, same machines, same branches, diff commit hashes
                     raise RuntimeError('Different usage scenarios & commits not supported')
             else: # same repo, diff usage scenarios, same machines, diff branches
@@ -305,7 +344,7 @@ def determine_comparison_case(ids):
             if machine_ids == 2: # same repo, same usage scenarios, diff machines
                 if branches <= 1:
                     if commit_hashes == 1: # same repo, same usage scenarios, diff machines, same branches, same commit hashes
-                        case = 'Machine' # Case C_1
+                        return ('Machine', 'machine_id') # Case C_1
                     else: # same repo, same usage scenarios, diff machines, same branches, diff commit hashes
                         raise RuntimeError('Different machines & commits not supported')
                 else: # same repo, same usage scenarios, diff machines, diff branches
@@ -314,15 +353,15 @@ def determine_comparison_case(ids):
             elif machine_ids == 1: # same repo, same usage scenarios, same machines
                 if branches <= 1:
                     if commit_hashes == 2: # same repo, same usage scenarios, same machines, diff commit hashes
-                        case = 'Commit' # Case B
+                        return ('Commit', 'commit_hash') # Case B
                     elif commit_hashes > 2: # same repo, same usage scenarios, same machines, many commit hashes
                         raise RuntimeError('Multiple commits comparison not supported. Please switch to Timeline view')
                     else: # same repo, same usage scenarios, same machines, same branches, same commit hashes
-                        case = 'Repeated Run' # Case A
+                        return ('Repeated Run', 'commit_hash') # Case A
                 else: # same repo, same usage scenarios, same machines, diff branch
                     # diff branches will have diff commits in most cases. so we allow 2, but no more
                     if commit_hashes <= 2:
-                        case = 'Branch' # Case C_3
+                        return ('Branch', 'branch') # Case C_3
                     else:
                         raise RuntimeError('Different branches and more than 2 commits not supported')
             else:
@@ -335,13 +374,14 @@ def determine_comparison_case(ids):
         # multiple t-tests / ANOVA etc. and hard to grasp, only a focus on one metric shall be provided.
         raise RuntimeError('Less than 1 or more than 2 repos not supported for overview. Please apply metric filter.')
 
-    return case
+    raise RuntimeError('Could not determine comparison case after checking all conditions')
 
 def get_phase_stats(ids):
     query = """
             SELECT
                 a.phase, a.metric, a.detail_name, a.value, a.type, a.max_value, a.min_value, a.unit,
-                b.uri, c.description, b.filename, b.commit_hash, b.branch
+                b.uri, c.description, b.filename, b.commit_hash, b.branch,
+                b.id
             FROM phase_stats as a
             LEFT JOIN runs as b on b.id = a.run_id
             LEFT JOIN machines as c on c.id = b.machine_id
@@ -349,20 +389,13 @@ def get_phase_stats(ids):
             WHERE
                 a.run_id = ANY(%s::uuid[])
             ORDER BY
-                a.phase ASC,
-                a.metric ASC,
-                a.detail_name ASC,
-                b.uri ASC,
-                b.machine_id ASC,
-                b.filename ASC,
-                b.commit_hash ASC,
-                branch ASC,
-                b.created_at ASC
+                b.created_at ASC -- Must be same order as in get_comparison_details
             """
     return DB().fetch_all(query, (ids, ))
 
 # Would be interesting to know if in an application server like gunicor @cache
 # Will also work for subsequent requests ...?
+# Update: It does, but only for the same worker. We are caching this request anyway now in Redis
 '''  Object structure
     comparison_case: str
     statistics: dict
@@ -448,19 +481,27 @@ def get_phase_stats(ids):
                                 values: list // the actual values
             ...
 '''
-def get_phase_stats_object(phase_stats, case):
+def get_phase_stats_object(phase_stats, case=None, comparison_details=None, comparison_identifiers=None):
 
     phase_stats_object = {
         'comparison_case': case,
-        'comparison_details': set(),
-        'data': {}
+        'comparison_details': comparison_details,
+        'comparison_identifiers': comparison_identifiers,
+        'data': OrderedDict()
     }
+
+    if comparison_details: # override with parsed data
+        phase_stats_object['comparison_details'] = transform_dict_to_list_two_level(comparison_details) # list, becase better parseable in echarts and lower overhead in JSON
+        phase_stats_object['comparison_identifiers'] = list(comparison_details.keys())
 
     for phase_stat in phase_stats:
         [
             phase, metric_name, detail_name, value, metric_type, max_value, min_value, unit,
-            repo, machine_description, filename, commit_hash, branch
-        ] = phase_stat # unpack
+            repo, machine_description, filename, commit_hash, branch,
+            run_id
+        ] = phase_stat
+
+        run_id = str(run_id)
 
         phase = phase.split('_', maxsplit=1)[1] # remove the 001_ prepended stuff again, which is only for ordering
 
@@ -472,12 +513,12 @@ def get_phase_stats_object(phase_stats, case):
             key = filename # Case C_2 : SoftwareDeveloper Case
         elif case == 'Machine':
             key = machine_description # Case C_1 : DataCenter Case
-        elif commit_hash:
-            key = commit_hash # No comparison case / Case A: Blue Angel / Case B: DevOps Case
+        elif case in ('Commit', 'Repeated Run'):
+            key = commit_hash # Repeated Run
         else:
-            key = 'not-set'
+            key = run_id # No comparison case - Single view
 
-        if phase not in phase_stats_object['data']: phase_stats_object['data'][phase] = {}
+        if phase not in phase_stats_object['data']: phase_stats_object['data'][phase] = OrderedDict()
 
         if metric_name not in phase_stats_object['data'][phase]:
             phase_stats_object['data'][phase][metric_name] = {
@@ -488,7 +529,7 @@ def get_phase_stats_object(phase_stats, case):
                 #'ci': None,  # currently no use for that
                 #'p_value': None,  # currently no use for that
                 #'is_significant': None,  # currently no use for that
-                'data': {},
+                'data': OrderedDict(),
             }
         elif phase_stats_object['data'][phase][metric_name]['unit'] != unit:
             raise RuntimeError(f"Metric cannot be compared as units have changed: {unit} vs. {phase_stats_object['data'][phase][metric_name]['unit']}")
@@ -504,7 +545,7 @@ def get_phase_stats_object(phase_stats, case):
                 # 'ci': None, # since we only compare two keys atm this  could no be calculated.
                 'p_value': None, # comparing the means of two machines, branches etc. Both cases must have multiple values for this to get populated
                 'is_significant': None, # comparing the means of two machines, branches etc. Both cases must have multiple values for this to get populated
-                'data': {},
+                'data': OrderedDict(),
             }
 
         detail_data = phase_stats_object['data'][phase][metric_name]['data'][detail_name]['data']
@@ -519,20 +560,27 @@ def get_phase_stats_object(phase_stats, case):
                 'ci': None,
                 'p_value': None, # only for the last key the list compare to the rest. one-sided t-test
                 'is_significant': None, # only for the last key the list compare to the rest. one-sided t-test
-                'values': [],
+                'values': [value],
             }
-            phase_stats_object['comparison_details'].add(key)
+            if comparison_details:
+                detail_data[key]['values'] = [None for _ in comparison_details[key]] # create None filled list in comparision casese so that we can later understand which values are missing when parsing in JS for example
 
-        detail_data[key]['values'].append(value)
+        # we replace None where we can with actual values
+        if comparison_details:
+            detail_data[key]['values'][comparison_details[key][run_id]['index']] = value
 
         # since we do not save the min/max values we need to to the comparison here in every loop again
         # all other statistics are derived later in add_phase_stats_statistics()
         detail_data[key]['max'] = max((x for x in [max_value, detail_data[key]['max']] if x is not None), default=None)
         detail_data[key]['min'] = min((x for x in [min_value, detail_data[key]['min']] if x is not None), default=None)
 
-    phase_stats_object['comparison_details'] = list(phase_stats_object['comparison_details'])
-
     return phase_stats_object
+
+def transform_dict_to_list_two_level(my_dict):
+    my_list = [[] for _ in range(len(my_dict))]
+    for index, item in enumerate(my_dict.values()):
+        my_list[index] = list(item.values())
+    return list(my_list)
 
 
 '''
@@ -549,17 +597,19 @@ def add_phase_stats_statistics(phase_stats_object):
 
                     # if a detail has multiple values we calculate a std.dev and the one-sided t-test for the last value
 
-                    key_obj['mean'] = key_obj['values'][0] # default. might be overridden
-                    key_obj['max_mean'] = key_obj['values'][0] # default. might be overridden
-                    key_obj['min_mean'] = key_obj['values'][0] # default. might be overridden
+                    values_none_filtered = [item for item in key_obj['values'] if item is not None]
+                    key_obj['mean'] = values_none_filtered[0] # default. might be overridden
+                    key_obj['max_mean'] = values_none_filtered[0] # default. might be overridden
+                    key_obj['min_mean'] = values_none_filtered[0] # default. might be overridden
 
-                    if len(key_obj['values']) > 1:
-                        t_stat = get_t_stat(len(key_obj['values']))
+                    if len(values_none_filtered) > 1:
+
+                        t_stat = get_t_stat(len(values_none_filtered))
 
                         # JSON does not recognize the numpy data types. Sometimes int64 is returned
-                        key_obj['mean'] = np.mean(key_obj['values']).item()
+                        key_obj['mean'] = np.mean(values_none_filtered).item()
 
-                        key_obj['stddev'] = np.std(key_obj['values'], correction=1).item()
+                        key_obj['stddev'] = np.std(values_none_filtered, correction=1).item()
                         # We are using now the STDDEV of the sample for two reasons:
                         # It is required by the Blue Angel for Software
                         # We got many debates that in cases where the average is only estimated through measurements and is not absolute
@@ -567,12 +617,12 @@ def add_phase_stats_statistics(phase_stats_object):
                         # Still one could argue that one does not want to characterize the measured software but rather the measurement setup
                         # it is safer to use the sample STDDEV as it is always higher
 
-                        key_obj['max_mean'] = np.max(key_obj['values']).item() # overwrite with max of list
-                        key_obj['min_mean'] = np.min(key_obj['values']).item() # overwrite with min of list
+                        key_obj['max_mean'] = np.max(values_none_filtered).item() # overwrite with max of list
+                        key_obj['min_mean'] = np.min(values_none_filtered).item() # overwrite with min of list
                         key_obj['ci'] = (key_obj['stddev']*t_stat).item()
 
-                        if len(key_obj['values']) > 2:
-                            data_c = key_obj['values'].copy()
+                        if len(values_none_filtered) > 2:
+                            data_c = values_none_filtered.copy()
                             pop_mean = data_c.pop()
                             _, p_value = scipy.stats.ttest_1samp(data_c, pop_mean)
                             if not np.isnan(p_value):
@@ -584,11 +634,11 @@ def add_phase_stats_statistics(phase_stats_object):
 
 
     ## builds stats between the keys
-    if len(phase_stats_object['comparison_details']) == 2:
+    if len(phase_stats_object['comparison_identifiers']) == 2:
         # since we currently allow only two comparisons we hardcode this here
-        # this is then needed to rebuild if we would allow more
-        key1 = phase_stats_object['comparison_details'][0]
-        key2 = phase_stats_object['comparison_details'][1]
+        # this is then needed to rebuild if we would allow more !IMPROVEMENT
+        key1 = phase_stats_object['comparison_identifiers'][0]
+        key2 = phase_stats_object['comparison_identifiers'][1]
 
         # we need to traverse only one branch of the tree like structure, as we only need to compare matching metrics
         for _, phase_data in phase_stats_object['data'].items():
@@ -598,7 +648,10 @@ def add_phase_stats_statistics(phase_stats_object):
                         continue
 
                     # Welch-Test because we cannot assume equal variances
-                    _, p_value = scipy.stats.ttest_ind(detail['data'][key1]['values'], detail['data'][key2]['values'], equal_var=False)
+                    values_none_filtered_1 = [item for item in detail['data'][key1]['values'] if item is not None]
+                    values_none_filtered_2 = [item for item in detail['data'][key2]['values'] if item is not None]
+
+                    _, p_value = scipy.stats.ttest_ind(values_none_filtered_1, values_none_filtered_2, equal_var=False)
 
                     if not np.isnan(p_value):
                         detail['p_value'] = p_value.item()

--- a/api_test.py
+++ b/api_test.py
@@ -14,9 +14,10 @@ if __name__ == '__main__':
 
     ids = args.ids.split(',')
 
-    case = api_helpers.determine_comparison_case(ids)
+    case, comparison_db_key = api_helpers.determine_comparison_case(ids)
+    comparison_details = api_helpers.get_comparison_details(ids, comparison_db_key)
     phase_stats = api_helpers.get_phase_stats(ids)
-    phase_stats_object = api_helpers.get_phase_stats_object(phase_stats, case)
+    phase_stats_object = api_helpers.get_phase_stats_object(phase_stats, case, comparison_details)
     phase_stats_object = api_helpers.add_phase_stats_statistics(phase_stats_object)
 
     print(json.dumps(phase_stats_object, indent=4))

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -311,3 +311,7 @@ a,
     page-break-before: always;
   }
 }
+
+
+/* Allow clickable boxes for chart overlays */
+.statistics-chart div { pointer-events: all !important }

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -1,13 +1,3 @@
-const numberFormatter = new Intl.NumberFormat('en-US', {
-  style: 'decimal',
-  maximumFractionDigits: 2,
-});
-
-const numberFormatterLong = new Intl.NumberFormat('en-US', {
-  style: 'decimal',
-  maximumFractionDigits: 4,
-});
-
 const calculateStats = (energy_measurements, carbon_ug_measurements, carbon_intensity_g_measurements, duration_us_measurements, cpu_util_measurements) => {
 
     let energy_avg = energy_stddev = energy_stddev_rel = energy_sum = '--'

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -4,6 +4,7 @@ const getURLParams = () => {
     return url_params;
 }
 
+
 async function fetchDiff() {
     document.querySelector('#diff-question').remove();
     document.querySelector('#loader-diff').style.display = '';
@@ -47,18 +48,18 @@ $(document).ready( (e) => {
             params.forEach( id => {
                 api_url = `${api_url}${id}`
             });
-            var phase_stats_data = (await makeAPICall(api_url)).data
+            window.phase_stats_data = (await makeAPICall(api_url)).data
         } catch (err) {
             showNotification('Could not get compare in-repo data from API', err);
         }
 
         if (phase_stats_data == undefined) return;
 
-        let comparison_details = phase_stats_data.comparison_details.map((el) => replaceRepoIcon(el));
-        comparison_details = comparison_details.join(' vs. ')
+        let comparison_identifiers = phase_stats_data.comparison_identifiers.map((el) => replaceRepoIcon(el));
+        comparison_identifiers = comparison_identifiers.join(' vs. ')
         document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Comparison Type</strong></td><td>${phase_stats_data.comparison_case}</td></tr>`)
         document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Number of runs compared</strong></td><td>${run_count}</td></tr>`)
-        document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${comparison_details}</td></tr>`)
+        document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${comparison_identifiers}</td></tr>`)
         Object.keys(phase_stats_data['common_info']).forEach(function(key) {
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${key}</strong></td><td>${phase_stats_data['common_info'][key]}</td></tr>`)
           });
@@ -70,7 +71,14 @@ $(document).ready( (e) => {
 
         document.querySelector('#fetch-diff').addEventListener('click', fetchDiff);
 
-        displayComparisonMetrics(phase_stats_data)
+        buildPhaseTabs(phase_stats_data)
+        renderCompareChartsForPhase(phase_stats_data, getAndShowPhase(), run_count);
+        displayTotalChart(...buildTotalChartData(phase_stats_data));
+
+        document.querySelectorAll('.ui.steps.phases .step, .runtime-step').forEach(node => node.addEventListener('click', el => {
+            const phase = el.currentTarget.getAttribute('data-tab');
+            renderCompareChartsForPhase(phase_stats_data, phase, run_count);
+        }));
 
     })();
 });

--- a/frontend/js/helpers/charts.js
+++ b/frontend/js/helpers/charts.js
@@ -20,6 +20,7 @@ const getCompareChartOptions = (legend, series, chart_type='line', x_axis='time'
         tooltip: {
             triggerOn: 'click',
             formatter: function (params, ticket, callback) {
+                if(params.componentType != 'series') return; // no overlay for markLine and markArea etc.
                 if (select_diff_buffer.length > 0) {
                     window.open(`/compare.html?ids=${select_diff_buffer[0]},${comparison_details[params.seriesIndex][params.dataIndex].run_id}`, '_blank');
                     select_diff_buffer = [] // reset

--- a/frontend/js/helpers/charts.js
+++ b/frontend/js/helpers/charts.js
@@ -95,9 +95,9 @@ const getCompareChartOptions = (legend, series, chart_type='line', x_axis='time'
             mark_point.data.push({ name: 'Missing', coord: [0, 0], value: 'Missing Data', label: { show: true } })
         } else { // single runs have missing metrics. Happens if run ended prematurely in earlier phase or did not run at all
             data = series[index]
-            for (el_index in series[index]) {
-                if (series[index][el_index] == null) {
-                    mark_point.data.push({ name: 'Missing', coord: [el_index, 0], value: 'Missing Data', label: { show: true } })
+            for (let i = 0; i < series[index].length; i++) {
+                if (series[index][i] == null) {
+                    mark_point.data.push({ name: 'Missing', coord: [i, 0], value: 'Missing Data', label: { show: true } })
                 }
             }
         }
@@ -553,11 +553,11 @@ const displayTotalChart = (legend, labels, data) => {
 
     const series = [];
 
-    for (const key in data) {
+    for (let key in data) {
         const mark_point_data = []
-        for (el_index in data[key]) {
-            if (data[key][el_index] == null) {
-                mark_point_data.push({ name: 'Missing', coord: [parseInt(el_index), 0], value: 'Missing Data', label: { show: true } })
+        for (let i = 0; i < data[key].length; i++) {
+            if (data[key][i] == null) {
+                mark_point_data.push({ name: 'Missing', coord: [i, 0], value: 'Missing Data', label: { show: true } })
             }
         }
         series.push({

--- a/frontend/js/helpers/charts.js
+++ b/frontend/js/helpers/charts.js
@@ -1,4 +1,11 @@
-const getCompareChartOptions = (legend, series, chart_type='line', x_axis='time', y_axis_name, mark_area=null,  graphic=null) => {
+let select_diff_buffer = [];
+
+const addToDiffSelection = (node) => {
+    select_diff_buffer.push(node.getAttribute('data-run-id'));
+    return false;
+}
+
+const getCompareChartOptions = (legend, series, chart_type='line', x_axis='time', y_axis_name, mark_area=null,  graphic=null, comparison_details=null, comparison_identifiers=null) => {
     let tooltip_trigger = (chart_type=='line') ? 'axis' : 'item';
 
     let series_count = series.length;
@@ -10,15 +17,35 @@ const getCompareChartOptions = (legend, series, chart_type='line', x_axis='time'
     max = Math.round(max*1.2)
 
     let options =  {
-        tooltip: {trigger: tooltip_trigger},
-            xAxis: [],
-            yAxis: [],
-            areaStyle: {},
-            grid: [],
-            series: [],
-            animation: false,
-            graphic: graphic,
-            legend: [],
+        tooltip: {
+            triggerOn: 'click',
+            formatter: function (params, ticket, callback) {
+                if (select_diff_buffer.length > 0) {
+                    window.open(`/compare.html?ids=${select_diff_buffer[0]},${comparison_details[params.seriesIndex][params.dataIndex].run_id}`, '_blank');
+                    select_diff_buffer = [] // reset
+                    return false;
+                }
+
+                return `<strong>${comparison_details[params.seriesIndex][params.dataIndex].name}</strong><br>
+                        run_id: <a href="/stats.html?id=${comparison_details[params.seriesIndex][params.dataIndex].run_id}"  target="_blank">${comparison_details[params.seriesIndex][params.dataIndex].run_id}</a><br>
+                        date: ${comparison_details[params.seriesIndex][params.dataIndex].created_at}<br>
+                        value: ${numberFormatter.format(params.value)}<br>
+                        commit_timestamp: ${comparison_details[params.seriesIndex][params.dataIndex].commit_timestamp}<br>
+                        commit_hash: <a href="${$("#uri").text()}/commit/${comparison_details[params.seriesIndex][params.dataIndex].commit_hash}" target="_blank">${comparison_details[params.seriesIndex][params.dataIndex].commit_hash}</a><br>
+                        gmt_hash: <a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${comparison_details[params.seriesIndex][params.dataIndex].gmt_hash}" target="_blank">${comparison_details[params.seriesIndex][params.dataIndex].gmt_hash}</a><br>
+                        <br>
+                        👉 <a href="" class="select-diff-run" onClick="return addToDiffSelection(this);" data-run-id="${comparison_details[params.seriesIndex][params.dataIndex].run_id}" target="_blank">Diff with ... (?)</a>
+                        `;
+            },
+        },
+        xAxis: [],
+        yAxis: [],
+        areaStyle: {},
+        grid: [],
+        series: [],
+        animation: false,
+        graphic: graphic,
+        legend: [],
     }
 
     series.forEach((item, index) => {
@@ -58,17 +85,36 @@ const getCompareChartOptions = (legend, series, chart_type='line', x_axis='time'
               type: 'scroll',
             }
         );
+        let mark_point = {
+          data: []
+        };
+
+        let data = [null] // default. Used as indicator for missing data
+
+        if (series[index] == null) { // whole series to compare is missing. Happens if different metrics where captured
+            mark_point.data.push({ name: 'Missing', coord: [0, 0], value: 'Missing Data', label: { show: true } })
+        } else { // single runs have missing metrics. Happens if run ended prematurely in earlier phase or did not run at all
+            data = series[index]
+            for (el_index in series[index]) {
+                if (series[index][el_index] == null) {
+                    mark_point.data.push({ name: 'Missing', coord: [el_index, 0], value: 'Missing Data', label: { show: true } })
+                }
+            }
+        }
+
+
         options.series.push(
             {
                 type: chart_type,
-                data: series[index],
+                data: data,
                 xAxisIndex: index,
                 yAxisIndex:index,
                 markLine: {
                     precision: 4, // generally annoying that precision is by default 2. Wrong AVG if values are smaller than 0.001 and no autoscaling!
                     data: [ {type: "average",label: {formatter: "Mean:\n{c}"}}]
-                }
-            }
+                },
+                markPoint: mark_point,
+            },
         );
         if (mark_area != null) {
             options['series'][index]['markArea'] = {
@@ -500,26 +546,34 @@ const displayKeyMetricsEmbodiedCarbonChart = (phase) => {
 }
 
 const displayTotalChart = (legend, labels, data) => {
-
-    let chartDom = document.querySelector(`#total-phases-data .bar-chart .statistics-chart`);
+    const chartDom = document.querySelector(`#total-phases-data .bar-chart .statistics-chart`);
     document.querySelector(`#total-phases-data .bar-chart .chart-title`).innerText = TOTAL_CHART_BOTTOM_TITLE;
 
-    let myChart = echarts.init(chartDom);
+    const myChart = echarts.init(chartDom);
 
-    let series = [];
+    const series = [];
+
     for (const key in data) {
+        const mark_point_data = []
+        for (el_index in data[key]) {
+            if (data[key][el_index] == null) {
+                mark_point_data.push({ name: 'Missing', coord: [parseInt(el_index), 0], value: 'Missing Data', label: { show: true } })
+            }
+        }
         series.push({
               name: key,
               type: 'bar',
               emphasis: {
                 focus: 'series'
               },
-              data: data[key]
+              data: data[key],
+              markPoint: {data: mark_point_data}
         })
     }
 
 
-    let options = getLineBarChartOptions(null, labels, series, null, TOTAL_CHART_UNIT, 'category', null, true)
+    const options = getLineBarChartOptions(null, labels, series, null, TOTAL_CHART_UNIT, 'category', null, true)
+
     myChart.setOption(options);
         // set callback when ever the user changes the viewport
     // we need to use jQuery here and not Vanilla JS to not overwrite but add multiple resize callbacks
@@ -531,11 +585,10 @@ const displayTotalChart = (legend, labels, data) => {
 }
 
 
-const displayCompareChart = (phase, title, y_axis_name, legend, data, mark_area, graphic) => {
-
+const displayCompareChart = (phase, title, y_axis_name, legend, data, mark_area=null, graphic=null, comparison_details=null, comparison_identifiers=null) => {
     const element = createChartContainer(`.ui.tab[data-tab='${phase}'] .compare-chart-container`, title);
     const myChart = echarts.init(element);
-    let options = getCompareChartOptions(legend, data, 'bar', 'category', y_axis_name, mark_area);
+    let options = getCompareChartOptions(legend, data, 'bar', 'category', y_axis_name, mark_area, graphic, comparison_details, comparison_identifiers);
     myChart.setOption(options);
     // set callback when ever the user changes the viewport
     // we need to use jQuery here and not Vanilla JS to not overwrite but add multiple resize callbacks
@@ -544,4 +597,3 @@ const displayCompareChart = (phase, title, y_axis_name, legend, data, mark_area,
     });
 
 }
-

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -269,6 +269,18 @@ async function sortName() {
     await getRepositories('name');
 }
 
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  style: 'decimal', // You can also use 'currency', 'percent', or 'unit'
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const numberFormatterLong = new Intl.NumberFormat('en-US', {
+  style: 'decimal',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+});
+
 $(document).ready(function () {
     $(document).on('click','#menu-toggle.closed', openMenu);
     $(document).on('click','#menu-toggle.opened', closeMenu);

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -112,7 +112,7 @@ const createPhaseTab = (phase) => {
 
 const buildPhaseTabs = (phase_stats_object) => {
 
-    for (phase in phase_stats_object['data']) {
+    for (const phase in phase_stats_object['data']) {
         createPhaseTab(phase); // will not create already existing phase tabs
         createTableHeader(
             phase,

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -58,7 +58,7 @@ const getAndShowPhase = () => {
     } else {
         // although there are multiple .step.runtime-step containers the first one
         // marks the first runtime step and is shown by default
-        document.querySelector('a.step[data-tab="[RUNTIME]"').dispatchEvent(new Event('click'));
+        document.querySelector('a.step[data-tab="[RUNTIME]"]').dispatchEvent(new Event('click'));
     }
 
     return shown_phase;

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -65,7 +65,8 @@ const getAndShowPhase = () => {
 }
 
 const showWarning = (phase, warning) => {
-    if (phase == '[RUNTIME]' ) phase == '[[RUNTIME]]';
+    if (phase == '[RUNTIME]' ) phase = '[[RUNTIME]]'; // map to "All Flows" phase
+
     document.querySelector(`div.tab[data-tab='${phase}'] .ui.warning.message`).classList.remove('hidden');
     const newListItem = document.createElement("li");
     newListItem.textContent = warning;

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -219,7 +219,7 @@ const renderCompareChartsForPhase = (phase_stats_object, phase='[RUNTIME]', run_
             let compare_chart_data = []
             let compare_chart_mark = []
             let compare_chart_labels = []
-            let metric_box_data = [...Array(phase_stats_object.comparison_identifiers.length)].map(e => {{}})
+            let metric_box_data = Array(phase_stats_object.comparison_identifiers.length).fill().map(() => ({}))
 
             // we loop over all keys that exist, not over the one that are present in detail_data['data']
             phase_stats_object.comparison_identifiers.forEach((key,key_index) => {

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -201,9 +201,16 @@ const renderCompareChartsForPhase = (phase_stats_object, phase='[RUNTIME]', run_
             /* END BLOCK LABELS*/
 
             if (
-                (phase_stats_object.comparison_identifiers.length == 2 && detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values?.length != detail_data['data'][phase_stats_object.comparison_identifiers[1]]?.values?.length)
+                (phase_stats_object.comparison_identifiers.length == 2
+                    && (
+                        detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values == null
+                        || detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values?.includes(null)
+                        || detail_data['data'][phase_stats_object.comparison_identifiers[1]]?.values == null
+                        || detail_data['data'][phase_stats_object.comparison_identifiers[1]].values.includes(null)
+                    )
+                )
                 ||
-                (phase_stats_object.comparison_identifiers.length == 1 && detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values?.length != run_count)
+                (phase_stats_object.comparison_identifiers.length == 1 && detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values?.includes(null))
             ) {
                 showWarning(phase, `${metric_name} ${detail_name} was missing from at least one comparison.`)
             }

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -41,6 +41,29 @@ const createTableHeader = (phase, comparison_keys, comparison_case, comparison_a
     }
 }
 
+const getAndShowPhase = () => {
+    let shown_phase = '[RUNTIME]'; // default
+    let phase_to_display = decodeURIComponent(window.location.hash).split('#')[1];
+    if (phase_to_display != null) {
+        const allowed_phases = ['BASELINE', 'INSTALLATION', 'BOOT', 'IDLE', 'RUNTIME', 'REMOVE'];
+        phase_to_display = phase_to_display.split('__');
+        if (allowed_phases.includes(phase_to_display[0])) {
+            document.querySelector(`a.step[data-tab="[${phase_to_display[0]}]"`).dispatchEvent(new Event('click'));
+            shown_phase = phase_to_display[0];
+        }
+        const sub_phase_regex = /^[\.\s0-9a-zA-Z_\(\)-]+$/; // Matches strings containing only letters and digits
+        if (phase_to_display[1] != null && sub_phase_regex.test(phase_to_display[1])) {
+            document.querySelector(`a.runtime-step[data-tab="${phase_to_display[1]}"`).dispatchEvent(new Event('click'));
+        }
+    } else {
+        // although there are multiple .step.runtime-step containers the first one
+        // marks the first runtime step and is shown by default
+        document.querySelector('a.step[data-tab="[RUNTIME]"').dispatchEvent(new Event('click'));
+    }
+
+    return shown_phase;
+}
+
 const showWarning = (phase, warning) => {
     if (phase == '[RUNTIME]' ) phase == '[[RUNTIME]]';
     document.querySelector(`div.tab[data-tab='${phase}'] .ui.warning.message`).classList.remove('hidden');
@@ -85,199 +108,25 @@ const createPhaseTab = (phase) => {
     }
 }
 
-/*
-    We traverse the multi-dimensional metrics object only once and fill data
-    in the appropriate variables for metric-boxes and charts
-*/
-const displayComparisonMetrics = (phase_stats_object) => {
-    // we now traverse all branches of the tree
-    // the tree is sparese, so although we see all metrics that are throughout all phases and comparison_keys
-    // not every branch has a leaf with the metric for the corresponding comparsion_key ... it might be missing
-    // we must fill this value than with a NaN in the charts
 
-    // if we have a comparison case between the two we just display the difference between them
-    // if we have a repetition case we display the STDDEV
-    // otherwise we just display the value
+const buildPhaseTabs = (phase_stats_object) => {
 
-    // unsure atm what to do in a Diff scenario ... filling with 0 can be misleading
-
-    let total_chart_bottom_data =  {};
-    let total_chart_bottom_legend =  {};
-    let total_chart_bottom_labels = [];
-
-    for (const phase in phase_stats_object['data']) {
+    for (phase in phase_stats_object['data']) {
         createPhaseTab(phase); // will not create already existing phase tabs
         createTableHeader(
             phase,
-            phase_stats_object.comparison_details,
+            phase_stats_object.comparison_identifiers,
             phase_stats_object.comparison_case,
-            phase_stats_object.comparison_details.length
+            phase_stats_object.comparison_identifiers.length
         )
+    }
 
-        let phase_data = phase_stats_object['data'][phase];
-
-        let radar_chart_labels = [];
-        let radar_chart_data = [...Array(phase_stats_object.comparison_details.length)].map(e => Array(0));
-
-        let top_bar_chart_labels = [];
-        let top_bar_chart_data =  [[],[]];
-        total_chart_bottom_labels.push(phase);
-        total_chart_bottom_legend[phase]  = [];
-
-        let co2_calculated = false;
-
-        // the following variables are needed for filling missing values in charts and the machine energy
-        // we need to keep track if in the coming loop a matching metric was found or mitigate the missing value
-        let found_bottom_chart_metric = false;
-        const bottom_chart_present_keys = Object.fromEntries(phase_stats_object.comparison_details.map(e => [e, false]))
-
-        for (const metric_name in phase_data) {
-            let metric_data = phase_data[metric_name]
-            let found_radar_chart_item = false;
-
-            for (const detail_name in metric_data['data']) {
-                let detail_data = metric_data['data'][detail_name]
-
-                /*
-                    BLOCK LABELS
-                    This block must be done outside of the key loop and cannot use a Set() datastructure
-                    as we can have the same metric multiple times just with different detail names
-                */
-                if(radar_chart_condition(metric_name) && phase_stats_object.comparison_details.length >= 2) {
-                    radar_chart_labels.push(getPretty(metric_name, 'clean_name'));
-                }
-
-                if (top_bar_chart_condition(metric_name)) {
-                    top_bar_chart_labels.push(`${getPretty(metric_name, 'clean_name')} (${getPretty(metric_name, 'source')})`);
-                }
-
-                if (total_chart_bottom_condition(metric_name)) {
-                    if(found_bottom_chart_metric) {
-                        showWarning(phase, `Another metric for the bottom chart was already set (${found_bottom_chart_metric}), skipping ${metric_name} and only first one will be shown.`);
-                    } else {
-                        total_chart_bottom_legend[phase].push(getPretty(metric_name, 'clean_name'));
-                        found_bottom_chart_metric = `${metric_name} ${detail_name}`;
-                    }
-                }
-                /* END BLOCK LABELS*/
-
-                if (Object.keys(detail_data['data']).length != phase_stats_object.comparison_details.length) {
-                    showWarning(phase, `${metric_name} ${detail_name} was missing from at least one comparison.`);
-                }
-
-                let compare_chart_data = []
-                let compare_chart_mark = []
-                let compare_chart_labels = []
-                let metric_box_data = [...Array(phase_stats_object.comparison_details.length)].map(e => {{}})
-
-                // we loop over all keys that exist, not over the one that are present in detail_data['data']
-                phase_stats_object.comparison_details.forEach((key,key_index) => {
-                    if(radar_chart_condition(metric_name) && phase_stats_object.comparison_details.length >= 2) {
-                        radar_chart_data[key_index].push(detail_data['data'][key]?.mean)
-                    }
-
-                    if (top_bar_chart_condition(metric_name)) {
-                        top_bar_chart_data[key_index].push(detail_data['data'][key]?.mean)
-                    }
-                    if (total_chart_bottom_condition(metric_name) && `${metric_name} ${detail_name}` == found_bottom_chart_metric) {
-                        if(total_chart_bottom_data?.[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] == null) {
-                            total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] = []
-                        }
-                        total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`].push(detail_data['data'][key]?.mean)
-                        bottom_chart_present_keys[key] = true
-                    }
-
-                    if (phase_stats_object.comparison_case == null && psu_machine_carbon_metric_condition(metric_name)) {
-                        if(co2_calculated) {
-                            showWarning(phase, 'CO2 was already calculated! Do you have multiple machine energy reporters set?');
-                        }
-                        // mean will always be present, as we only have one key and thus we need no ?.
-                        calculateCO2(phase, detail_data['data'][key].mean);
-                        co2_calculated = true;
-                    }
-
-                    metric_box_data[key_index] = detail_data['data'][key]?.mean
-                    compare_chart_data.push(detail_data['data'][key]?.values)
-                    compare_chart_labels.push(`${phase_stats_object.comparison_case}: ${key}`)
-                    compare_chart_mark.push({
-                        name:'Confidence Interval',
-                        bottom: detail_data['data'][key]?.mean-detail_data['data'][key]?.ci,
-                        top: detail_data['data'][key]?.mean+detail_data['data'][key]?.ci
-                    })
-                }) // end key
-
-                if (phase_stats_object.comparison_details.length == 1) {
-                    // Note: key is still the set variable from the for loop earlier
-                    displaySimpleMetricBox(phase, metric_name, metric_data, detail_name, detail_data['data'][phase_stats_object.comparison_details[0]], phase_stats_object.comparison_case);
-                } else {
-                    displayDiffMetricBox(
-                        phase, metric_name, metric_data, detail_name, metric_box_data,
-                        detail_data.is_significant
-                    );
-                }
-                if(phase_stats_object.comparison_case !== null) { // compare charts will display for everything apart stats.html
-                    displayCompareChart(
-                        phase,
-                        `${getPretty(metric_name, 'clean_name')} via ${getPretty(metric_name, 'source')} - ${detail_name} <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`,
-                        metric_data.unit,
-                        compare_chart_labels,
-                        compare_chart_data,
-                        compare_chart_mark,
-                    );
-                }
-            } // end detail
-        } // end metric
-
-        // a phase had no bottom chart metric and must be null-filled
-        // this can for instance happen if a phase is too short and no metric was reported in the timespan
-        for (const key in bottom_chart_present_keys) {
-            if(bottom_chart_present_keys[key] == false) {
-                if(total_chart_bottom_data?.[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] == null) {
-                    total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] = []
-                }
-                total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`].push(NaN)
-            }
-        }
-
-        let radar_legend = phase_stats_object.comparison_details.map(e => `${phase_stats_object.comparison_case}: ${e}`)
-
-        if(phase_stats_object.comparison_details.length >= 2) {
-            displayKeyMetricsRadarChart(
-                radar_legend,
-                radar_chart_labels,
-                radar_chart_data,
-                phase
-            );
-        } else if(phase_stats_object.comparison_case != null) {
-            // stats.html does not even have it. so only remove for Repeated Run etc.
-            removeKeyMetricsRadarChart(phase)
-        }
-
-        displayKeyMetricsBarChart(
-            radar_legend,
-            top_bar_chart_labels,
-            top_bar_chart_data,
-            phase
-        )
-
-        // displayKeyMetricsEmbodiedCarbonChart(phase);
-
-    } // phase end
-
-    displayTotalChart(
-        total_chart_bottom_legend,
-        total_chart_bottom_labels,
-        total_chart_bottom_data
-    )
-
-    /*
-        Display all boxes and charts
-    */
     $('.ui.steps.phases .step').tab({
         onLoad: function(value, text) {
             window.dispatchEvent(new Event('resize'));
         }
     }); // activate tabs for runtime sub-phases
+
 
     $('#runtime-sub-phases.menu .item').tab({
         onLoad: function(value, text) {
@@ -292,25 +141,217 @@ const displayComparisonMetrics = (phase_stats_object) => {
         }
     });
 
-    $('table').tablesort();
+}
 
-    // although there are multiple .step.runtime-step containers the first one
-    // marks the first runtime step and is shown by default
-    document.querySelector('a.step[data-tab="[RUNTIME]"').dispatchEvent(new Event('click'));
+/*
+    We traverse the multi-dimensional metrics object only once and fill data
+    in the appropriate variables for metric-boxes and charts
 
-    // now we override if given
-    let phase_to_display = decodeURIComponent(window.location.hash).split('#')[1];
-    if (phase_to_display != null) {
-        const allowed_phases = ['BASELINE', 'INSTALLATION', 'BOOT', 'IDLE', 'RUNTIME', 'REMOVE'];
-        phase_to_display = phase_to_display.split('__');
-        if (allowed_phases.includes(phase_to_display[0])) {
-            document.querySelector(`a.step[data-tab="[${phase_to_display[0]}]"`).dispatchEvent(new Event('click'));
-        }
-        const sub_phase_regex = /^[\.\s0-9a-zA-Z_\(\)-]+$/; // Matches strings containing only letters and digits
-        if (phase_to_display[1] != null && sub_phase_regex.test(phase_to_display[1])) {
-            document.querySelector(`a.runtime-step[data-tab="${phase_to_display[1]}"`).dispatchEvent(new Event('click'));
-        }
+    render* means that build* and display* functions are mixed
+*/
+const renderCompareChartsForPhase = (phase_stats_object, phase='[RUNTIME]', run_count=1) => {
+
+    // we now traverse all branches of the tree
+    // the tree is sparese, so although we see all metrics that are throughout all phases and comparison_keys
+    // not every branch has a leaf with the metric for the corresponding comparsion_key ... it might be missing
+    // we must fill this value than with a NaN in the charts
+
+    // if we have a comparison case between the two we just display the difference between them
+    // if we have a repetition case we display the STDDEV
+    // otherwise we just display the value
+
+    // unsure atm what to do in a Diff scenario ... filling with 0 can be misleading
+
+    if (window.__rendered_phases == null) {
+        window.__rendered_phases = {};
+    } else if (window.__rendered_phases[phase] != null) return; // we have already rendered this phase!
+
+    window.__rendered_phases[phase] = true;
+
+    let phase_data = phase_stats_object['data'][phase];
+
+    let radar_chart_labels = [];
+    let radar_chart_data = [...Array(phase_stats_object.comparison_identifiers.length)].map(e => Array(0));
+
+    let top_bar_chart_labels = [];
+    let top_bar_chart_data =  [[],[]];
+
+    let co2_calculated = false;
+
+    for (const metric_name in phase_data) {
+        let metric_data = phase_data[metric_name]
+        let found_radar_chart_item = false;
+
+        for (const detail_name in metric_data['data']) {
+            let detail_data = metric_data['data'][detail_name]
+
+            /*
+                BLOCK LABELS
+                This block must be done outside of the key loop and cannot use a Set() datastructure
+                as we can have the same metric multiple times just with different detail names
+            */
+            if(radar_chart_condition(metric_name) && phase_stats_object.comparison_identifiers.length >= 2) {
+                radar_chart_labels.push(getPretty(metric_name, 'clean_name'));
+            }
+
+            if (top_bar_chart_condition(metric_name)) {
+                top_bar_chart_labels.push(`${getPretty(metric_name, 'clean_name')} (${getPretty(metric_name, 'source')})`);
+            }
+
+            /* END BLOCK LABELS*/
+
+            if (
+                (phase_stats_object.comparison_identifiers.length == 2 && detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values?.length != detail_data['data'][phase_stats_object.comparison_identifiers[1]]?.values?.length)
+                ||
+                (phase_stats_object.comparison_identifiers.length == 1 && detail_data['data'][phase_stats_object.comparison_identifiers[0]]?.values?.length != run_count)
+            ) {
+                showWarning(phase, `${metric_name} ${detail_name} was missing from at least one comparison.`)
+            }
+
+            let compare_chart_data = []
+            let compare_chart_mark = []
+            let compare_chart_labels = []
+            let metric_box_data = [...Array(phase_stats_object.comparison_identifiers.length)].map(e => {{}})
+
+            // we loop over all keys that exist, not over the one that are present in detail_data['data']
+            phase_stats_object.comparison_identifiers.forEach((key,key_index) => {
+                if(radar_chart_condition(metric_name) && phase_stats_object.comparison_identifiers.length >= 2) {
+                    radar_chart_data[key_index].push(detail_data['data'][key]?.mean)
+                }
+
+                if (top_bar_chart_condition(metric_name)) {
+                    top_bar_chart_data[key_index].push(detail_data['data'][key]?.mean)
+                }
+
+                if (phase_stats_object.comparison_case == null && psu_machine_carbon_metric_condition(metric_name)) {
+                    if(co2_calculated) {
+                        showWarning(phase, 'CO2 was already calculated! Do you have multiple machine energy reporters set?');
+                    }
+                    // mean will always be present, as we only have one key and thus we need no ?.
+                    calculateCO2(phase, detail_data['data'][key].mean);
+                    co2_calculated = true;
+                }
+
+                metric_box_data[key_index] = detail_data['data'][key]?.mean
+                compare_chart_data.push(detail_data['data'][key]?.values)
+                compare_chart_labels.push(`${phase_stats_object.comparison_case}: ${key}`)
+                compare_chart_mark.push({
+                    name:'Confidence Interval',
+                    bottom: detail_data['data'][key]?.mean-detail_data['data'][key]?.ci,
+                    top: detail_data['data'][key]?.mean+detail_data['data'][key]?.ci
+                })
+            }) // end key
+
+            if (phase_stats_object.comparison_identifiers.length == 1) {
+                // Note: key is still the set variable from the for loop earlier
+                displaySimpleMetricBox(phase, metric_name, metric_data, detail_name, detail_data['data'][phase_stats_object.comparison_identifiers[0]], phase_stats_object.comparison_case);
+            } else {
+                displayDiffMetricBox(
+                    phase, metric_name, metric_data, detail_name, metric_box_data,
+                    detail_data.is_significant
+                );
+            }
+            if(phase_stats_object.comparison_case != null) { // compare charts will display for everything apart stats.html
+                displayCompareChart(
+                    phase,
+                    `${getPretty(metric_name, 'clean_name')} via ${getPretty(metric_name, 'source')} - ${detail_name} <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`,
+                    metric_data.unit,
+                    compare_chart_labels,
+                    compare_chart_data,
+                    compare_chart_mark,
+                    null, // graphic
+                    phase_stats_object.comparison_details,
+                    phase_stats_object.comparison_identifiers,
+                );
+            }
+        } // end detail
+    } // end metric
+
+    let radar_legend = phase_stats_object.comparison_identifiers.map(e => `${phase_stats_object.comparison_case}: ${e}`)
+
+    if(phase_stats_object.comparison_identifiers.length >= 2) {
+        displayKeyMetricsRadarChart(
+            radar_legend,
+            radar_chart_labels,
+            radar_chart_data,
+            phase
+        );
+    } else if(phase_stats_object.comparison_case != null) {
+        // stats.html does not even have it. so only remove for Repeated Run etc.
+        removeKeyMetricsRadarChart(phase)
     }
 
+    displayKeyMetricsBarChart(
+        radar_legend,
+        top_bar_chart_labels,
+        top_bar_chart_data,
+        phase
+    )
+
+    // displayKeyMetricsEmbodiedCarbonChart(phase);
+
+    $(`div.tab[data-tab='${phase}'] .compare-metrics-table.sortable`).tablesort();
+
     window.dispatchEvent(new Event('resize'));
+}
+
+const buildTotalChartData = (phase_stats_object) => {
+
+    let total_chart_bottom_data =  {};
+    let total_chart_bottom_legend =  {};
+    let total_chart_bottom_labels = [];
+
+    for (const phase in phase_stats_object['data']) {
+        let phase_data = phase_stats_object['data'][phase];
+
+        total_chart_bottom_labels.push(phase);
+        total_chart_bottom_legend[phase]  = [];
+
+        // the following variables are needed for filling missing values in charts and the machine energy
+        // we need to keep track if in the coming loop a matching metric was found or mitigate the missing value
+        let found_bottom_chart_metric = false;
+        const bottom_chart_present_keys = Object.fromEntries(phase_stats_object.comparison_identifiers.map(e => [e, false]))
+
+        for (const metric_name in phase_data) {
+            let metric_data = phase_data[metric_name]
+
+            for (const detail_name in metric_data['data']) {
+                let detail_data = metric_data['data'][detail_name]
+
+                if (total_chart_bottom_condition(metric_name)) {
+                    if(found_bottom_chart_metric) {
+                        showWarning(phase, `Another metric for the bottom chart was already set (${found_bottom_chart_metric}), skipping ${metric_name} and only first one will be shown.`);
+                    } else {
+                        total_chart_bottom_legend[phase].push(getPretty(metric_name, 'clean_name'));
+                        found_bottom_chart_metric = `${metric_name} ${detail_name}`;
+                    }
+                }
+                // we loop over all keys that exist, not over the one that are present in detail_data['data']
+                phase_stats_object.comparison_identifiers.forEach((key,key_index) => {
+
+                    if (total_chart_bottom_condition(metric_name) && `${metric_name} ${detail_name}` == found_bottom_chart_metric) {
+                        if(total_chart_bottom_data?.[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] == null) {
+                            total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] = []
+                        }
+                        total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`].push(detail_data['data'][key]?.mean)
+                        bottom_chart_present_keys[key] = true
+                    }
+                })
+            } // end metric_data['data']
+        } // end phase_data
+
+        // a phase can have no bottom chart metric and must be null-filled
+        // this can for instance happen if a phase is too short and no metric was reported in the timespan
+        for (const key in bottom_chart_present_keys) {
+            if(bottom_chart_present_keys[key] == false) {
+                if(total_chart_bottom_data?.[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] == null) {
+                    total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`] = []
+                }
+                total_chart_bottom_data[`${TOTAL_CHART_BOTTOM_LABEL} - ${key}`].push(null)
+            }
+        }
+
+    } // end phase_stats_object['data']
+
+    return [total_chart_bottom_legend, total_chart_bottom_labels, total_chart_bottom_data];
 }

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -12,13 +12,6 @@ window.onresize = function() { // set callback when ever the user changes the vi
     })
 }
 
-
-const numberFormatter = new Intl.NumberFormat('en-US', {
-  style: 'decimal', // You can also use 'currency', 'percent', or 'unit'
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
 function* colorIterator() {
     colors = [
         '#88a788',

--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -34,10 +34,6 @@
     <script src="/js/timeline.js" defer></script>
     <link rel="stylesheet" type="text/css" class="ui" href="/dist/css/semantic_reduced.min.css">
     <link rel="stylesheet" type="text/css" href="/css/green-coding.css">
-    <style type="text/css">
-        .hide-for-single-stats { display: none !important; }
-        .statistics-chart div { pointer-events: all !important }
-    </style>
 </head>
 <body class="preload">
     <gmt-menu></gmt-menu>


### PR DESCRIPTION
This PR:
- Introduces new QoL feature to see in comparsion view which bar belongs to which run (See Screenshot)
- Refactors how phase display works. Before ALL phases and charts where rendered. In practice however in 90% of the cases only the *[RUNTIME]* phase is really looked at. Which means GMT is doing 90% waste compute for every frontend display. In larger runs this can take up to 10 seconds to render. This now renders phases on demand only


<img width="1088" alt="Screenshot 2024-12-15 at 2 02 33 AM" src="https://github.com/user-attachments/assets/53083c5a-eead-44b2-9d04-5e01785497d1" />
