### PR TITLE
Removing href for non actual links [skip ci]

### DIFF
--- a/frontend/authentication.html
+++ b/frontend/authentication.html
@@ -27,7 +27,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             Authentication
         </h1>
         <div class="ui full-width-card segment card">

--- a/frontend/ci-index.html
+++ b/frontend/ci-index.html
@@ -31,7 +31,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             CI Projects
         </h1>
 <!--

--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -32,10 +32,10 @@
 <body class="preload">
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
-        <h1 class="ui header float left"><a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> CI Run Info</h1>
+        <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> CI Run Info</h1>
         <div class="ui full-width-card card">
             <div class="content">
-                <div class="header"><a class="ui red ribbon label" href="#">
+                <div class="header"><a class="ui red ribbon label">
                     <h3>General Info</h3>
                 </a></div>
                 <div class="description">
@@ -45,7 +45,7 @@
                                 <td><strong>Last Run Badge:</strong></td>
                                 <td>
                                     <span class="energy-badge-container" data-metric="ml-estimated"></span>
-                                    <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                                    <a class="copy-badge"><i class="copy icon"></i></a>
                                 </td>
                             </tr>
                         </table>
@@ -93,7 +93,7 @@
 
         </div>
         <div class = "ui segment" id="stats-container">
-            <div class="header"><a class="ui teal ribbon label" href="#">
+            <div class="header"><a class="ui teal ribbon label">
                     <h3>Pipeline stats</h3>
                 </a></div>
                 <br/>
@@ -133,7 +133,7 @@
             </div>
         </div>
         <div class="ui segment" id="runs-table">
-            <div class="header"><a class="ui teal ribbon label" href="#">
+            <div class="header"><a class="ui teal ribbon label">
                     <h3 data-tooltip="The runs table shows all measurements your pipeline has made in the selected timeframe" data-position="top left">Runs Table <i class="question circle icon "></i> </h3>
                 </a></div>
             <table class="ui sortable celled striped table">

--- a/frontend/compare.html
+++ b/frontend/compare.html
@@ -36,11 +36,11 @@
 <body class="preload">
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
-        <h1 class="ui header float left"><a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Comparison of runs in repo</h1>
+        <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Comparison of runs in repo</h1>
         <div class="ui full-width-card card">
             <div class="content">
                 <div class="header">
-                    <a class="ui red ribbon label" href="#">
+                    <a class="ui red ribbon label">
                         <h3>Run Data</h3>
                     </a>
                 </div>
@@ -117,7 +117,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -142,7 +142,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -168,7 +168,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -194,7 +194,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -230,7 +230,7 @@
                 </div>
                 <div class="ui segment secondary">
                     <div class="content">
-                        <div class="header"><a class="ui blue ribbon label" href="#">
+                        <div class="header"><a class="ui blue ribbon label">
                             <h3>Single Phase Data</h3>
                         </a></div>
                     </div>
@@ -257,7 +257,7 @@
                 </div>
                 <div class="ui segment secondary">
                     <div class="content">
-                        <div class="header"><a class="ui blue ribbon label" href="#">
+                        <div class="header"><a class="ui blue ribbon label">
                             <h3>Single Phase Data</h3>
                         </a></div>
                     </div>
@@ -284,7 +284,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -304,7 +304,7 @@
 
         <div id="total-phases-data" class="ui segment print-page-break">
             <div class="content">
-                <div class="header"><a class="ui orange ribbon label" href="#">
+                <div class="header"><a class="ui orange ribbon label">
                     <h3>Total Phases Data</h3>
                 </a></div>
             </div>

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -295,6 +295,11 @@ a,
     white-space: nowrap;
 }
 
+/* Since we have a without href we need to force pointer */
+a {
+    cursor: pointer;
+}
+
 .close.icon {
     cursor: pointer;
     position: absolute;

--- a/frontend/data-analysis.html
+++ b/frontend/data-analysis.html
@@ -22,7 +22,7 @@
 <body class="preload">
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
-        <h1 class="ui header float left"><a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Data Analysis</h1>
+        <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Data Analysis</h1>
 
         <div class="ui full-width-card segment card">
             <div class="content">
@@ -44,7 +44,7 @@
         <div class="ui two cards stackable">
             <div class="ui card">
                 <div class="content">
-                    <div class="header"><a class="ui orange ribbon label" href="#"><h3>Wordpress vs. Static</h3></a></div>
+                    <div class="header"><a class="ui orange ribbon label"><h3>Wordpress vs. Static</h3></a></div>
                     <div class="description">
                         <p>Here we compared the measurements of a Wordpress website vs. a static
                             website.
@@ -67,7 +67,7 @@
             </div>
             <div class="ui card">
                 <div class="content">
-                    <div class="header"><a class="ui blue ribbon label" href="#"><h3>Comparing runs</h3></a></div>
+                    <div class="header"><a class="ui blue ribbon label"><h3>Comparing runs</h3></a></div>
                     <div class="description">
                         <p>The web interface will only show you global averages and chart previews.</p>
                         <p>In this Deepnote Notebook we focus on looking at the mean and standard
@@ -88,7 +88,7 @@
         <div class="ui two cards stackable">
             <div class="ui card">
                 <div class="content">
-                    <div class="header"><a class="ui teal ribbon label" href="#"><h3>Statistical Significance</h3></a></div>
+                    <div class="header"><a class="ui teal ribbon label"><h3>Statistical Significance</h3></a></div>
                     <div class="description">
                         <p>Here we look again at the example of the Wordpress and the Static versions of the website.</p>
                         <p>Our research question is: Is there really a statistically signifcant difference between the energy of the runs? Or is the difference we see just random noise?</p>

--- a/frontend/energy-timeline.html
+++ b/frontend/energy-timeline.html
@@ -28,7 +28,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             Green Metrics Tool - Energy Timeline
         </h1>
         <div class="ui full-width-card segment card">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,7 +31,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             Green Metrics Tool - Home
         </h1>
         <div class="ui full-width-card segment card">

--- a/frontend/js/energy-timeline.js
+++ b/frontend/js/energy-timeline.js
@@ -48,7 +48,7 @@ $(document).ready(function () {
                                 </i>
                             </div>
                             <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?uri=${url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}" target="_blank"><img src="${API_URL}/v1/badge/timeline?uri=${url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}&metrics=${metric_name}&detail_name=${detail_name}" alt="Image Failed to Load" onerror="this.closest('.field').style.display='none'"></a></span>
-                            <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                            <a class="copy-badge"><i class="copy icon"></i></a>
                         </div>
                         </div>
                         <p></p><hr>`
@@ -118,7 +118,7 @@ $(document).ready(function () {
                                 </i>
                             </div>
                             <span class="energy-badge-container"><a href="/timeline.html?uri=${row[1]}&branch=${row[3] == null ? '': row[3]}&filename=${row[4] == null ? '': row[4]}&machine_id=${row[5]}"><img src="${API_URL}/v1/badge/timeline?uri=${row[1]}&branch=${row[3] == null ? '': row[3]}&filename=${row[4] == null ? '': row[4]}&machine_id=${row[5]}&metrics=${`cores_energy_powermetrics_component`}&detail_name=${`[COMPONENT]`}"></a></span>
-                            <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                            <a class="copy-badge"><i class="copy icon"></i></a>
                         </div>
                         <p></p>`
 

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -188,7 +188,7 @@ const loadCharts = async () => {
                         </i>
                     </div>
                     <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?${buildQueryParams()}" target="_blank"><img src="${API_URL}/v1/badge/timeline?${buildQueryParams(skip_dates=false,metric_override=series[my_series].metric_name,detail_name=series[my_series].detail_name)}"></a></span>
-                    <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                    <a class="copy-badge"><i class="copy icon"></i></a>
                 </div>
                 <p></p>`
         document.querySelector("#badge-container").innerHTML += badge;

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -31,7 +31,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             Green Metrics Tool - All Repositories
         </h1>
         <div class="ui full-width-card segment card">

--- a/frontend/request.html
+++ b/frontend/request.html
@@ -26,7 +26,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             Measure software on measurement cluster
         </h1>
         <div class="ui full-width-card segment card">

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -26,7 +26,7 @@
 <body class="preload">
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
-        <h1 class="ui header float left"><a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Settings</h1>
+        <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Settings</h1>
         <div class="ui full-width-card card">
             <div class="content">
                 <div class="description">

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -37,10 +37,10 @@
 <body class="preload">
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
-        <h1 class="ui header float left"><a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Detailed Metrics</h1>
+        <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Detailed Metrics</h1>
         <div class="ui full-width-card card">
             <div class="content">
-                <div class="header"><a class="ui red ribbon label" href="#">
+                <div class="header"><a class="ui red ribbon label">
                     <h3>Run Data</h3>
                 </a></div>
                 <div class="description run-data-container">
@@ -72,7 +72,7 @@
                         <div id="badges">
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="ml-estimated"></span>
-                                <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                                <a class="copy-badge"><i class="copy icon"></i></a>
                                 <div class="ui left pointing blue basic label">
                                     XGBoost estimated AC energy (Runtime)
                                 </div>
@@ -80,7 +80,7 @@
                             <div class="ui divider"></div>
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="RAPL"></span>
-                                <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                                <a class="copy-badge"><i class="copy icon"></i></a>
                                 <div class="ui left pointing blue basic label">
                                     RAPL component energy (Runtime)
                                 </div>
@@ -88,7 +88,7 @@
                             <div class="ui divider"></div>
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="AC"></span>
-                                <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                                <a class="copy-badge"><i class="copy icon"></i></a>
                                 <div class="ui left pointing blue basic label">
                                     Measured AC energy (Runtime)
                                 </div>
@@ -96,7 +96,7 @@
                             <div class="ui divider"></div>
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="SCI"></span>
-                                <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                                <a class="copy-badge"><i class="copy icon"></i></a>
                                 <div class="ui left pointing blue basic label">
                                     SCI (Runtime)
                                 </div>
@@ -172,7 +172,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -193,7 +193,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -215,7 +215,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -237,7 +237,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -269,7 +269,7 @@
                 </div>
                 <div class="ui segment secondary">
                     <div class="content">
-                        <div class="header"><a class="ui blue ribbon label" href="#">
+                        <div class="header"><a class="ui blue ribbon label">
                             <h3>Single Phase Data</h3>
                         </a></div>
                     </div>
@@ -292,7 +292,7 @@
                 </div>
                 <div class="ui segment secondary">
                     <div class="content">
-                        <div class="header"><a class="ui blue ribbon label" href="#">
+                        <div class="header"><a class="ui blue ribbon label">
                             <h3>Single Phase Data</h3>
                         </a></div>
                     </div>
@@ -315,7 +315,7 @@
                 <ul></ul>
             </div>
             <div class="content">
-                <div class="header"><a class="ui blue ribbon label" href="#">
+                <div class="header"><a class="ui blue ribbon label">
                     <h3>Single Phase Data</h3>
                 </a></div>
             </div>
@@ -331,7 +331,7 @@
 
         <div id="total-phases-data" class="ui segment print-page-break">
             <div class="content">
-                <div class="header"><a class="ui orange ribbon label" href="#">
+                <div class="header"><a class="ui orange ribbon label">
                     <h3>Total Phases Data</h3>
                 </a></div>
             </div>
@@ -347,7 +347,7 @@
 
         <div class="ui full-width-card card">
             <div class="content">
-                <div class="header"><a class="ui teal ribbon label" href="#">
+                <div class="header"><a class="ui teal ribbon label">
                     <h3>Metric Charts</h3>
                 </a></div>
                 <div class="description">

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -32,7 +32,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left">
-            <a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a>
             Green Metrics Tool - Status
         </h1>
         <div class="ui full-width-card segment card">

--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -38,11 +38,11 @@
 <body class="preload">
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
-        <h1 class="ui header float left"><a href="#" id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Timeline View</h1>
+        <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon openend"></i></a> Timeline View</h1>
         <div class="ui full-width-card card">
             <div class="content">
                 <div class="description run-data-container">
-                    <div class="header"><a class="ui red ribbon label" href="#">
+                    <div class="header"><a class="ui red ribbon label">
                         <h3>Timeline View Details</h3>
                     </a></div>
                     <h4>What is Timeline View?</h4>


### PR DESCRIPTION
we have many links that had href="#"

Not only does this hop to the top of the page, but it also is misleading. Removing href entirely is way cleaner and still conformant