### PR TITLE
Added average function to badges

### DIFF
--- a/api/eco_ci.py
+++ b/api/eco_ci.py
@@ -330,7 +330,7 @@ async def get_ci_badge_get(repo: str, branch: str, workflow:str, mode: str = 'la
             WITH my_table as (
                 SELECT SUM({metric}) my_sum
                 FROM ci_measurements
-                WHERE repo = %s AND branch = %s AND workflow_id = %s AND created_at > NOW() - make_interval(days => %s)
+                WHERE repo = %s AND branch = %s AND workflow_id = %s AND DATE(created_at) > NOW() - make_interval(days => %s)
                 GROUP BY run_id
             ) SELECT AVG(my_sum) FROM my_table;
         """
@@ -340,7 +340,7 @@ async def get_ci_badge_get(repo: str, branch: str, workflow:str, mode: str = 'la
         query = f"{query} GROUP BY run_id ORDER BY MAX(created_at) DESC LIMIT 1"
         label = f"Last run {label}"
     elif mode == 'totals' and duration_days:
-        query = f"{query} AND created_at > NOW() - make_interval(days => %s)"
+        query = f"{query} AND DATE(created_at) > NOW() - make_interval(days => %s)"
         params.append(duration_days)
         label = f"Last {duration_days} days total {label}"
     elif mode == 'totals':

--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -158,7 +158,33 @@
                 </table>
             </div>
         </div>
-        <div class="ui segment" id="runs-table">
+
+       <div id="loader-question" class="ui icon info message blue">
+            <i class="info circle icon"></i>
+
+            <div class="content">
+                <div class="header">
+                    Runs detail table is not displayed automatically
+                </div>
+                <p>Please click the button below to fetch data.</p>
+                <p>You can change the default behaviour under <a href="/settings.html" style="text-decoration: underline; font-weight: bold;">Settings</a></p>
+                <button id="display-run-details-table" class="blue ui button">Display runs table</button>
+            </div>
+            <ul></ul>
+        </div>
+
+        <div class="ui one cards" id="api-loader" style="display:none;">
+            <div class="card" style="min-height: 300px">
+                <div class="ui active dimmer">
+                    <div class="ui indeterminate text loader">Building table ...</div>
+                </div>
+                <p></p>
+            </div>
+        </div>
+        <div id="chart-container"></div>
+
+
+        <div class="ui segment" id="run-details-table" style="display: none">
             <div class="header"><a class="ui teal ribbon label">
                     <h3 data-tooltip="The runs table shows all measurements your pipeline has made in the selected timeframe" data-position="top left">Runs Table <i class="question circle icon "></i> </h3>
                 </a></div>

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -310,6 +310,10 @@ a {
     transition: opacity .1s ease;
 }
 
+.bold {
+    font-weight: bold;
+}
+
 
 /* PRINT STYLESHEETS */
 @media print {

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -473,6 +473,9 @@ const bindRefreshButton = (repo, branch, workflow_id, chart_instance) => {
 
 $(document).ready((e) => {
     (async () => {
+
+        $('.ui.secondary.menu .item').tab(); // must happen very early so tab menu is not broken if return happens
+
         const query_string = window.location.search;
         const url_params = (new URLSearchParams(query_string))
 
@@ -549,8 +552,6 @@ $(document).ready((e) => {
 
             displayStatsTable(filteredMeasurements);
         });
-
-        $('.ui.secondary.menu .item').tab();
 
         setTimeout(function(){console.log("Resize"); window.dispatchEvent(new Event('resize'))}, 500);
     })();

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -300,13 +300,13 @@ const getMeasurementsAndStats = async (repo, branch, workflow_id) => {
     const start_date = dateToYMD(new Date($('#rangestart input').val()), short=true);
     const end_date = dateToYMD(new Date($('#rangeend input').val()), short=true);
 
-    history.pushState(null, '', `${window.location.origin}${window.location.pathname}?repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`); // replace URL to bookmark!
-
     const query_string=`repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`;
     const [measurements, stats] = await Promise.all([
         makeAPICall(`/v1/ci/measurements?${query_string}`),
         makeAPICall(`/v1/ci/stats?${query_string}`)
     ]);
+
+    history.pushState(null, '', `${window.location.origin}${window.location.pathname}?repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`); // replace URL to bookmark!
 
     return [measurements, stats];
 }

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -74,6 +74,8 @@ const createStatsArrays = (measurements) => {  // iterates 2n times (1 full, 1 b
     measurements.forEach(measurement => {
         let [energy_uj, run_id, created_at, label, cpu, commit_hash, duration_us, source, cpu_util, workflow_name, lat, lon, city, carbon_intensity_g, carbon_ug] = measurement;
 
+        label = escapeString(label) // we print it later and it is user submitted string
+
         if (!measurementsByLabel[label]) {
             measurementsByLabel[label] = {
                 energy_uj: [],
@@ -267,30 +269,30 @@ const displayStatsTable = (measurements) => {
 
     const full_run_stats_avg_node = document.createElement("tr")
     full_run_stats_avg_node.innerHTML += `
-                            <td class="td-index" data-tooltip="Stats for the series of runs (labels aggregated for each pipeline run)" data-position="top left">All steps <i class="question circle icon small"></i> </td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.energy_uj.avg/1000000)} J (± ${numberFormatter.format(full_run_stats.energy_uj.stddev_rel)}%)</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.duration_us.avg/1000000)} s (± ${numberFormatter.format(full_run_stats.duration_us.stddev_rel)}%)</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.cpu_util.avg)}% (± ${numberFormatter.format(full_run_stats.cpu_util.stddev_rel)}%%)</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.carbon_intensity_g.avg)} gCO2/kWh (± ${numberFormatter.format(full_run_stats.carbon_intensity_g.stddev_rel)}%)</td>
-                            <td class="td-index">${numberFormatterLong.format(full_run_stats.carbon_ug.avg/1000000)} gCO2e (± ${numberFormatter.format(full_run_stats.carbon_ug.stddev_rel)}%)</td>
-                            <td class="td-index">${fullRunArray.count}</td>`;
+                            <td class="bold td-index" data-tooltip="Averages for whole run" data-position="top left">Total run <i class="question circle icon small"></i> </td>
+                            <td class="bold td-index">${numberFormatter.format(full_run_stats.energy_uj.avg/1000000)} J (± ${numberFormatter.format(full_run_stats.energy_uj.stddev_rel)}%)</td>
+                            <td class="bold td-index">${numberFormatter.format(full_run_stats.duration_us.avg/1000000)} s (± ${numberFormatter.format(full_run_stats.duration_us.stddev_rel)}%)</td>
+                            <td class="bold td-index">${numberFormatter.format(full_run_stats.cpu_util.avg)}% (± ${numberFormatter.format(full_run_stats.cpu_util.stddev_rel)}%%)</td>
+                            <td class="bold td-index">${numberFormatter.format(full_run_stats.carbon_intensity_g.avg)} gCO2/kWh (± ${numberFormatter.format(full_run_stats.carbon_intensity_g.stddev_rel)}%)</td>
+                            <td class="bold td-index">${numberFormatterLong.format(full_run_stats.carbon_ug.avg/1000000)} gCO2e (± ${numberFormatter.format(full_run_stats.carbon_ug.stddev_rel)}%)</td>
+                            <td class="bold td-index">${fullRunArray.count}</td>`;
 
     avg_table.appendChild(full_run_stats_avg_node);
 
     const full_run_stats_total_node = document.createElement("tr")
     full_run_stats_total_node.innerHTML += `
-                            <td class="td-index" data-tooltip="Stats for the series of runs (labels aggregated for each pipeline run)" data-position="top left">All steps <i class="question circle icon small"></i> </td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.energy_uj.total/1000000)} J</td>
-                            <td class="td-index">${numberFormatter.format(full_run_stats.duration_us.total/1000000)} s</td>
-                            <td class="td-index">${numberFormatterLong.format(full_run_stats.carbon_ug.total/1000000)} gCO2e</td>
-                            <td class="td-index">${fullRunArray.count}</td>`;
+                            <td class="bold td-index" data-tooltip="Totals for whole run" data-position="top left">Per total run <i class="question circle icon small"></i> </td>
+                            <td class="bold td-index">${numberFormatter.format(full_run_stats.energy_uj.total/1000000)} J</td>
+                            <td class="bold td-index">${numberFormatter.format(full_run_stats.duration_us.total/1000000)} s</td>
+                            <td class="bold td-index">${numberFormatterLong.format(full_run_stats.carbon_ug.total/1000000)} gCO2e</td>
+                            <td class="bold td-index">${fullRunArray.count}</td>`;
     total_table.appendChild(full_run_stats_total_node)
 
     for (const label in labelsArray) {
         const label_stats = calculateStats(labelsArray[label].energy_uj, labelsArray[label].carbon_ug, labelsArray[label].carbon_intensity_g, labelsArray[label].duration_us, labelsArray[label].cpu_util)
         const label_stats_avg_node = document.createElement("tr")
         label_stats_avg_node.innerHTML += `
-                                        <td class="td-index" data-tooltip="stats for the series of steps represented by the ${label} label"  data-position="top left">${label} <i class="question circle icon small"></i></td>
+                                        <td class="td-index" data-tooltip="Averages per step '${label}'"  data-position="top left">${label} <i class="question circle icon small"></i></td>
                                         <td class="td-index">${numberFormatter.format(label_stats.energy_uj.avg/1000000)} J (± ${numberFormatter.format(label_stats.energy_uj.stddev_rel)}%)</td>
                                         <td class="td-index">${numberFormatter.format(label_stats.duration_us.avg/1000000)} s (± ${numberFormatter.format(label_stats.duration_us.stddev_rel)}%)</td>
                                         <td class="td-index">${numberFormatter.format(label_stats.cpu_util.avg)}% (± ${numberFormatter.format(label_stats.cpu_util.stddev_rel)}%%)</td>
@@ -302,7 +304,7 @@ const displayStatsTable = (measurements) => {
 
         const label_stats_total_node = document.createElement("tr")
         label_stats_total_node.innerHTML += `
-                                        <td class="td-index" data-tooltip="stats for the series of steps represented by the ${label} label"  data-position="top left">${label} <i class="question circle icon small"></i></td>
+                                        <td class="td-index" data-tooltip="Totals per step '${label}'"  data-position="top left">${label} <i class="question circle icon small"></i></td>
                                         <td class="td-index">${numberFormatter.format(label_stats.energy_uj.total/1000000)} J</td>
                                         <td class="td-index">${numberFormatter.format(label_stats.duration_us.total/1000000)} s</td>
                                         <td class="td-index">${numberFormatterLong.format(label_stats.carbon_ug.total/1000000)} gCO2e</td>

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -349,8 +349,8 @@ const bindRefreshButton = (repo, branch, workflow_id, chart_instance) => {
 const populateInputs = (url_params) => {
 
     // set defaults first, so we have filled in data if we fail
-    const start_date = (url_params.get('start_date') == null) ? dateToYMD(new Date(), short=true) : url_params.get('start_date');
-    const end_date = (url_params.get('end_date') == null) ? dateToYMD(new Date((new Date()).setDate((new Date).getDate() -7)), short=true) : url_params.get('end_date');
+    const start_date = (url_params.get('start_date') == null) ? dateToYMD(new Date((new Date()).setDate((new Date).getDate() -7)), short=true) : url_params.get('start_date');
+    const end_date = (url_params.get('end_date') == null) ? dateToYMD(new Date(), short=true) : url_params.get('end_date');
 
     // these two need no escaping, as the date library will always produce a result
     // it might fail parsing the date however

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -1,139 +1,3 @@
-const calculateStats = (energy_measurements, carbon_ug_measurements, carbon_intensity_g_measurements, duration_us_measurements, cpu_util_measurements) => {
-
-    let energy_avg = energy_stddev = energy_stddev_rel = energy_sum = '--'
-    let duration_us_avg = duration_us_stddev = duration_us_stddev_rel = duration_us_sum = '--'
-    let carbon_ug_avg = carbon_ug_stddev = carbon_ug_stddev_rel = carbon_ug_sum ='--'
-    let carbon_intensity_g_avg = carbon_intensity_g_stddev = carbon_intensity_g_stddev_rel = '--'
-    let cpuUtil_stddev = cpuUtil_avg = cpuUtil_stddev_rel = '--'
-
-    if (energy_measurements.length > 0) {
-        [energy_avg, energy_stddev, energy_sum, energy_stddev_rel] = calculateStatistics(energy_measurements)
-    }
-    if (duration_us_measurements.length > 0) {
-        [duration_us_avg, duration_us_stddev, duration_us_sum, duration_us_stddev_rel] = calculateStatistics(duration_us_measurements)
-    }
-    if (carbon_ug_measurements.length > 0) {
-        [carbon_ug_avg, carbon_ug_stddev, carbon_ug_sum, carbon_ug_stddev_rel] = calculateStatistics(carbon_ug_measurements)
-    }
-
-    // intentially skipping carbon_intensity_g_sum
-    if (carbon_intensity_g_measurements.length > 0) {
-        [carbon_intensity_g_avg, carbon_intensity_g_stddev, , carbon_intensity_g_stddev_rel] = calculateStatistics(carbon_intensity_g_measurements)
-    }
-
-    // intentially skipping cpuUtil_sum
-    if (cpu_util_measurements.length > 0) {
-        [cpuUtil_avg, cpuUtil_stddev, , cpuUtil_stddev_rel] = calculateStatistics(cpu_util_measurements)
-    }
-
-    return {
-        energy_uj: {
-            avg: energy_avg,
-            stddev: energy_stddev,
-            stddev_rel: energy_stddev_rel,
-            total: energy_sum
-        },
-        duration_us: {
-            avg: duration_us_avg,
-            stddev: duration_us_stddev,
-            stddev_rel: duration_us_stddev_rel,
-            total: duration_us_sum
-        },
-        carbon_ug: {
-            avg: carbon_ug_avg,
-            stddev: carbon_ug_stddev,
-            stddev_rel: carbon_ug_stddev_rel,
-            total: carbon_ug_sum
-        },
-        carbon_intensity_g: {
-            avg: carbon_intensity_g_avg,
-            stddev: carbon_intensity_g_stddev,
-            stddev_rel: carbon_intensity_g_stddev_rel
-        },
-        cpu_util: {
-            avg: cpuUtil_avg,
-            stddev: cpuUtil_stddev,
-            stddev_rel: cpuUtil_stddev_rel
-        },
-    };
-};
-
-const createStatsArrays = (measurements) => {  // iterates 2n times (1 full, 1 by run ID)
-    const measurementsByRun = {}
-    const measurementsByLabel = {}
-
-    const measurementsForFullRun = {
-        energy_uj: [],
-        carbon_ug: [],
-        carbon_intensity_g: [],
-        duration_us: [],
-        cpu_util: [],
-        count: 0
-    };
-
-    measurements.forEach(measurement => {
-        let [energy_uj, run_id, created_at, label, cpu, commit_hash, duration_us, source, cpu_util, workflow_name, lat, lon, city, carbon_intensity_g, carbon_ug] = measurement;
-
-        label = escapeString(label) // we print it later and it is user submitted string
-
-        if (!measurementsByLabel[label]) {
-            measurementsByLabel[label] = {
-                energy_uj: [],
-                carbon_ug: [],
-                carbon_intensity_g: [],
-                duration_us: [],
-                cpu_util: [],
-                count: 0
-            };
-        }
-        if (!measurementsByRun[run_id]) {
-            measurementsByRun[run_id] = {
-                energy_uj: [],
-                carbon_ug: [],
-                carbon_intensity_g: [],
-                duration_us: [],
-                cpu_util: []
-            };
-        }
-
-        if (energy_uj != null) {
-            measurementsByLabel[label].energy_uj.push(energy_uj);
-            measurementsByRun[run_id].energy_uj.push(energy_uj);
-        }
-        if (duration_us != null) {
-            measurementsByLabel[label].duration_us.push(duration_us);
-            measurementsByRun[run_id].duration_us.push(duration_us);
-        }
-        if (cpu_util != null) {
-            measurementsByLabel[label].cpu_util.push(cpu_util);
-            measurementsByRun[run_id].cpu_util.push(cpu_util);
-        }
-        if (carbon_ug != null) {
-            measurementsByLabel[label].carbon_ug.push(carbon_ug);
-            measurementsByRun[run_id].carbon_ug.push(carbon_ug);
-        }
-        if (carbon_intensity_g != null) {
-            measurementsByLabel[label].carbon_intensity_g.push(carbon_intensity_g);
-            measurementsByRun[run_id].carbon_intensity_g.push(carbon_intensity_g);
-        }
-        measurementsByLabel[label].count += 1;
-        measurementsForFullRun.count += 1;
-    });
-
-
-
-   for (const run_id in measurementsByRun) {
-        if (measurementsByRun[run_id].energy_uj) measurementsForFullRun.energy_uj.push(measurementsByRun[run_id].energy_uj);
-        if (measurementsByRun[run_id].carbon_ug) measurementsForFullRun.carbon_ug.push(measurementsByRun[run_id].carbon_ug);
-        if (measurementsByRun[run_id].duration_us) measurementsForFullRun.duration_us.push(measurementsByRun[run_id].duration_us);
-        if (measurementsByRun[run_id].cpu_util) measurementsForFullRun.cpu_util.push(measurementsByRun[run_id].cpu_util);
-        if (measurementsByRun[run_id].carbon_intensity_g) measurementsForFullRun.carbon_intensity_g.push(measurementsByRun[run_id].carbon_intensity_g);
-    }
-
-    return [measurementsForFullRun, measurementsByLabel];
-
-}
-
 const createChartContainer = (container, el) => {
     const chart_node = document.createElement("div")
     chart_node.classList.add("card");
@@ -249,6 +113,7 @@ const getChartOptions = (measurements) => {
 const displayGraph = (chart_instance, measurements) => {
 
     const options = getChartOptions(measurements); // iterates
+    chart_instance.clear();
     chart_instance.setOption(options);
 
     window.onresize = function () { // set callback when ever the user changes the viewport
@@ -256,8 +121,7 @@ const displayGraph = (chart_instance, measurements) => {
     }
 }
 
-const displayStatsTable = (measurements) => {
-    const [fullRunArray, labelsArray] = createStatsArrays(measurements); // iterates 2n times
+const displayStatsTable = (stats) => {
 
     const total_table = document.querySelector("#label-stats-table-total");
     const avg_table = document.querySelector("#label-stats-table-avg");
@@ -265,57 +129,57 @@ const displayStatsTable = (measurements) => {
     total_table.innerHTML = "";
     avg_table.innerHTML = "";
 
-    const full_run_stats = calculateStats(fullRunArray.energy_uj.flat(), fullRunArray.carbon_ug.flat(), fullRunArray.carbon_intensity_g.flat(), fullRunArray.duration_us.flat(), fullRunArray.cpu_util.flat())
-
     const full_run_stats_avg_node = document.createElement("tr")
     full_run_stats_avg_node.innerHTML += `
                             <td class="bold td-index" data-tooltip="Averages for whole run" data-position="top left">Total run <i class="question circle icon small"></i> </td>
-                            <td class="bold td-index">${numberFormatter.format(full_run_stats.energy_uj.avg/1000000)} J (± ${numberFormatter.format(full_run_stats.energy_uj.stddev_rel)}%)</td>
-                            <td class="bold td-index">${numberFormatter.format(full_run_stats.duration_us.avg/1000000)} s (± ${numberFormatter.format(full_run_stats.duration_us.stddev_rel)}%)</td>
-                            <td class="bold td-index">${numberFormatter.format(full_run_stats.cpu_util.avg)}% (± ${numberFormatter.format(full_run_stats.cpu_util.stddev_rel)}%%)</td>
-                            <td class="bold td-index">${numberFormatter.format(full_run_stats.carbon_intensity_g.avg)} gCO2/kWh (± ${numberFormatter.format(full_run_stats.carbon_intensity_g.stddev_rel)}%)</td>
-                            <td class="bold td-index">${numberFormatterLong.format(full_run_stats.carbon_ug.avg/1000000)} gCO2e (± ${numberFormatter.format(full_run_stats.carbon_ug.stddev_rel)}%)</td>
-                            <td class="bold td-index">${fullRunArray.count}</td>`;
+                            <td class="bold td-index">${numberFormatter.format(stats.totals[0]/1000000)} J (± ${numberFormatter.format(stats.totals[3])}%)</td>
+                            <td class="bold td-index">${numberFormatter.format(stats.totals[4]/1000000)} s (± ${numberFormatter.format(stats.totals[7])}%)</td>
+                            <td class="bold td-index">${numberFormatter.format(stats.totals[8])}% (± ${numberFormatter.format(stats.totals[11])}%%)</td>
+                            <td class="bold td-index">${numberFormatter.format(stats.totals[12])} gCO2/kWh (± ${numberFormatter.format(stats.totals[15])}%)</td>
+                            <td class="bold td-index">${numberFormatterLong.format(stats.totals[16]/1000000)} gCO2e (± ${numberFormatter.format(stats.totals[19])}%)</td>
+                            <td class="bold td-index">${stats.totals[20]}</td>`;
 
     avg_table.appendChild(full_run_stats_avg_node);
 
     const full_run_stats_total_node = document.createElement("tr")
     full_run_stats_total_node.innerHTML += `
                             <td class="bold td-index" data-tooltip="Totals for whole run" data-position="top left">Per total run <i class="question circle icon small"></i> </td>
-                            <td class="bold td-index">${numberFormatter.format(full_run_stats.energy_uj.total/1000000)} J</td>
-                            <td class="bold td-index">${numberFormatter.format(full_run_stats.duration_us.total/1000000)} s</td>
-                            <td class="bold td-index">${numberFormatterLong.format(full_run_stats.carbon_ug.total/1000000)} gCO2e</td>
-                            <td class="bold td-index">${fullRunArray.count}</td>`;
+                            <td class="bold td-index">${numberFormatter.format(stats.totals[1]/1000000)} J</td>
+                            <td class="bold td-index">${numberFormatter.format(stats.totals[5]/1000000)} s</td>
+                            <td class="bold td-index">${numberFormatterLong.format(stats.totals[17]/1000000)} gCO2e</td>
+                            <td class="bold td-index">${stats.totals[20]}</td>`;
     total_table.appendChild(full_run_stats_total_node)
 
-    for (const label in labelsArray) {
-        const label_stats = calculateStats(labelsArray[label].energy_uj, labelsArray[label].carbon_ug, labelsArray[label].carbon_intensity_g, labelsArray[label].duration_us, labelsArray[label].cpu_util)
+    stats.per_label.forEach((row) =>{
         const label_stats_avg_node = document.createElement("tr")
+        const label = row[21];
         label_stats_avg_node.innerHTML += `
                                         <td class="td-index" data-tooltip="Averages per step '${label}'"  data-position="top left">${label} <i class="question circle icon small"></i></td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.energy_uj.avg/1000000)} J (± ${numberFormatter.format(label_stats.energy_uj.stddev_rel)}%)</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.duration_us.avg/1000000)} s (± ${numberFormatter.format(label_stats.duration_us.stddev_rel)}%)</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.cpu_util.avg)}% (± ${numberFormatter.format(label_stats.cpu_util.stddev_rel)}%%)</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.carbon_intensity_g.avg)} gCO2/kWh (± ${numberFormatter.format(label_stats.carbon_intensity_g.stddev_rel)}%)</td>
-                                        <td class="td-index">${numberFormatterLong.format(label_stats.carbon_ug.avg/1000000)} gCO2e (± ${numberFormatter.format(label_stats.carbon_ug.stddev_rel)}%)</td>
-                                        <td class="td-index">${labelsArray[label].count}</td>`;
+                                        <td class=" td-index">${numberFormatter.format(row[0]/1000000)} J (± ${numberFormatter.format(row[3])}%)</td>
+                                        <td class=" td-index">${numberFormatter.format(row[4]/1000000)} s (± ${numberFormatter.format(row[7])}%)</td>
+                                        <td class=" td-index">${numberFormatter.format(row[8])}% (± ${numberFormatter.format(row[11])}%%)</td>
+                                        <td class=" td-index">${numberFormatter.format(row[12])} gCO2/kWh (± ${numberFormatter.format(row[15])}%)</td>
+                                        <td class=" td-index">${numberFormatterLong.format(row[16]/1000000)} gCO2e (± ${numberFormatter.format(row[19])}%)</td>
+                                        <td class="td-index">${row[20]}</td>`;
 
         avg_table.appendChild(label_stats_avg_node);
 
         const label_stats_total_node = document.createElement("tr")
         label_stats_total_node.innerHTML += `
                                         <td class="td-index" data-tooltip="Totals per step '${label}'"  data-position="top left">${label} <i class="question circle icon small"></i></td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.energy_uj.total/1000000)} J</td>
-                                        <td class="td-index">${numberFormatter.format(label_stats.duration_us.total/1000000)} s</td>
-                                        <td class="td-index">${numberFormatterLong.format(label_stats.carbon_ug.total/1000000)} gCO2e</td>
-                                        <td class="td-index">${labelsArray[label].count}</td>`;
+                                        <td class=" td-index">${numberFormatter.format(row[0]/1000000)} J (± ${numberFormatter.format(row[3])}%)</td>
+                                        <td class=" td-index">${numberFormatter.format(row[4]/1000000)} s (± ${numberFormatter.format(row[7])}%)</td>
+                                        <td class=" td-index">${numberFormatterLong.format(row[17]/1000000)} gCO2e (± ${numberFormatter.format(row[19])}%)</td>
+                                        <td class="td-index">${row[20]}</td>`;
         total_table.appendChild(label_stats_total_node);
 
-    };
+    }) ;
+
 }
 
-const displayCITable = (measurements, repo) => {
+const displayRunDetailsTable = (measurements, repo) => {
 
+    document.querySelector("#run-details-table").style.display = ''; // show
     document.querySelector("#ci-table").innerHTML = ''; // clear
 
     measurements.forEach(measurement => {
@@ -432,34 +296,42 @@ const getBadges = async (repo, branch, workflow_id) => {
     }
 }
 
-const getMeasurements = async (repo, branch, workflow_id, start_date = null, end_date = null) => {
-    if(end_date == null) end_date = dateToYMD(new Date(), short=true);
-    if(start_date == null) start_date = dateToYMD(new Date((new Date()).setDate((new Date).getDate() -7)), short=true);
-    const api_string=`/v1/ci/measurements?repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`;
-    return await makeAPICall(api_string);
+const getMeasurementsAndStats = async (repo, branch, workflow_id) => {
+    const start_date = dateToYMD(new Date($('#rangestart input').val()), short=true);
+    const end_date = dateToYMD(new Date($('#rangeend input').val()), short=true);
+
+    history.pushState(null, '', `${window.location.origin}${window.location.pathname}?repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`); // replace URL to bookmark!
+
+    const query_string=`repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`;
+    const [measurements, stats] = await Promise.all([
+        makeAPICall(`/v1/ci/measurements?${query_string}`),
+        makeAPICall(`/v1/ci/stats?${query_string}`)
+    ]);
+
+    return [measurements, stats];
 }
 
 const bindRefreshButton = (repo, branch, workflow_id, chart_instance) => {
     // When the user selects a subset of the measurement data via the date-picker
     $('#submit').on('click', async function () {
-        const startDate = dateToYMD(new Date($('#rangestart input').val()), short=true);
-        const endDate = dateToYMD(new Date($('#rangeend input').val()), short=true);
 
         let measurements = null;
+        let stats = null;
         try {
-            measurements = await getMeasurements(repo, branch, workflow_id, startDate, endDate); // iterates I
+            [measurements, stats] = await getMeasurementsAndStats(repo, branch, workflow_id); // iterates I
+
         } catch (err) {
             showNotification('Could not get data from API', err);
             return; // abort
         }
 
-        displayStatsTable(measurements.data); //iterates II
-        displayCITable(measurements.data, repo); // Iterates I (total: 1)
+        if (document.querySelector('#run-details-table').style.display != 'none') {
+            displayRunDetailsTable(measurements.data, repo);
+        }
 
-        // set new chart instance options
-        const options = getChartOptions(measurements.data); //iterates I
-        chart_instance.clear();
-        chart_instance.setOption(options);
+        displayStatsTable(stats.data); //iterates II
+
+        displayGraph(chart_instance, measurements.data)
 
         chart_instance.off('legendselectchanged') // remove
         // we need to re-bind the handler here and can also not really refactor that
@@ -468,9 +340,26 @@ const bindRefreshButton = (repo, branch, workflow_id, chart_instance) => {
             // get list of all legends that are on
             const selectedLegends = params.selected;
             const filteredMeasurements = measurements.data.filter(measurement => selectedLegends[measurement[4]]);
-            displayStatsTable(filteredMeasurements);
+            // displayStatsTable(filteredMeasurements); -- this does not work anymore, as we are now fetching the data from the API
+            // this decision was done as the JS code was very unmaintainable and SQL was far more readable. Performance was even though. Rework this if functionality needed
         });
     });
+}
+
+const populateInputs = (url_params) => {
+
+    // set defaults first, so we have filled in data if we fail
+    const start_date = (url_params.get('start_date') == null) ? dateToYMD(new Date(), short=true) : url_params.get('start_date');
+    const end_date = (url_params.get('end_date') == null) ? dateToYMD(new Date((new Date()).setDate((new Date).getDate() -7)), short=true) : url_params.get('end_date');
+
+    // these two need no escaping, as the date library will always produce a result
+    // it might fail parsing the date however
+    try {
+        $('#rangestart').calendar({initialDate: start_date});
+        $('#rangeend').calendar({initialDate: end_date});
+    } catch (err) {
+        showNotification('Date error', 'Date parsing failed');
+    }
 }
 
 $(document).ready((e) => {
@@ -478,8 +367,7 @@ $(document).ready((e) => {
 
         $('.ui.secondary.menu .item').tab(); // must happen very early so tab menu is not broken if return happens
 
-        const query_string = window.location.search;
-        const url_params = (new URLSearchParams(query_string))
+        const url_params = getURLParams();
 
         let branch = escapeString(url_params.get('branch'));
         let repo = escapeString(url_params.get('repo'));
@@ -509,13 +397,14 @@ $(document).ready((e) => {
 
         getBadges(repo, branch, workflow_id) // async
 
-        $('#rangestart input').val(new Date((new Date()).setDate((new Date).getDate() -7))) // set default on load
-        $('#rangeend input').val(new Date()) // set default on load
+        populateInputs(url_params);
+
         dateTimePicker();
 
         let measurements = null;
+        let stats = null;
         try {
-            measurements = await getMeasurements(repo, branch, workflow_id)
+            [measurements, stats] = await getMeasurementsAndStats(repo, branch, workflow_id)
         } catch (err) {
             showNotification('Could not get data from API', err);
             return; // abort
@@ -540,19 +429,25 @@ $(document).ready((e) => {
         const repo_link_node = `<a href="${repo_link}" target="_blank">${repo}</a>`
         ci_data_node.insertAdjacentHTML('afterbegin', `<tr><td><strong>Repository:</strong></td><td>${repo_link_node}</td></tr>`)
 
-        displayCITable(measurements.data, repo); // Iterates I (total: 1)
 
         displayGraph(chart_instance, measurements.data) // iterates I (total: 2)
 
-        displayStatsTable(measurements.data) // iterates II (total: 4)
+        displayStatsTable(stats.data) // iterates II (total: 4)
+
+        document.querySelector('#display-run-details-table').addEventListener('click', () => {
+            document.querySelector('#api-loader').style.display = '';
+            document.querySelector('#loader-question').remove();
+            setTimeout(() => {displayRunDetailsTable(measurements.data, repo); document.querySelector('#api-loader').remove();}, 100); // we need to include a mini delay here, because otherwise the loader does not render, but is blocked by the hefty calculation
+        });
+
 
         // On legend change, recalculate stats table
         chart_instance.on('legendselectchanged', function (params) {
             // get list of all legends that are on
             const selectedLegends = params.selected;
             const filteredMeasurements = measurements.data.filter(measurement => selectedLegends[measurement[4]]);
-
-            displayStatsTable(filteredMeasurements);
+            // displayStatsTable(filteredMeasurements); -- this does not work anymore, as we are now fetching the data from the API
+            // this decision was done as the JS code was very unmaintainable and SQL was far more readable. Performance was even though. Rework this if functionality needed
         });
 
         setTimeout(function(){console.log("Resize"); window.dispatchEvent(new Event('resize'))}, 500);

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -1,10 +1,3 @@
-const getURLParams = () => {
-    const query_string = window.location.search;
-    const url_params = (new URLSearchParams(query_string))
-    return url_params;
-}
-
-
 async function fetchDiff() {
     document.querySelector('#diff-question').remove();
     document.querySelector('#loader-diff').style.display = '';

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -71,6 +71,11 @@ class GMTMenu extends HTMLElement {
 }
 customElements.define('gmt-menu', GMTMenu);
 
+const getURLParams = () => {
+    const query_string = window.location.search;
+    return (new URLSearchParams(query_string))
+}
+
 const getPretty = (metric_name, key)  => {
     if (METRIC_MAPPINGS[metric_name] == null || METRIC_MAPPINGS[metric_name][key] == null) {
         console.log(metric_name, ' is undefined in METRIC_MAPPINGS or has no key');

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -405,18 +405,6 @@ const displayOptimizationsData = (optimizations_data) => {
     $('#optimization_count').html(optimizations_data.length)
 }
 
-
-const getURLParams = () => {
-    const query_string = window.location.search;
-    const url_params = (new URLSearchParams(query_string))
-
-    if(url_params.get('id') == null || url_params.get('id') == '' || url_params.get('id') == 'null') {
-        showNotification('No run id', 'ID parameter in URL is empty or not present. Did you follow a correct URL?');
-        throw "Error";
-    }
-    return url_params;
-}
-
 async function fetchTimelineData(url_params) {
     document.querySelector('#api-loader').style.display = '';
     document.querySelector('#loader-question').remove();
@@ -446,6 +434,7 @@ $(document).ready( (e) => {
     (async () => {
 
         let url_params = getURLParams();
+
         if(url_params.get('id') == null || url_params.get('id') == '' || url_params.get('id') == 'null') {
             showNotification('No run id', 'ID parameter in URL is empty or not present. Did you follow a correct URL?');
             return;

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -1,9 +1,3 @@
-const getURLParams = () => {
-    const query_string = window.location.search;
-    const url_params = (new URLSearchParams(query_string))
-    return url_params;
-}
-
 let chart_instances = [];
 
 window.onresize = function() { // set callback when ever the user changes the viewport

--- a/tests/api/test_api_eco_ci.py
+++ b/tests/api/test_api_eco_ci.py
@@ -209,23 +209,30 @@ def test_ci_badge_get_average():
 
     for i in range(1,3):
         measurement_model = MEASUREMENT_MODEL_NEW.copy()
-        measurement_model['energy_uj'] += i*1000
-        measurement_model['carbon_ug'] = i*1000
-
+        measurement_model['carbon_ug'] = 1000
         response = requests.post(f"{API_URL}/v2/ci/measurement/add", json=measurement_model, timeout=15)
         assert response.status_code == 204, Tests.assertion_info('success', response.text)
+
+    for i in range(1,6):
+        measurement_model = MEASUREMENT_MODEL_NEW.copy()
+        measurement_model['energy_uj'] *= 1000
+        measurement_model['carbon_ug'] = i*100000
+        measurement_model['run_id'] = 'Other run'
+        response = requests.post(f"{API_URL}/v2/ci/measurement/add", json=measurement_model, timeout=15)
+        assert response.status_code == 204, Tests.assertion_info('success', response.text)
+
 
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'Per run moving average (5 days) energy used' in response.text, Tests.assertion_info('success', response.text)
-    assert '124.50 mJ' in response.text, Tests.assertion_info('success', response.text)
+    assert '307.62 J' in response.text, Tests.assertion_info('success', response.text)
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5&metric=carbon", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
 
     assert 'Per run moving average (5 days) carbon emitted' in response.text, Tests.assertion_info('success', response.text)
-    assert '1.50 mg' in response.text, Tests.assertion_info('success', response.text)
+    assert '751.00 mg' in response.text, Tests.assertion_info('success', response.text)
 
 
 ## helpers

--- a/tests/api/test_api_eco_ci.py
+++ b/tests/api/test_api_eco_ci.py
@@ -172,6 +172,62 @@ def test_ci_measurement_add_filters():
     data = fetch_data_from_db(measurement_model['run_id'])
     compare_carbondb_data(measurement_model, data)
 
+def test_ci_badge_duration_error():
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=avg&duration_days=900", timeout=15)
+    assert response.status_code == 422
+    assert response.text == '{"success":false,"err":"Duration days must be between 1 and 365 days","body":null}'
+
+
+def test_ci_badge_get_last():
+    Tests.import_demo_data()
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=last", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Last run energy used' in response.text, Tests.assertion_info('success', response.text)
+    assert '28.95 J' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=last&metric=carbon", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Last run carbon emitted' in response.text, Tests.assertion_info('success', response.text)
+    assert '17.32 mg' in response.text, Tests.assertion_info('success', response.text)
+
+
+def test_ci_badge_get_totals():
+    Tests.import_demo_data()
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'All runs total energy used' in response.text, Tests.assertion_info('success', response.text)
+    assert '49.02 kJ' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals&metric=carbon", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'All runs total carbon emitted' in response.text, Tests.assertion_info('success', response.text)
+    assert '15.56 g' in response.text, Tests.assertion_info('success', response.text)
+
+def test_ci_badge_get_average():
+
+    for i in range(1,3):
+        measurement_model = MEASUREMENT_MODEL_NEW.copy()
+        measurement_model['energy_uj'] += i*1000
+        measurement_model['carbon_ug'] = i*1000
+
+        response = requests.post(f"{API_URL}/v2/ci/measurement/add", json=measurement_model, timeout=15)
+        assert response.status_code == 204, Tests.assertion_info('success', response.text)
+
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Per run moving average (5 days) energy used' in response.text, Tests.assertion_info('success', response.text)
+    assert '124.50 mJ' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5&metric=carbon", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+
+    assert 'Per run moving average (5 days) carbon emitted' in response.text, Tests.assertion_info('success', response.text)
+    assert '1.50 mg' in response.text, Tests.assertion_info('success', response.text)
+
+
 ## helpers
 
 def fetch_data_from_db(run_id):

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -81,39 +81,39 @@ def test_eco_ci_demo_data():
     time.sleep(2) # wait for new data to render
 
     energy_avg_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(2)").text_content()
-    assert energy_avg_all_steps.strip() == '14.30 J (± 72.61%)'
+    assert energy_avg_all_steps.strip() == '28.60 J (± 3.30%)'
 
     time_avg_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(3)").text_content()
-    assert time_avg_all_steps.strip() == '6.40 s (± 59.48%)'
+    assert time_avg_all_steps.strip() == '12.80 s (± 3.49%)'
 
     cpu_avg_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(4)").text_content()
-    assert cpu_avg_all_steps.strip() == '38.60% (± 36.31%%)'
+    assert cpu_avg_all_steps.strip() == '44.73% (± 10.65%%)'
 
     grid_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(5)").text_content()
-    assert grid_all_steps.strip() == '494.20 gCO2/kWh (± 5.16%)'
+    assert grid_all_steps.strip() == '494.20 gCO2/kWh (± 5.47%)'
 
     carbon_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(6)").text_content()
-    assert carbon_all_steps.strip() == '0.008 gCO2e (± 71.27%)'
+    assert carbon_all_steps.strip() == '0.016 gCO2e (± 5.71%)'
 
     count_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(7)").text_content()
-    assert count_all_steps.strip() == '10'
+    assert count_all_steps.strip() == '5'
 
 
 
     energy_avg_single = page.locator("#label-stats-table-avg > tr:nth-child(2) > td:nth-child(2)").text_content()
-    assert energy_avg_single.strip() == '4.46 J (± 10.96%)'
+    assert energy_avg_single.strip() == '24.14 J (± 1.88%)'
 
     time_avg_single = page.locator("#label-stats-table-avg > tr:nth-child(2) > td:nth-child(3)").text_content()
-    assert time_avg_single.strip() == '2.80 s (± 15.97%)'
+    assert time_avg_single.strip() == '10.00 s (± 0.00%)'
 
     cpu_avg_single = page.locator("#label-stats-table-avg > tr:nth-child(2) > td:nth-child(4)").text_content()
-    assert cpu_avg_single.strip() == '27.60% (± 41.83%%)'
+    assert cpu_avg_single.strip() == '49.60% (± 5.06%%)'
 
     grid_single = page.locator("#label-stats-table-avg > tr:nth-child(2) > td:nth-child(5)").text_content()
     assert grid_single.strip() == '494.20 gCO2/kWh (± 5.47%)'
 
     carbon_single = page.locator("#label-stats-table-avg > tr:nth-child(2) > td:nth-child(6)").text_content()
-    assert carbon_single.strip() == '0.0026 gCO2e (± 9.83%)'
+    assert carbon_single.strip() == '0.0134 gCO2e (± 5.27%)'
 
     count_single = page.locator("#label-stats-table-avg > tr:nth-child(2) > td:nth-child(7)").text_content()
     assert count_single.strip() == '5'
@@ -157,13 +157,13 @@ def test_eco_ci_adding_data():
         page.wait_for_load_state("load") # ALL JS should be done
 
         energy_avg_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(2)").text_content()
-        assert energy_avg_all_steps.strip() == '26.00 J (± 50.00%)'
+        assert energy_avg_all_steps.strip() == '78.00 J (± 0.00%)'
 
         carbon_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(6)").text_content()
-        assert carbon_all_steps.strip() == '0.3235 gCO2e (± 0.00%)'
+        assert carbon_all_steps.strip() == '0.9704 gCO2e (± 0.00%)'
 
         carbon_all_steps = page.locator("#label-stats-table-avg > tr:nth-child(1) > td:nth-child(3)").text_content()
-        assert carbon_all_steps.strip() == '0.04 s (± 0.00%)'
+        assert carbon_all_steps.strip() == '0.11 s (± 0.00%)'
 
 
     finally: # reset state to expectation of this file


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Enhanced CI badge functionality by adding configurable time-based average metrics and improving server-side calculations for better performance and accuracy.

- Added duration validation (1-365 days) and weighted averages for CPU utilization and carbon intensity in `/api/eco_ci.py`
- Moved statistics calculations from client-side JS to server-side SQL for improved performance
- Updated test assertions in `/tests/frontend/test_frontend.py` to reflect new weighted average calculations
- Modified default date range in `/frontend/js/ci.js` to show last 7 days instead of next 7 days
- Added proper error handling for duration_days parameter and improved date handling consistency



<!-- /greptile_comment -->