### PR TITLE
Measurement table split

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -249,7 +249,7 @@ def get_comparison_details(user, ids, comparison_db_key):
         WHERE
             (TRUE = %s OR user_id = ANY(%s::int[]))
             AND id = ANY(%s::uuid[])
-        ORDER BY created_at  -- Must be same order as in get_phase_stats
+        ORDER BY created_at DESC -- must be same order as get_phase_stats so that the order in the comparison bar charts aligns with the comparsion_details array
     ''').format(sql.Identifier(comparison_db_key))
 
     params = (user.is_super_user(), user.visible_users(), ids)
@@ -398,7 +398,9 @@ def get_phase_stats(user, ids):
                 (TRUE = %s OR b.user_id = ANY(%s::int[]))
                 AND a.run_id = ANY(%s::uuid[])
             ORDER BY
-                b.created_at ASC -- Must be same order as in get_comparison_details
+                -- at least the run_ids must be same order as get_comparsion_details so that the order in the comparison bar charts aligns with the comparsion_details array
+                b.created_at ASC,
+                a.id ASC
             """
     params = (user.is_super_user(), user.visible_users(), ids)
     return DB().fetch_all(query, params=params)

--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -386,7 +386,8 @@ def determine_comparison_case(user, ids):
 def get_phase_stats(user, ids):
     query = """
             SELECT
-                a.phase, a.metric, a.detail_name, a.value, a.type, a.max_value, a.min_value, a.unit,
+                a.phase, a.metric, a.detail_name, a.value, a.type, a.max_value, a.min_value,
+                a.sampling_resolution_avg, a.sampling_resolution_max, a.sampling_resolution_95p, a.unit,
                 b.uri, c.description, b.filename, b.commit_hash, b.branch,
                 b.id
             FROM phase_stats as a
@@ -505,7 +506,8 @@ def get_phase_stats_object(phase_stats, case=None, comparison_details=None, comp
 
     for phase_stat in phase_stats:
         [
-            phase, metric_name, detail_name, value, metric_type, max_value, min_value, unit,
+            phase, metric_name, detail_name, value, metric_type, max_value, min_value,
+            sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit,
             repo, machine_description, filename, commit_hash, branch,
             run_id
         ] = phase_stat
@@ -533,6 +535,9 @@ def get_phase_stats_object(phase_stats, case=None, comparison_details=None, comp
             phase_stats_object['data'][phase][metric_name] = {
                 'type': metric_type,
                 'unit': unit,
+                'sampling_resolution_avg': sampling_resolution_avg,
+                'sampling_resolution_max': sampling_resolution_max,
+                'sampling_resolution_95p': sampling_resolution_95p,
                 #'mean': None, # currently no use for that
                 #'stddev': None,  # currently no use for that
                 #'ci': None,  # currently no use for that

--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -387,7 +387,7 @@ def get_phase_stats(user, ids):
     query = """
             SELECT
                 a.phase, a.metric, a.detail_name, a.value, a.type, a.max_value, a.min_value,
-                a.sampling_resolution_avg, a.sampling_resolution_max, a.sampling_resolution_95p, a.unit,
+                a.sampling_rate_avg, a.sampling_rate_max, a.sampling_rate_95p, a.unit,
                 b.uri, c.description, b.filename, b.commit_hash, b.branch,
                 b.id
             FROM phase_stats as a
@@ -507,7 +507,7 @@ def get_phase_stats_object(phase_stats, case=None, comparison_details=None, comp
     for phase_stat in phase_stats:
         [
             phase, metric_name, detail_name, value, metric_type, max_value, min_value,
-            sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit,
+            sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit,
             repo, machine_description, filename, commit_hash, branch,
             run_id
         ] = phase_stat
@@ -535,9 +535,9 @@ def get_phase_stats_object(phase_stats, case=None, comparison_details=None, comp
             phase_stats_object['data'][phase][metric_name] = {
                 'type': metric_type,
                 'unit': unit,
-                'sampling_resolution_avg': sampling_resolution_avg,
-                'sampling_resolution_max': sampling_resolution_max,
-                'sampling_resolution_95p': sampling_resolution_95p,
+                'sr_avg': sampling_rate_avg,
+                'sr_max': sampling_rate_max,
+                'sr_95p': sampling_rate_95p,
                 #'mean': None, # currently no use for that
                 #'stddev': None,  # currently no use for that
                 #'ci': None,  # currently no use for that

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -172,9 +172,9 @@ CREATE TABLE phase_stats (
     type text NOT NULL,
     max_value bigint,
     min_value bigint,
-    sampling_resolution_avg DOUBLE PRECISION NOT NULL,
-    sampling_resolution_max DOUBLE PRECISION NOT NULL,
-    sampling_resolution_95p DOUBLE PRECISION NOT NULL,
+    sampling_rate_avg DOUBLE PRECISION NOT NULL,
+    sampling_rate_max DOUBLE PRECISION NOT NULL,
+    sampling_rate_95p DOUBLE PRECISION NOT NULL,
     unit text NOT NULL,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -112,27 +112,27 @@ CREATE TRIGGER runs_moddatetime
     EXECUTE PROCEDURE moddatetime (updated_at);
 
 
-CREATE TABLE measurements (
+CREATE TABLE measurement_metrics (
     id SERIAL PRIMARY KEY,
-    run_id uuid NOT NULL REFERENCES runs(id) ON DELETE CASCADE ON UPDATE CASCADE ,
-    detail_name text NOT NULL,
+    run_id uuid NOT NULL REFERENCES runs(id) ON DELETE CASCADE ON UPDATE CASCADE,
     metric text NOT NULL,
-    value bigint NOT NULL,
-    resolution_avg DOUBLE PRECISION NOT NULL,
-    resolution_max DOUBLE PRECISION NOT NULL,
-    resolution_95p DOUBLE PRECISION NOT NULL,
-    unit text NOT NULL,
-    time bigint NOT NULL,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone
+    detail_name text NOT NULL,
+    unit text NOT NULL
 );
-CREATE UNIQUE INDEX measurements_get ON measurements(run_id ,metric ,detail_name ,time );
-CREATE INDEX measurements_build_and_store_phase_stats ON measurements(run_id, metric, unit, detail_name);
-CREATE INDEX measurements_build_phases ON measurements(metric, unit, detail_name);
-CREATE TRIGGER measurements_moddatetime
-    BEFORE UPDATE ON measurements
-    FOR EACH ROW
-    EXECUTE PROCEDURE moddatetime (updated_at);
+
+CREATE UNIQUE INDEX measurement_metrics_get ON measurement_metrics(run_id,metric,detail_name); -- technically we could allow also different units, but we want to see the use case for that first
+CREATE INDEX measurement_metrics_build_and_store_phase_stats ON measurement_metrics(run_id,metric,detail_name,unit);
+CREATE INDEX measurement_metrics_build_phases ON measurement_metrics(metric,detail_name,unit);
+
+CREATE TABLE measurement_values (
+    measurement_metric_id int NOT NULL REFERENCES measurement_metrics(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    value bigint NOT NULL,
+    time bigint NOT NULL
+);
+
+CREATE INDEX measurement_values_mmid ON measurement_values(measurement_metric_id);
+CREATE UNIQUE INDEX measurement_values_unique ON measurement_values(measurement_metric_id, time);
+
 
 CREATE TABLE network_intercepts (
     id SERIAL PRIMARY KEY,
@@ -172,6 +172,9 @@ CREATE TABLE phase_stats (
     type text NOT NULL,
     max_value bigint,
     min_value bigint,
+    sampling_resolution_avg DOUBLE PRECISION NOT NULL,
+    sampling_resolution_max DOUBLE PRECISION NOT NULL,
+    sampling_resolution_95p DOUBLE PRECISION NOT NULL,
     unit text NOT NULL,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -238,10 +238,10 @@ CREATE TRIGGER ci_measurements_moddatetime
 
 CREATE TABLE client_status (
     id SERIAL PRIMARY KEY,
-	status_code TEXT NOT NULL,
-	machine_id int REFERENCES machines(id) ON DELETE RESTRICT ON UPDATE CASCADE,
-	"data" TEXT,
-	run_id uuid REFERENCES runs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    status_code TEXT NOT NULL,
+    machine_id int REFERENCES machines(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    "data" TEXT,
+    run_id uuid REFERENCES runs(id) ON DELETE CASCADE ON UPDATE CASCADE,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone
 );

--- a/frontend/js/helpers/config.js.example
+++ b/frontend/js/helpers/config.js.example
@@ -14,6 +14,17 @@ ACTIVATE_POWER_HOG = __ACTIVATE_POWER_HOG__;
 METRIC_MAPPINGS = {
 
 
+    'disk_total_bytesread_powermetrics_vm': {
+        'clean_name': 'Disk Total (Read)',
+        'source': 'powermetrics',
+        'explanation': 'Disk Total bytes read',
+    },
+    'disk_total_byteswritten_powermetrics_vm': {
+        'clean_name': 'Disk Total (Write)',
+        'source': 'powermetrics',
+        'explanation': 'Disk total bytes written',
+    },
+
     'disk_used_statvfs_system': {
         'clean_name': 'Disk Usage',
         'source': 'statvfs syscall',
@@ -248,14 +259,14 @@ METRIC_MAPPINGS = {
         'explanation': 'Effective execution time of the CPU for all cores combined',
     },
     'disk_io_bytesread_powermetrics_vm': {
-        'clean_name': 'Bytes read (HDD/SDD)',
+        'clean_name': 'Disk I/O (Read)',
         'source': 'powermetrics',
-        'explanation': 'Effective execution time of the CPU for all cores combined',
+        'explanation': 'Disk I/O - Bytes read per second for SDD/HDD',
     },
     'disk_io_byteswritten_powermetrics_vm': {
-        'clean_name': 'Bytes written (HDD/SDD)',
+        'clean_name': 'Disk I/O (Write)',
         'source': 'powermetrics',
-        'explanation': 'Effective execution time of the CPU for all cores combined',
+        'explanation': 'Disk I/O - Bytes written per second for SDD/HDD',
     },
     'energy_impact_powermetrics_vm': {
         'clean_name': 'Energy impact',

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -248,7 +248,7 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
             <td>${unit}</td>
             <td>${max_value}</td>
             <td>${min_value}</td>
-            <td>${metric_data.sampling_resolution_avg.toFixed(0)} / ${metric_data.sampling_resolution_95p.toFixed(0)} / ${metric_data.sampling_resolution_max.toFixed(0)} ms</td>`;
+            <td>${metric_data.sr_avg.toFixed(0)} / ${metric_data.sr_95p.toFixed(0)} / ${metric_data.sr_max.toFixed(0)} ms</td>`;
     }
 
 

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -247,7 +247,8 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
             <td>${value}</td>
             <td>${unit}</td>
             <td>${max_value}</td>
-            <td>${min_value}</td>`;
+            <td>${min_value}</td>
+            <td>${metric_data.sampling_resolution_avg.toFixed(0)} / ${metric_data.sampling_resolution_95p.toFixed(0)} / ${metric_data.sampling_resolution_max.toFixed(0)} ms</td>`;
     }
 
 

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -235,7 +235,8 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
             <td>${max_value}</td>
             <td>${min_value}</td>
             <td>${max_mean_value}</td>
-            <td>${min_mean_value}</td>`;
+            <td>${min_mean_value}</td>
+            <td>${detail_data.sr_avg_avg.toFixed(0)} / ${detail_data.sr_95p_max.toFixed(0)} / ${detail_data.sr_max_max.toFixed(0)} ms</td>`;
 
     } else {
         tr.innerHTML = `
@@ -248,7 +249,7 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
             <td>${unit}</td>
             <td>${max_value}</td>
             <td>${min_value}</td>
-            <td>${metric_data.sr_avg.toFixed(0)} / ${metric_data.sr_95p.toFixed(0)} / ${metric_data.sr_max.toFixed(0)} ms</td>`;
+            <td>${detail_data.sr_avg_avg.toFixed(0)} / ${detail_data.sr_95p_max.toFixed(0)} / ${detail_data.sr_max_max.toFixed(0)} ms</td>`;
     }
 
 

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -12,7 +12,8 @@ const createTableHeader = (phase, comparison_keys, comparison_case, comparison_a
             <th><span class="overflow-ellipsis" style="width: 100px; display:block;" title="${comparison_keys[1]}">${replaceRepoIcon(comparison_keys[1])}</span></th>
             <th>Unit</th>
             <th>Change</th>
-            <th>Significant (T-Test)</th>`;
+            <th>Significant (T-Test)</th>
+            <th><span data-position="bottom left" data-inverted="" data-tooltip="Achieved sampling rate (Mean of means, max of 95p and max of max)"><i class="question circle icon"></i> SR (Ø/95p/max)</span></th>`;
     } else if(comparison_case !== null) {
         tr.innerHTML = `
             <th>Metric</th>
@@ -25,8 +26,9 @@ const createTableHeader = (phase, comparison_keys, comparison_case, comparison_a
             <th>StdDev</th>
             <th>Max.</th>
             <th>Min.</th>
-            <th>Max. (of means)</th>
-            <th>Min. (of means)</th>`;
+            <th><i class="question circle icon"></i> Max. (Ø)</th>
+            <th><i class="question circle icon"></i> Min. (Ø)</th>
+            <th><span data-position="bottom left" data-inverted="" data-tooltip="Achieved sampling rate (Mean of means, max of 95p and max of max)"><i class="question circle icon"></i> SR (Ø/95p/max)</span></th>`;
     } else {
         tr.innerHTML = `
             <th>Metric</th>

--- a/frontend/js/helpers/phase-stats.js
+++ b/frontend/js/helpers/phase-stats.js
@@ -37,7 +37,8 @@ const createTableHeader = (phase, comparison_keys, comparison_case, comparison_a
             <th>Value</th>
             <th>Unit</th>
             <th>Max.</th>
-            <th>Min.</th>`;
+            <th>Min.</th>
+            <th><span data-position="bottom left" data-inverted="" data-tooltip="Achieved sampling rate"><i class="question circle icon"></i>SR (mean/95p/max)</span></th>`;
     }
 }
 

--- a/lib/metric_importer.py
+++ b/lib/metric_importer.py
@@ -3,23 +3,6 @@ from io import StringIO
 from lib.db import DB
 from metric_providers.network.connections.tcpdump.system.provider import generate_stats_string
 
-def import_measurements_new(df, metric_name, run_id):
-
-    df['measurement_metric_id'] = None # prepare
-    detail_names = df[['detail_name', 'unit']].drop_duplicates()
-
-    for _, row in detail_names.iterrows():
-        measurement_metric_id = DB().fetch_one('''
-            INSERT INTO measurement_metrics (run_id, metric, detail_name, unit)
-            VALUES (%s, %s, %s, %s)
-            RETURNING id
-        ''', params=(run_id, metric_name, row['detail_name'], row['unit']))[0]
-        df.loc[(df['detail_name'] == row['detail_name']) & (df['unit'] == row['unit']), 'measurement_metric_id'] = measurement_metric_id
-
-    f = StringIO(df[['measurement_metric_id', 'value', 'time']]
-        .to_csv(index=False, header=False))
-    DB().copy_from(file=f, table='measurement_values', columns=['measurement_metric_id', 'value', 'time'], sep=',')
-    f.close()
 
 def import_measurements(df, metric_name, run_id, containers=None):
 
@@ -44,8 +27,23 @@ def import_measurements(df, metric_name, run_id, containers=None):
 
         df['run_id'] = run_id
 
-        f = StringIO(df.to_csv(index=False, header=False))
-        DB().copy_from(file=f, table='measurements', columns=df.columns, sep=',')
+        metric_and_detail_names = df[['metric', 'detail_name', 'unit']].drop_duplicates()
+
+        for _, row in metric_and_detail_names.iterrows():
+            measurement_metric_id = DB().fetch_one('''
+                INSERT INTO measurement_metrics (run_id, metric, detail_name, unit)
+                VALUES (%s, %s, %s, %s)
+                RETURNING id
+            ''', params=(run_id, row['metric'], row['detail_name'], row['unit']))[0] # using row['metric'] here instead of metric_name, as some providers have multiple metrics inlined like powermetrics
+            df.loc[(df['metric'] == row['metric']) & (df['detail_name'] == row['detail_name']) & (df['unit'] == row['unit']), 'measurement_metric_id'] = measurement_metric_id
+
+        df['measurement_metric_id'] = df.measurement_metric_id.astype(int)
+
+        f = StringIO(df[['measurement_metric_id', 'value', 'time']]
+            .to_csv(index=False, header=False))
+
+        DB().copy_from(file=f, table='measurement_values', columns=['measurement_metric_id', 'value', 'time'], sep=',')
+
         f.close()
 
 def map_container_id_to_detail_name(df, containers):

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -12,8 +12,8 @@ from lib.global_config import GlobalConfig
 from lib.db import DB
 from lib import error_helpers
 
-def generate_csv_line(run_id, metric, detail_name, phase_name, value, value_type, max_value, min_value, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit):
-    return f"{run_id},{metric},{detail_name},{phase_name},{round(value)},{value_type},{round(max_value) if max_value is not None else ''},{round(min_value) if min_value is not None else ''},{sampling_resolution_avg},{sampling_resolution_max},{sampling_resolution_95p},{unit},NOW()\n"
+def generate_csv_line(run_id, metric, detail_name, phase_name, value, value_type, max_value, min_value, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit):
+    return f"{run_id},{metric},{detail_name},{phase_name},{round(value)},{value_type},{round(max_value) if max_value is not None else ''},{round(min_value) if min_value is not None else ''},{sampling_rate_avg},{sampling_rate_max},{sampling_rate_95p},{unit},NOW()\n"
 
 def build_and_store_phase_stats(run_id, sci=None):
     config = GlobalConfig().config
@@ -70,9 +70,9 @@ def build_and_store_phase_stats(run_id, sci=None):
                 WHERE measurement_metric_id = %s AND time > %s and time < %s
             )
             SELECT SUM(value), MAX(value), MIN(value), AVG(value), COUNT(value),
-                COALESCE(AVG(diff), 0)/1000.0 as sampling_resolution_avg,
-                COALESCE(MAX(diff), 0)/1000.0 as sampling_resolution_max,
-                COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY diff), 0)/1000.0 AS sampling_resolution_95p
+                COALESCE(AVG(diff), 0)/1000.0 as sampling_rate_avg,
+                COALESCE(MAX(diff), 0)/1000.0 as sampling_rate_max,
+                COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY diff), 0)/1000.0 AS sampling_rate_95p
             FROM lag_table
         """
 
@@ -99,7 +99,7 @@ def build_and_store_phase_stats(run_id, sci=None):
             avg_value = 0
             value_count = 0
 
-            value_sum, max_value, min_value, avg_value, value_count, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p = results
+            value_sum, max_value, min_value, avg_value, value_count, sampling_rate_avg, sampling_rate_max, sampling_rate_95p = results
 
             # no need to calculate if we have no results to work on
             # This can happen if the phase is too short
@@ -117,7 +117,7 @@ def build_and_store_phase_stats(run_id, sci=None):
                 'disk_used_statvfs_system',
                 'cpu_frequency_sysfs_core',
             ):
-                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", avg_value, 'MEAN', max_value, min_value, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit))
+                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", avg_value, 'MEAN', max_value, min_value, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit))
 
                 if metric in ('cpu_utilization_procfs_system', 'cpu_utilization_mach_system'):
                     cpu_utilization_machine = avg_value
@@ -127,27 +127,27 @@ def build_and_store_phase_stats(run_id, sci=None):
             elif metric in ['network_io_cgroup_container', 'network_io_procfs_system', 'disk_io_procfs_system', 'disk_io_cgroup_container', 'disk_io_bytesread_powermetrics_vm', 'disk_io_byteswritten_powermetrics_vm']:
                 # I/O values should be per second. However we have very different timing intervals.
                 # So we do not directly use the average here, as this would be the average per sampling frequency. We go through the duration
-                provider_conversion_factor_to_s = decimal.Decimal(sampling_resolution_avg/1_000_000)
-                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", avg_value/provider_conversion_factor_to_s, 'MEAN', max_value/provider_conversion_factor_to_s, min_value/provider_conversion_factor_to_s, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, f"{unit}/s"))
+                provider_conversion_factor_to_s = decimal.Decimal(sampling_rate_avg/1_000_000)
+                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", avg_value/provider_conversion_factor_to_s, 'MEAN', max_value/provider_conversion_factor_to_s, min_value/provider_conversion_factor_to_s, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, f"{unit}/s"))
 
                 # we also generate a total line to see how much total data was processed
-                csv_buffer.write(generate_csv_line(run_id, metric.replace('_io_', '_total_'), detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', None, None, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit))
+                csv_buffer.write(generate_csv_line(run_id, metric.replace('_io_', '_total_'), detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', None, None, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit))
 
                 if metric == 'network_io_cgroup_container': # save to calculate CO2 later. We do this only for the cgroups. Not for the system to not double count
                     network_bytes_total.append(value_sum)
 
             elif "_energy_" in metric and unit == 'mJ':
-                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', None, None, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit))
+                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', None, None, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit))
                 # for energy we want to deliver an extra value, the watts.
                 # Here we need to calculate the average differently
                 power_avg = (value_sum * 10**6) / duration
                 power_max = (max_value * 10**6) / (duration / value_count)
                 power_min = (min_value * 10**6) / (duration / value_count)
-                csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_avg, 'MEAN', power_max, power_min, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, 'mW'))
+                csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_avg, 'MEAN', power_max, power_min, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, 'mW'))
 
                 if metric.endswith('_machine') and sci.get('I', None) is not None:
                     machine_carbon_in_ug = decimal.Decimal((value_sum / 3_600) * sci['I'])
-                    csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_carbon_')}", detail_name, f"{idx:03}_{phase['name']}", machine_carbon_in_ug, 'TOTAL', None, None, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, 'ug'))
+                    csv_buffer.write(generate_csv_line(run_id, f"{metric.replace('_energy_', '_carbon_')}", detail_name, f"{idx:03}_{phase['name']}", machine_carbon_in_ug, 'TOTAL', None, None, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, 'ug'))
 
                     if phase['name'] == '[BASELINE]':
                         machine_power_baseline = power_avg
@@ -158,7 +158,7 @@ def build_and_store_phase_stats(run_id, sci=None):
             else: # Default
                 if metric not in ('cpu_time_powermetrics_vm', ):
                     error_helpers.log_error('Unmapped phase_stat found, using default', metric=metric, detail_name=detail_name, run_id=run_id)
-                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', max_value, min_value, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, unit))
+                csv_buffer.write(generate_csv_line(run_id, metric, detail_name, f"{idx:03}_{phase['name']}", value_sum, 'TOTAL', max_value, min_value, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit))
 
         # after going through detail metrics, create cumulated ones
         if network_bytes_total:
@@ -205,6 +205,6 @@ def build_and_store_phase_stats(run_id, sci=None):
         csv_buffer,
         table='phase_stats',
         sep=',',
-        columns=('run_id', 'metric', 'detail_name', 'phase', 'value', 'type', 'max_value', 'min_value', 'sampling_resolution_avg', 'sampling_resolution_max', 'sampling_resolution_95p', 'unit', 'created_at')
+        columns=('run_id', 'metric', 'detail_name', 'phase', 'value', 'type', 'max_value', 'min_value', 'sampling_rate_avg', 'sampling_rate_max', 'sampling_rate_95p', 'unit', 'created_at')
     )
     csv_buffer.close()  # Close the buffer

--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -142,16 +142,16 @@ class BaseMetricProvider:
         excluded_columns = ['time', 'value']
         grouping_columms = [col for col in df.columns if col not in excluded_columns]
         df['effective_resolution'] = df.groupby(grouping_columms)['time'].diff()
-        df['resolution_max'] = df.groupby(grouping_columms)['effective_resolution'].transform('max')
-        df['resolution_avg'] = df.groupby(grouping_columms)['effective_resolution'].transform('mean')
-        df['resolution_95p'] = df.groupby(grouping_columms)['effective_resolution'].transform(lambda x: x.quantile(0.95))
+        df['sampling_resolution_max'] = df.groupby(grouping_columms)['effective_resolution'].transform('max')
+        df['sampling_resolution_avg'] = df.groupby(grouping_columms)['effective_resolution'].transform('mean')
+        df['sampling_resolution_95p'] = df.groupby(grouping_columms)['effective_resolution'].transform(lambda x: x.quantile(0.95))
         df = df.drop('effective_resolution', axis=1)
 
-        if (resolution_95p := df['resolution_95p'].max()) >= self._resolution*1000*1.2:
-            raise RuntimeError(f"Resolution 95p was absurdly high: {resolution_95p} compared to base resolution of {self._resolution*1000}", df)
+        if (resolution_95p := df['sampling_resolution_95p'].max()) >= self._resolution*1000*1.2:
+            raise RuntimeError(f"Effective sampling resolution (95p) was absurdly high: {resolution_95p} compared to target resolution of {self._resolution*1000}", df)
 
-        if (resolution_95p := df['resolution_95p'].min()) <= self._resolution*1000*0.8:
-            raise RuntimeError(f"Resolution 95p was absurdly low: {resolution_95p} compared to base resolution of {self._resolution*1000}", df)
+        if (resolution_95p := df['sampling_resolution_95p'].min()) <= self._resolution*1000*0.8:
+            raise RuntimeError(f"Effective sampling resolution (95p) was absurdly low: {resolution_95p} compared to target resolution of {self._resolution*1000}", df)
 
 
         return df

--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -141,16 +141,16 @@ class BaseMetricProvider:
         # for most metric providers only detail_name and container_id should be present and differ though
         excluded_columns = ['time', 'value']
         grouping_columms = [col for col in df.columns if col not in excluded_columns]
-        df['effective_resolution'] = df.groupby(grouping_columms)['time'].diff()
-        df['sampling_resolution_max'] = df.groupby(grouping_columms)['effective_resolution'].transform('max')
-        df['sampling_resolution_avg'] = df.groupby(grouping_columms)['effective_resolution'].transform('mean')
-        df['sampling_resolution_95p'] = df.groupby(grouping_columms)['effective_resolution'].transform(lambda x: x.quantile(0.95))
-        df = df.drop('effective_resolution', axis=1)
+        df['sampling_rate'] = df.groupby(grouping_columms)['time'].diff()
+        df['sampling_rate_max'] = df.groupby(grouping_columms)['sampling_rate'].transform('max')
+        df['sampling_rate_avg'] = df.groupby(grouping_columms)['sampling_rate'].transform('mean')
+        df['sampling_rate_95p'] = df.groupby(grouping_columms)['sampling_rate'].transform(lambda x: x.quantile(0.95))
+        df = df.drop('sampling_rate', axis=1)
 
-        if (resolution_95p := df['sampling_resolution_95p'].max()) >= self._resolution*1000*1.2:
+        if (resolution_95p := df['sampling_rate_95p'].max()) >= self._resolution*1000*1.2:
             raise RuntimeError(f"Effective sampling resolution (95p) was absurdly high: {resolution_95p} compared to target resolution of {self._resolution*1000}", df)
 
-        if (resolution_95p := df['sampling_resolution_95p'].min()) <= self._resolution*1000*0.8:
+        if (resolution_95p := df['sampling_rate_95p'].min()) <= self._resolution*1000*0.8:
             raise RuntimeError(f"Effective sampling resolution (95p) was absurdly low: {resolution_95p} compared to target resolution of {self._resolution*1000}", df)
 
 

--- a/migrations/2024_12_24_measurement_table_split.sql
+++ b/migrations/2024_12_24_measurement_table_split.sql
@@ -1,0 +1,44 @@
+CREATE TABLE measurement_metrics (
+    id SERIAL PRIMARY KEY,
+    run_id uuid NOT NULL REFERENCES runs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    metric text NOT NULL,
+    detail_name text NOT NULL,
+    unit text NOT NULL
+);
+
+CREATE UNIQUE INDEX measurement_metrics_get ON measurement_metrics(run_id,metric,detail_name);
+CREATE INDEX measurement_metrics_build_and_store_phase_stats ON measurement_metrics(run_id,metric,detail_name,unit);
+CREATE INDEX measurement_metrics_build_phases ON measurement_metrics(metric,detail_name,unit);
+
+CREATE TABLE measurement_values (
+    measurement_metric_id int NOT NULL REFERENCES measurement_metrics(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    value bigint NOT NULL,
+    time bigint NOT NULL
+);
+
+CREATE INDEX measurement_values_mmid ON measurement_values(measurement_metric_id);
+CREATE UNIQUE INDEX measurement_values_unique ON measurement_values(measurement_metric_id, time);
+
+INSERT INTO measurement_metrics (run_id, metric, detail_name, unit)
+SELECT DISTINCT run_id, metric, detail_name, unit
+FROM measurements;
+
+INSERT INTO measurement_values (measurement_metric_id, value, time)
+SELECT 
+    mm.id AS measurement_metric_id,
+    m.value,
+    m.time
+FROM 
+    measurements m
+JOIN 
+    measurement_metrics mm
+ON 
+    m.run_id = mm.run_id
+    AND m.metric = mm.metric
+    AND m.detail_name = mm.detail_name
+    AND m.unit = mm.unit;
+
+ALTER TABLE phase_stats
+    ADD COLUMN "sampling_resolution_avg" DOUBLE PRECISION NOT NULL,
+    ADD COLUMN "sampling_resolution_max" DOUBLE PRECISION NOT NULL,
+    ADD COLUMN "sampling_resolution_95p" DOUBLE PRECISION NOT NULL;

--- a/migrations/2024_12_24_measurement_table_split.sql
+++ b/migrations/2024_12_24_measurement_table_split.sql
@@ -39,6 +39,6 @@ ON
     AND m.unit = mm.unit;
 
 ALTER TABLE phase_stats
-    ADD COLUMN "sampling_resolution_avg" DOUBLE PRECISION NOT NULL,
-    ADD COLUMN "sampling_resolution_max" DOUBLE PRECISION NOT NULL,
-    ADD COLUMN "sampling_resolution_95p" DOUBLE PRECISION NOT NULL;
+    ADD COLUMN "sampling_rate_avg" DOUBLE PRECISION NOT NULL,
+    ADD COLUMN "sampling_rate_max" DOUBLE PRECISION NOT NULL,
+    ADD COLUMN "sampling_rate_95p" DOUBLE PRECISION NOT NULL;

--- a/runner.py
+++ b/runner.py
@@ -1329,6 +1329,7 @@ class Runner:
                 errors.append(f"Stderr on {metric_provider.__class__.__name__} was NOT empty: {stderr_read}")
 
             # pylint: disable=broad-exception-caught
+            # we definitely want to first try to stop all providers and then fail
             try:
                 metric_provider.stop_profiling()
             except Exception as exc:

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -205,27 +205,36 @@ def test_stats():
     assert chart_label.strip() == 'CPU % via procfs'
 
 
-    first_metric = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(1)").text_content()
-    assert first_metric.strip() == 'Machine Power'
+    first_metric = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(1) > td:nth-child(1)").text_content()
+    assert first_metric.strip() == 'Phase Duration'
 
-    first_value = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(6)").text_content()
-    assert first_value.strip() == '14.62'
+    first_value = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(1) > td:nth-child(6)").text_content()
+    assert first_value.strip() == '5.20'
 
-    first_unit = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(7)").text_content()
-    assert first_unit.strip() == 'W'
+    first_unit = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(1) > td:nth-child(7)").text_content()
+    assert first_unit.strip() == 's'
+
+    machine_power_metric = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(10) > td:nth-child(1)").text_content()
+    assert machine_power_metric.strip() == 'Machine Power'
+
+    machine_power_value = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(10) > td:nth-child(6)").text_content()
+    assert machine_power_value.strip() == '14.62'
+
+    machine_power_unit = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(10) > td:nth-child(7)").text_content()
+    assert machine_power_unit.strip() == 'W'
 
 
     # click on baseline
     new_page.locator('a.step[data-tab="[BASELINE]"]').click()
     new_page.locator('div[data-tab="[BASELINE]"] .ui.accordion .title > a').click()
 
-    first_metric = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(1) > td:nth-child(1)").text_content()
+    first_metric = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(8) > td:nth-child(1)").text_content()
     assert first_metric.strip() == 'Embodied Carbon'
 
-    first_value = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(1) > td:nth-child(6)").text_content()
+    first_value = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(8) > td:nth-child(6)").text_content()
     assert first_value.strip() == '0.01'
 
-    first_unit = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(1) > td:nth-child(7)").text_content()
+    first_unit = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(8) > td:nth-child(7)").text_content()
     assert first_unit.strip() == 'g'
 
     new_page.close()
@@ -258,34 +267,34 @@ def test_repositories_and_compare():
     new_page.locator('a.step[data-tab="[RUNTIME]"]').click()
     new_page.locator('#runtime-steps phase-metrics .ui.accordion .title > a').first.click()
 
-    first_metric = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(13) > td:nth-child(1)").text_content()
+    first_metric = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(3) > td:nth-child(1)").text_content()
     assert first_metric.strip() == 'CPU Power (Package)'
 
-    first_value = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(13) > td:nth-child(6)").text_content()
-    assert first_value.strip() == '8.50'
+    first_value = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(3) > td:nth-child(6)").text_content()
+    assert first_value.strip() == '8.58'
 
-    first_unit = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(13) > td:nth-child(7)").text_content()
+    first_unit = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(3) > td:nth-child(7)").text_content()
     assert first_unit.strip() == 'W'
 
-    first_stddev = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(13) > td:nth-child(8)").text_content()
-    assert first_stddev.strip() == '± 2.85%'
+    first_stddev = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(3) > td:nth-child(8)").text_content()
+    assert first_stddev.strip() == '± 2.21%'
 
 
     # click on baseline
     new_page.locator('a.step[data-tab="[BASELINE]"]').click()
     new_page.locator('div[data-tab="[BASELINE]"] .ui.accordion a').click()
 
-    first_metric = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(1)").text_content()
+    first_metric = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(1)").text_content()
     assert first_metric.strip() == 'CPU Energy (Package)'
 
-    first_value = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(6)").text_content()
-    assert first_value.strip() == '9.21'
+    first_value = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(6)").text_content()
+    assert first_value.strip() == '8.91'
 
-    first_unit = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(7)").text_content()
+    first_unit = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(7)").text_content()
     assert first_unit.strip() == 'J'
 
-    first_stddev = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(7) > td:nth-child(8)").text_content()
-    assert first_stddev.strip() == '± 13.53%'
+    first_stddev = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(8)").text_content()
+    assert first_stddev.strip() == '± 13.68%'
 
     new_page.close()
 

--- a/tests/lib/test_metric_importer.py
+++ b/tests/lib/test_metric_importer.py
@@ -8,54 +8,42 @@ def test_import_cpu_utilization():
     run_id = Tests.insert_run()
     measurement_lines = Tests.import_cpu_utilization(run_id)
 
-    results = DB().fetch_all('SELECT COUNT(*), AVG(value), MAX(resolution_avg), MAX(resolution_max), MAX(resolution_95p) FROM measurements GROUP BY metric, detail_name, unit')
+    results = DB().fetch_all('SELECT COUNT(mm.id), AVG(mv.value) FROM measurement_metrics as mm JOIN measurement_values as mv ON mv.measurement_metric_id = mm.id GROUP BY metric, detail_name, unit')
 
     assert len(results) == 2, 'Too many entries in table'
 
-
-
     result = results[0]
     assert result[0] == len(measurement_lines)/2 # since we group, length mus be divided by groups
-    assert math.isclose(result[1], 3958.59401, rel_tol=1e-5), 'AVG value not in expected range'
-    assert math.isclose(result[2], 99373.57636, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(result[3], 100688.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(result[4],  99696.0, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(result[1], 1985.44716, rel_tol=1e-5), 'AVG value not in expected range'
 
     result = results[1]
     assert result[0] == len(measurement_lines)/2 # since we group, length mus be divided by groups
-    assert math.isclose(result[1], 1985.44716, rel_tol=1e-5), 'AVG value not in expected range'
-    assert math.isclose(result[2], 99373.57636, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(result[3], 100688.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(result[4],  99696.0, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(result[1], 3958.59401, rel_tol=1e-5), 'AVG value not in expected range'
+
 
 def test_import_machine_energy():
 
     run_id = Tests.insert_run()
     measurement_lines = Tests.import_machine_energy(run_id)
 
-    results = DB().fetch_all('SELECT COUNT(*), AVG(value), MAX(resolution_avg), MAX(resolution_max), MAX(resolution_95p) FROM measurements GROUP BY metric, detail_name, unit')
+    results = DB().fetch_all('SELECT COUNT(mm.id), AVG(mv.value) FROM measurement_metrics as mm JOIN measurement_values as mv ON mv.measurement_metric_id = mm.id GROUP BY metric, detail_name, unit')
 
     assert len(results) == 1, 'Too many entries in table'
     result = results[0]
 
     assert result[0] == len(measurement_lines)
     assert math.isclose(result[1], 2921.3863, rel_tol=1e-5), 'AVG value not in expected range'
-    assert math.isclose(result[2], 101673.76957, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(result[3], 107613.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(result[4], 104670.55, rel_tol=1e-5), '95p resolution was not in expected range'
+
 
 def test_import_cpu_energy():
 
     run_id = Tests.insert_run()
     measurement_lines = Tests.import_cpu_energy(run_id)
 
-    results = DB().fetch_all('SELECT COUNT(*), AVG(value), MAX(resolution_avg), MAX(resolution_max), MAX(resolution_95p) FROM measurements GROUP BY metric, detail_name, unit')
+    results = DB().fetch_all('SELECT COUNT(mm.id), AVG(mv.value) FROM measurement_metrics as mm JOIN measurement_values as mv ON mv.measurement_metric_id = mm.id GROUP BY metric, detail_name, unit')
 
     assert len(results) == 1, 'Too many entries in table'
     result = results[0]
 
     assert result[0] == len(measurement_lines)
     assert math.isclose(result[1], 1194.5976, rel_tol=1e-5), 'AVG value not in expected range'
-    assert math.isclose(result[2], 99216.78038, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(result[3], 107827.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(result[4], 99486.0, rel_tol=1e-5), '95p resolution was not in expected range'

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -16,7 +16,7 @@ def test_phase_stats_single_energy():
 
     build_and_store_phase_stats(run_id)
 
-    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_rate_avg, sampling_rate_max, sampling_rate_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 3
     assert data[0]['metric'] == 'phase_time_syscall_system'
@@ -24,9 +24,9 @@ def test_phase_stats_single_energy():
     assert data[0]['unit'] == 'us'
     assert data[0]['value'] == Tests.TEST_MEASUREMENT_END_TIME - Tests.TEST_MEASUREMENT_START_TIME
     assert data[0]['type'] == 'TOTAL'
-    assert math.isclose(data[0]['sampling_resolution_avg'], 0, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[0]['sampling_resolution_max'], 0.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[0]['sampling_resolution_95p'], 0.0, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[0]['sampling_rate_avg'], 0, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[0]['sampling_rate_max'], 0.0, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[0]['sampling_rate_95p'], 0.0, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 
     assert data[1]['metric'] == 'psu_energy_ac_mcp_machine'
@@ -34,18 +34,18 @@ def test_phase_stats_single_energy():
     assert data[1]['unit'] == 'mJ'
     assert data[1]['value'] == 13175452
     assert data[1]['type'] == 'TOTAL'
-    assert math.isclose(data[1]['sampling_resolution_avg'], 101.67376, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[1]['sampling_resolution_max'], 107.613, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[1]['sampling_resolution_95p'], 104.67055, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_rate_avg'], 101.67376, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[1]['sampling_rate_max'], 107.613, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[1]['sampling_rate_95p'], 104.67055, rel_tol=1e-5), '95p sampling rate not in expected range'
 
     assert data[2]['metric'] == 'psu_power_ac_mcp_machine'
     assert data[2]['detail_name'] == '[machine]'
     assert data[2]['unit'] == 'mW'
     assert data[2]['value'] == 28033
     assert data[2]['type'] == 'MEAN'
-    assert math.isclose(data[2]['sampling_resolution_avg'], 101.67376, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[2]['sampling_resolution_max'], 107.613, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[2]['sampling_resolution_95p'], 104.67055, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[2]['sampling_rate_avg'], 101.67376, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[2]['sampling_rate_max'], 107.613, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[2]['sampling_rate_95p'], 104.67055, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 
 def test_phase_stats_single_cgroup():
@@ -54,7 +54,7 @@ def test_phase_stats_single_cgroup():
 
     build_and_store_phase_stats(run_id)
 
-    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_rate_avg, sampling_rate_max, sampling_rate_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 3
     assert data[0]['metric'] == 'phase_time_syscall_system'
@@ -63,9 +63,9 @@ def test_phase_stats_single_cgroup():
     assert data[0]['value'] == Tests.TEST_MEASUREMENT_END_TIME - Tests.TEST_MEASUREMENT_START_TIME
     assert data[0]['type'] == 'TOTAL'
 
-    assert math.isclose(data[1]['sampling_resolution_avg'], 99.37357, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[1]['sampling_resolution_max'], 100.688, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[1]['sampling_resolution_95p'],  99.6960, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_rate_avg'], 99.37357, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[1]['sampling_rate_max'], 100.688, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[1]['sampling_rate_95p'],  99.6960, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 def test_phase_stats_multi():
     run_id = Tests.insert_run()
@@ -75,7 +75,7 @@ def test_phase_stats_multi():
 
     build_and_store_phase_stats(run_id)
 
-    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, phase FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, phase FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 7
     assert data[1]['metric'] == 'cpu_energy_rapl_msr_component'
@@ -84,9 +84,9 @@ def test_phase_stats_multi():
     assert data[1]['type'] == 'TOTAL'
     assert data[1]['unit'] == 'mJ'
     assert data[1]['detail_name'] == 'Package_0'
-    assert math.isclose(data[1]['sampling_resolution_avg'], 99.2167, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[1]['sampling_resolution_max'], 107.827, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[1]['sampling_resolution_95p'],  99.486, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_rate_avg'], 99.2167, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[1]['sampling_rate_max'], 107.827, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[1]['sampling_rate_95p'],  99.486, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 
     assert data[2]['metric'] == 'cpu_power_rapl_msr_component'
@@ -95,9 +95,9 @@ def test_phase_stats_multi():
     assert data[2]['type'] == 'MEAN'
     assert data[2]['unit'] == 'mW'
     assert data[2]['detail_name'] == 'Package_0'
-    assert math.isclose(data[2]['sampling_resolution_avg'], 99.2167, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[2]['sampling_resolution_max'], 107.827, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[2]['sampling_resolution_95p'],  99.486, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[2]['sampling_rate_avg'], 99.2167, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[2]['sampling_rate_max'], 107.827, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[2]['sampling_rate_95p'],  99.486, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 
     assert data[3]['metric'] == 'cpu_utilization_cgroup_container'
@@ -106,9 +106,9 @@ def test_phase_stats_multi():
     assert data[3]['type'] == 'MEAN'
     assert data[3]['unit'] == 'Ratio'
     assert data[3]['detail_name'] == 'Arne'
-    assert math.isclose(data[3]['sampling_resolution_avg'], 99.37357, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[3]['sampling_resolution_max'], 100.688, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[3]['sampling_resolution_95p'],  99.696, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[3]['sampling_rate_avg'], 99.37357, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[3]['sampling_rate_max'], 100.688, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[3]['sampling_rate_95p'],  99.696, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 
     assert data[4]['metric'] == 'cpu_utilization_cgroup_container'
@@ -117,9 +117,9 @@ def test_phase_stats_multi():
     assert data[4]['type'] == 'MEAN'
     assert data[4]['unit'] == 'Ratio'
     assert data[4]['detail_name'] == 'Not-Arne'
-    assert math.isclose(data[3]['sampling_resolution_avg'], 99.37357, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(data[3]['sampling_resolution_max'], 100.688, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(data[3]['sampling_resolution_95p'],  99.696, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(data[3]['sampling_rate_avg'], 99.37357, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(data[3]['sampling_rate_max'], 100.688, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(data[3]['sampling_rate_95p'],  99.696, rel_tol=1e-5), '95p sampling rate not in expected range'
 
 
 def test_phase_embodied_and_operational_carbon():
@@ -129,7 +129,7 @@ def test_phase_embodied_and_operational_carbon():
     sci = {"I":436,"R":0,"EL":4,"RS":1,"TE":181000,"R_d":"page request"}
     build_and_store_phase_stats(run_id, sci=sci)
 
-    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, phase FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, phase FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 5
 
@@ -156,6 +156,6 @@ def test_phase_embodied_and_operational_carbon():
     assert embodied_carbon_share_machine['value'] == embodied_carbon_expected
     assert embodied_carbon_share_machine['type'] == 'TOTAL'
 
-    assert math.isclose(embodied_carbon_share_machine['sampling_resolution_avg'], 0.0, rel_tol=1e-5), 'Resolution was not in expected range'
-    assert math.isclose(embodied_carbon_share_machine['sampling_resolution_max'], 0.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
-    assert math.isclose(embodied_carbon_share_machine['sampling_resolution_95p'],  0.0, rel_tol=1e-5), '95p resolution was not in expected range'
+    assert math.isclose(embodied_carbon_share_machine['sampling_rate_avg'], 0.0, rel_tol=1e-5), 'AVG sampling rate not in expected range'
+    assert math.isclose(embodied_carbon_share_machine['sampling_rate_max'], 0.0, rel_tol=1e-5), 'MAX sampling rate not in expected range'
+    assert math.isclose(embodied_carbon_share_machine['sampling_rate_95p'],  0.0, rel_tol=1e-5), '95p sampling rate not in expected range'

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -1,4 +1,5 @@
 import os
+import math
 
 GMT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))+'/../../'
 
@@ -9,13 +10,51 @@ from lib.phase_stats import build_and_store_phase_stats
 MILLIJOULES_TO_KWH = 2.77778e-10
 MICROJOULES_TO_KWH = 2.77778e-13
 
-def test_phase_stats_single():
+def test_phase_stats_single_energy():
     run_id = Tests.insert_run()
     Tests.import_machine_energy(run_id)
 
     build_and_store_phase_stats(run_id)
 
-    data = DB().fetch_all('SELECT * FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+
+    assert len(data) == 3
+    assert data[0]['metric'] == 'phase_time_syscall_system'
+    assert data[0]['detail_name'] == '[SYSTEM]'
+    assert data[0]['unit'] == 'us'
+    assert data[0]['value'] == Tests.TEST_MEASUREMENT_END_TIME - Tests.TEST_MEASUREMENT_START_TIME
+    assert data[0]['type'] == 'TOTAL'
+    assert math.isclose(data[0]['sampling_resolution_avg'], 0, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[0]['sampling_resolution_max'], 0.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[0]['sampling_resolution_95p'], 0.0, rel_tol=1e-5), '95p resolution was not in expected range'
+
+
+    assert data[1]['metric'] == 'psu_energy_ac_mcp_machine'
+    assert data[1]['detail_name'] == '[machine]'
+    assert data[1]['unit'] == 'mJ'
+    assert data[1]['value'] == 13175452
+    assert data[1]['type'] == 'TOTAL'
+    assert math.isclose(data[1]['sampling_resolution_avg'], 101.67376, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_resolution_max'], 107.613, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_resolution_95p'], 104.67055, rel_tol=1e-5), '95p resolution was not in expected range'
+
+    assert data[2]['metric'] == 'psu_power_ac_mcp_machine'
+    assert data[2]['detail_name'] == '[machine]'
+    assert data[2]['unit'] == 'mW'
+    assert data[2]['value'] == 28033
+    assert data[2]['type'] == 'MEAN'
+    assert math.isclose(data[2]['sampling_resolution_avg'], 101.67376, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[2]['sampling_resolution_max'], 107.613, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[2]['sampling_resolution_95p'], 104.67055, rel_tol=1e-5), '95p resolution was not in expected range'
+
+
+def test_phase_stats_single_cgroup():
+    run_id = Tests.insert_run()
+    Tests.import_cpu_utilization(run_id)
+
+    build_and_store_phase_stats(run_id)
+
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 3
     assert data[0]['metric'] == 'phase_time_syscall_system'
@@ -24,19 +63,9 @@ def test_phase_stats_single():
     assert data[0]['value'] == Tests.TEST_MEASUREMENT_END_TIME - Tests.TEST_MEASUREMENT_START_TIME
     assert data[0]['type'] == 'TOTAL'
 
-
-    assert data[1]['metric'] == 'psu_energy_ac_mcp_machine'
-    assert data[1]['detail_name'] == '[machine]'
-    assert data[1]['unit'] == 'mJ'
-    assert data[1]['value'] == 13175452
-    assert data[1]['type'] == 'TOTAL'
-
-    assert data[2]['metric'] == 'psu_power_ac_mcp_machine'
-    assert data[2]['detail_name'] == '[machine]'
-    assert data[2]['unit'] == 'mW'
-    assert data[2]['value'] == 28033
-    assert data[2]['type'] == 'MEAN'
-
+    assert math.isclose(data[1]['sampling_resolution_avg'], 99.37357, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_resolution_max'], 100.688, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_resolution_95p'],  99.6960, rel_tol=1e-5), '95p resolution was not in expected range'
 
 def test_phase_stats_multi():
     run_id = Tests.insert_run()
@@ -46,7 +75,7 @@ def test_phase_stats_multi():
 
     build_and_store_phase_stats(run_id)
 
-    data = DB().fetch_all('SELECT * FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, phase FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 7
     assert data[1]['metric'] == 'cpu_energy_rapl_msr_component'
@@ -55,6 +84,10 @@ def test_phase_stats_multi():
     assert data[1]['type'] == 'TOTAL'
     assert data[1]['unit'] == 'mJ'
     assert data[1]['detail_name'] == 'Package_0'
+    assert math.isclose(data[1]['sampling_resolution_avg'], 99.2167, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_resolution_max'], 107.827, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[1]['sampling_resolution_95p'],  99.486, rel_tol=1e-5), '95p resolution was not in expected range'
+
 
     assert data[2]['metric'] == 'cpu_power_rapl_msr_component'
     assert data[2]['phase'] == '004_[RUNTIME]'
@@ -62,6 +95,10 @@ def test_phase_stats_multi():
     assert data[2]['type'] == 'MEAN'
     assert data[2]['unit'] == 'mW'
     assert data[2]['detail_name'] == 'Package_0'
+    assert math.isclose(data[2]['sampling_resolution_avg'], 99.2167, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[2]['sampling_resolution_max'], 107.827, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[2]['sampling_resolution_95p'],  99.486, rel_tol=1e-5), '95p resolution was not in expected range'
+
 
     assert data[3]['metric'] == 'cpu_utilization_cgroup_container'
     assert data[3]['phase'] == '004_[RUNTIME]'
@@ -69,6 +106,10 @@ def test_phase_stats_multi():
     assert data[3]['type'] == 'MEAN'
     assert data[3]['unit'] == 'Ratio'
     assert data[3]['detail_name'] == 'Arne'
+    assert math.isclose(data[3]['sampling_resolution_avg'], 99.37357, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[3]['sampling_resolution_max'], 100.688, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[3]['sampling_resolution_95p'],  99.696, rel_tol=1e-5), '95p resolution was not in expected range'
+
 
     assert data[4]['metric'] == 'cpu_utilization_cgroup_container'
     assert data[4]['phase'] == '004_[RUNTIME]'
@@ -76,6 +117,10 @@ def test_phase_stats_multi():
     assert data[4]['type'] == 'MEAN'
     assert data[4]['unit'] == 'Ratio'
     assert data[4]['detail_name'] == 'Not-Arne'
+    assert math.isclose(data[3]['sampling_resolution_avg'], 99.37357, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(data[3]['sampling_resolution_max'], 100.688, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(data[3]['sampling_resolution_95p'],  99.696, rel_tol=1e-5), '95p resolution was not in expected range'
+
 
 def test_phase_embodied_and_operational_carbon():
     run_id = Tests.insert_run()
@@ -84,7 +129,7 @@ def test_phase_embodied_and_operational_carbon():
     sci = {"I":436,"R":0,"EL":4,"RS":1,"TE":181000,"R_d":"page request"}
     build_and_store_phase_stats(run_id, sci=sci)
 
-    data = DB().fetch_all("SELECT * FROM phase_stats WHERE phase = %s ", params=('004_[RUNTIME]', ), fetch_mode='dict')
+    data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_resolution_avg, sampling_resolution_max, sampling_resolution_95p, phase FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
 
     assert len(data) == 5
 
@@ -110,3 +155,7 @@ def test_phase_embodied_and_operational_carbon():
     assert embodied_carbon_share_machine['unit'] == 'ug'
     assert embodied_carbon_share_machine['value'] == embodied_carbon_expected
     assert embodied_carbon_share_machine['type'] == 'TOTAL'
+
+    assert math.isclose(embodied_carbon_share_machine['sampling_resolution_avg'], 0.0, rel_tol=1e-5), 'Resolution was not in expected range'
+    assert math.isclose(embodied_carbon_share_machine['sampling_resolution_max'], 0.0, rel_tol=1e-5), 'MAX resolution was not in expected range'
+    assert math.isclose(embodied_carbon_share_machine['sampling_resolution_95p'],  0.0, rel_tol=1e-5), '95p resolution was not in expected range'


### PR DESCRIPTION
Implements https://github.com/green-coding-solutions/green-metrics-tool/discussions/888

<!-- greptile_comment -->

## Greptile Summary

This PR implements a significant database schema change by splitting the measurements table into two separate tables to improve data organization and performance. Here's a concise summary:

- Creates new `measurement_metrics` and `measurement_values` tables to separate metadata from time-series data in `/migrations/2024_12_24_measurement_table_split.sql`
- Adds sampling rate metrics (avg/max/95p) to `phase_stats` table to track measurement frequency
- Updates `lib/metric_importer.py` to handle two-step data insertion process with the new table structure
- Modifies frontend components to display new sampling rate information in metric tables
- Updates tests to verify sampling rate calculations and new table structure

The changes improve data normalization and reduce storage requirements by avoiding metadata repetition. However, the migration lacks transaction wrapping and proper cleanup of the old table structure.



<!-- /greptile_comment -->