### PR TITLE
Weighted Average for Phase Stats

### DIFF
--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -100,7 +100,7 @@ def test_phase_stats_multi():
 
     assert data[3]['metric'] == 'cpu_utilization_cgroup_container'
     assert data[3]['phase'] == '004_[RUNTIME]'
-    assert data[3]['value'] == 1985
+    assert data[3]['value'] == 1983
     assert data[3]['type'] == 'MEAN'
     assert data[3]['unit'] == 'Ratio'
     assert data[3]['detail_name'] == 'Arne'
@@ -110,7 +110,7 @@ def test_phase_stats_multi():
 
     assert data[4]['metric'] == 'cpu_utilization_cgroup_container'
     assert data[4]['phase'] == '004_[RUNTIME]'
-    assert data[4]['value'] == 3959
+    assert data[4]['value'] == 3954
     assert data[4]['type'] == 'MEAN'
     assert data[4]['unit'] == 'Ratio'
     assert data[4]['detail_name'] == 'Not-Arne'


### PR DESCRIPTION
(improvement): Phases Stats for CPU Utilization etc. now have weighte…

<!-- greptile_comment -->

## Greptile Summary

Implemented weighted average calculations for phase statistics in the Green Metrics Tool, improving the accuracy of metrics like CPU utilization by accounting for time intervals between measurements.

- Added weighted average calculation in `phase_stats.py` using LAG time differences for more accurate metrics
- Implemented classic average fallback when fewer than 3 measurements exist
- Modified SQL query to include ORDER BY clause ensuring correct LAG calculations
- Updated test values in `test_phase_stats.py` to reflect new weighted averaging (e.g. CPU utilization from 1985 to 1983)
- Converted all weighted averages to Decimal type for consistent precision handling



<!-- /greptile_comment -->