### PR TITLE
Internal network

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -82,8 +82,9 @@ class SchemaChecker():
         elif isinstance(value, dict):
             for key, item in value.items():
                 self.contains_no_invalid_chars(key)
-                if item is not None:
-                    self.contains_no_invalid_chars(item)
+                if item and 'internal' in item:
+                    if not isinstance(item['internal'], bool):
+                        raise SchemaError("networks modifier 'internal' must be boolean")
         else:
             raise SchemaError("'networks' should be a list or a dictionary")
 

--- a/runner.py
+++ b/runner.py
@@ -706,7 +706,12 @@ class Runner:
                 print('Creating network: ', network)
                 # remove first if present to not get error, but do not make check=True, as this would lead to inf. loop
                 subprocess.run(['docker', 'network', 'rm', network], stderr=subprocess.DEVNULL, check=False)
-                subprocess.run(['docker', 'network', 'create', network], check=True)
+
+                if self._usage_scenario['networks'][network] and self._usage_scenario['networks'][network].get('internal', False):
+                    subprocess.check_output(['docker', 'network', 'create', '--internal', network])
+                else:
+                    subprocess.check_output(['docker', 'network', 'create', network])
+
                 self.__networks.append(network)
         else:
             print(TerminalColors.HEADER, '\nNo network found. Creating default network', TerminalColors.ENDC)

--- a/tests/data/usage_scenarios/internal_network.yml
+++ b/tests/data/usage_scenarios/internal_network.yml
@@ -1,0 +1,24 @@
+---
+name: Internal network test
+author: Arne Tarara
+description: test
+
+networks:
+  gmt-test-network:
+    internal: true
+    
+services:
+  test-container:
+    type: container
+    image: gcb_stress
+    build:
+      context: ../stress-application
+    networks: 
+      - gmt-test-network
+
+flow:
+  - name: External network should fail
+    container: test-container
+    commands:
+      - type: console
+        command: curl -s --fail https://www.google.de

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -881,6 +881,14 @@ def test_non_git_root_supplied():
         Tests.assertion_info('Supplied folder through --uri is not the root of the git repository. Please only supply the root folder and then the target directory through --filename', str(e.value))
 
 
+def test_internal_network():
+    runner = Runner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/internal_network.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+
+    with pytest.raises(RuntimeError) as e:
+        runner.run()
+
+    assert str(e.value) == "Process '['docker', 'exec', 'test-container', 'curl', '-s', '--fail', 'https://www.google.de']' had bad returncode: 126. Stderr: ; Detached process: False. Please also check the stdout in the logs and / or enable stdout logging to debug further."
+
 
     ## rethink this one
 def wip_test_verbose_provider_boot():


### PR DESCRIPTION
Docker and other orchestrators allow the virtual network to be isolated.

This means that containers can connect to each other, but not to external networks like the internet.

This PR brings this feature to GMT.

Useful for testing workloads that do non critical network requests which shall be suppressed to make more stable measuerements

<!-- greptile_comment -->

## Greptile Summary

Added support for Docker's internal network feature, allowing containers to communicate internally while being isolated from external networks, useful for more stable measurements by suppressing non-critical network requests.

- Added internal network validation in `lib/schema_checker.py` to support the 'internal' network modifier as a boolean property
- Added test case in `tests/test_usage_scenario.py` verifying that containers in internal networks cannot access external URLs
- Created `tests/data/usage_scenarios/internal_network.yml` demonstrating internal network configuration and testing
- Modified `runner.py` to handle the `internal` flag when creating Docker networks using `--internal` option



<!-- /greptile_comment -->