### PR TITLE
Noise reduced run start

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -169,6 +169,9 @@ class Runner:
         Path(path).mkdir(parents=True, exist_ok=True)
 
     def save_notes_runner(self):
+        if not self._run_id:
+            return # Nothing to do, but also no hard error needed
+
         print(TerminalColors.HEADER, '\nSaving notes: ', TerminalColors.ENDC, self.__notes_helper.get_notes())
         self.__notes_helper.save_to_db(self._run_id)
 
@@ -1370,6 +1373,9 @@ class Runner:
         self.__notes_helper.add_note({'note': 'End of measurement', 'detail_name': '[NOTES]', 'timestamp': self.__end_measurement})
 
     def update_start_and_end_times(self):
+        if not self._run_id:
+            return # Nothing to do, but also no hard error needed
+
         print(TerminalColors.HEADER, '\nUpdating start and end measurement times', TerminalColors.ENDC)
         DB().query("""
             UPDATE runs
@@ -1391,6 +1397,9 @@ class Runner:
 
 
     def store_phases(self):
+        if not self._run_id:
+            return # Nothing to do, but also no hard error needed
+
         print(TerminalColors.HEADER, '\nUpdating phases in DB', TerminalColors.ENDC)
         # internally PostgreSQL stores JSON ordered. This means our name-indexed dict will get
         # re-ordered. Therefore we change the structure and make it a list now.
@@ -1437,6 +1446,9 @@ class Runner:
                 self.add_to_log(container_id, f"stderr: {log.stderr}")
 
     def save_stdout_logs(self):
+        if not self._run_id:
+            return # Nothing to do, but also no hard error needed
+
         print(TerminalColors.HEADER, '\nSaving logs to DB', TerminalColors.ENDC)
         logs_as_str = '\n\n'.join([f"{k}:{v}" for k,v in self.__stdout_logs.items()])
         logs_as_str = logs_as_str.replace('\x00','')
@@ -1643,7 +1655,7 @@ class Runner:
                                 raise exc
                             finally:
                                 try:
-                                    if self._dev_no_phase_stats is False:
+                                    if self._run_id and self._dev_no_phase_stats is False:
                                         # After every run, even if it failed, we want to generate phase stats.
                                         # They will not show the accurate data, but they are still neded to understand how
                                         # much a failed run has accrued in total energy and carbon costs

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -79,8 +79,8 @@ class RunUntilManager:
             self.__runner.check_system('start')
             self.__runner.initialize_folder(self.__runner._tmp_folder)
             self.__runner.checkout_repository()
-            self.__runner.initialize_run()
             self.__runner.initial_parse()
+            self.__runner.register_machine_id()
             self.__runner.import_metric_providers()
             if step == 'import_metric_providers':
                 return
@@ -89,8 +89,7 @@ class RunUntilManager:
             self.__runner.check_running_containers()
             self.__runner.remove_docker_images()
             self.__runner.download_dependencies()
-            self.__runner.register_machine_id()
-            self.__runner.update_and_insert_specs()
+            self.__runner.initialize_run()
 
             self.__runner.start_metric_providers(allow_other=True, allow_container=False)
             self.__runner.custom_sleep(config['measurement']['pre-test-sleep'])


### PR DESCRIPTION
In some occurences a machine_id = NULL entry could happen if the runner failed with an unexpected git repo.

This PR reworks this functionality by only saving to the DB once the init checks are all done and the machine verified.

Also adding more short circuits to remove noise when run_id not set

<!-- greptile_comment -->

## Greptile Summary

Reordered database operations in the runner to prevent NULL machine_id entries and reduce log noise by validating machine configuration before creating database entries.

- Moved `register_machine_id()` before `import_metric_providers()` to validate machine configuration early
- Relocated `initialize_run()` to execute after all initialization checks are complete
- Added short-circuit returns for DB operations when `run_id` is not set
- Consolidated `update_and_insert_specs()` functionality into `initialize_run()`
- Reordered operations in `run()` method to ensure proper machine validation sequence



<!-- /greptile_comment -->