### PR TITLE
(Feature): Check if swap is active; Drop VM caches and sync disk

### DIFF
--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -98,6 +98,11 @@ runs:
     # - name: Setup upterm session
     #   uses: lhotari/action-upterm@v1
 
+    - name: Disable swap
+      shell: bash
+      run: |
+        sudo swapoff -a
+
     - name: Run Tests
       shell: bash
       working-directory: ${{ inputs.gmt-directory }}/tests

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -39,6 +39,10 @@ if [[ $build_sgx == true ]] ; then
     rm lib/sgx-software-enable/sgx_enable.o
 fi
 
+print_message "Enabling cache cleanup without sudo via sudoers entry"
+echo "ALL ALL=(ALL) NOPASSWD:/usr/sbin/sysctl -w vm.drop_caches=3" | sudo tee /etc/sudoers.d/green-coding-drop-caches
+sudo chmod 500 /etc/sudoers.d/green-coding-drop-caches
+
 print_message "Setting the cluster cleanup.sh file to be owned by root"
 sudo cp -f $PWD/tools/cluster/cleanup_original.sh $PWD/tools/cluster/cleanup.sh
 sudo chown root:root $PWD/tools/cluster/cleanup.sh

--- a/runner.py
+++ b/runner.py
@@ -186,7 +186,7 @@ class Runner:
         if platform.system() == 'Darwin':
             return
         # 3 instructs kernel to drops page caches AND inode caches
-        subprocess.check_output(['/usr/sbin/sysctl', '-w', 'vm.drop_caches=3'])
+        subprocess.check_output(['sudo', '/usr/sbin/sysctl', '-w', 'vm.drop_caches=3'])
 
     def check_system(self, mode='start'):
         if self._skip_system_checks:

--- a/runner.py
+++ b/runner.py
@@ -180,6 +180,14 @@ class Runner:
         print(TerminalColors.HEADER, '\nSaving notes: ', TerminalColors.ENDC, self.__notes_helper.get_notes())
         self.__notes_helper.save_to_db(self._run_id)
 
+    def clear_caches(self):
+        subprocess.check_output(['sync'])
+
+        if platform.system() == 'Darwin':
+            return
+        # 3 instructs kernel to drops page caches AND inode caches
+        subprocess.check_output(['/usr/sbin/sysctl', '-w', 'vm.drop_caches=3'])
+
     def check_system(self, mode='start'):
         if self._skip_system_checks:
             print("System check skipped")
@@ -1579,6 +1587,7 @@ class Runner:
         try:
             config = GlobalConfig().config
             self.start_measurement() # we start as early as possible to include initialization overhead
+            self.clear_caches()
             self.check_system('start')
             self.initialize_folder(self._tmp_folder)
             self.checkout_repository()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -161,6 +161,7 @@ class RunUntilManager:
         try:
             config = GlobalConfig().config
             self.__runner.start_measurement()
+            self.__runner.clear_caches()
             self.__runner.check_system('start')
             self.__runner.initialize_folder(self.__runner._tmp_folder)
             self.__runner.checkout_repository()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added functionality to clear system caches and verify swap status across Linux and macOS systems, improving measurement consistency for the Green Metrics Tool.

- Added `clear_caches()` in `runner.py` using sudo for dropping page/inode caches on Linux systems
- Added sudoers entry in `install_linux.sh` to enable cache cleanup without sudo password prompt
- Added `check_swap_disabled()` in `lib/system_checks.py` for cross-platform swap verification
- Modified GitHub Actions workflow in `action.yml` to explicitly disable swap before test runs



<!-- /greptile_comment -->