### PR TITLE
Memcpy for dynamic buffer

### DIFF
--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -104,6 +104,7 @@ static int check_system() {
 int main(int argc, char **argv) {
 
     int c;
+    int optarg_len;
     char *containers_string = NULL;  // Dynamic buffer to store optarg
     container_t *containers = NULL;
     int check_system_flag = 0;
@@ -144,13 +145,14 @@ int main(int argc, char **argv) {
             msleep_time = parse_int(optarg);
             break;
         case 's':
-            containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            optarg_len = strlen(optarg);
+            containers_string = (char *)malloc(optarg_len + 1);  // Allocate memory
             if (!containers_string) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, strlen(optarg));
-            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
+            memcpy(containers_string, optarg, optarg_len);
+            containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -251,7 +251,7 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, optarg_len);
+            memcpy(containers_string, optarg, optarg_len);
             containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -205,6 +205,7 @@ int main(int argc, char **argv) {
 
     int c;
     int check_system_flag = 0;
+    int optarg_len;
     char *containers_string = NULL;  // Dynamic buffer to store optarg
     container_t *containers = NULL;
 
@@ -244,13 +245,14 @@ int main(int argc, char **argv) {
             msleep_time = parse_int(optarg);
             break;
         case 's':
-            containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            optarg_len = strlen(optarg);
+            containers_string = (char *)malloc(optarg_len + 1);  // Allocate memory
             if (!containers_string) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, strlen(optarg));
-            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
+            strncpy(containers_string, optarg, optarg_len);
+            containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -127,6 +127,7 @@ int main(int argc, char **argv) {
 
     int c;
     int check_system_flag = 0;
+    int optarg_len;
     char *containers_string = NULL;  // Dynamic buffer to store optarg
     container_t *containers = NULL;
 
@@ -155,13 +156,14 @@ int main(int argc, char **argv) {
             msleep_time = parse_int(optarg);
             break;
         case 's':
-            containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            optarg_len = strlen(optarg);
+            containers_string = (char *)malloc(optarg_len + 1);  // Allocate memory
             if (!containers_string) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, strlen(optarg));
-            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
+            memcpy(containers_string, optarg, optarg_len);
+            containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/memory/used/cgroup/container/source.c
+++ b/metric_providers/memory/used/cgroup/container/source.c
@@ -165,6 +165,7 @@ int main(int argc, char **argv) {
 
     int c;
     int check_system_flag = 0;
+    int optarg_len;
     char *containers_string = NULL;  // Dynamic buffer to store optarg
     container_t *containers = NULL;
 
@@ -193,13 +194,14 @@ int main(int argc, char **argv) {
             msleep_time = parse_int(optarg);
             break;
         case 's':
-            containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            optarg_len = strlen(optarg);
+            containers_string = (char *)malloc(optarg_len + 1);  // Allocate memory
             if (!containers_string) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, strlen(optarg));
-            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
+            memcpy(containers_string, optarg, optarg_len);
+            containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -201,6 +201,7 @@ int main(int argc, char **argv) {
 
     int c;
     int check_system_flag = 0;
+    int optarg_len;
     char *containers_string = NULL;  // Dynamic buffer to store optarg
     container_t *containers = NULL;
 
@@ -229,13 +230,14 @@ int main(int argc, char **argv) {
             msleep_time = parse_int(optarg);
             break;
         case 's':
-            containers_string = (char *)malloc(strlen(optarg) + 1);  // Allocate memory
+            optarg_len = strlen(optarg);
+            containers_string = (char *)malloc(optarg_len + 1);  // Allocate memory
             if (!containers_string) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, strlen(optarg));
-            containers_string[strlen(optarg)] = '\0'; // Ensure NUL termination if max length
+            strncpy(containers_string, optarg, optarg_len);
+            containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':
             check_system_flag = 1;

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "Could not allocate memory for containers string\n");
                 exit(1);
             }
-            strncpy(containers_string, optarg, optarg_len);
+            memcpy(containers_string, optarg, optarg_len);
             containers_string[optarg_len] = '\0'; // Ensure NUL termination if max length
             break;
         case 'c':


### PR DESCRIPTION
Using memcpy instead of strcpy for dynamically created buffer.

Some compilers where creating a warning here.

Since we make the buffer with malloc as big as we need it to be, there is no risk in running memcpy on the length.

<!-- greptile_comment -->

## Greptile Summary

This PR modifies string copying mechanisms across multiple metric provider files, replacing strncpy with memcpy for dynamically allocated buffers while handling container IDs.

- Memory leak in all files: `containers_string` is dynamically allocated but never freed
- Incorrect pointer check in `/metric_providers/memory/used/cgroup/container/source.c`: `if (!containers)` checks wrong pointer
- Misleading comment about memory cleanup in `/metric_providers/cpu/utilization/cgroup/container/source.c`: dynamically allocated memory requires explicit freeing
- Consistent implementation of `memcpy` with proper null-termination across all modified files
- Safe buffer allocation with exact size needed (optarg_len + 1) for all string operations



<!-- /greptile_comment -->