### PR TITLE
(Feature): Disk IO providers now block more virtual devices and stand multiple partitions

### DIFF
--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -74,7 +74,7 @@ static disk_io_t get_disk_cgroup(char* filename) {
             continue;
         }
         if (minor_number % 16 != 0) {
-            fprintf(stderr, "Partion inside a docker container found. This should not happen: %s:%s rbytes=%lld wbytes=%lld\n", major_number, minor_number, rbytes, wbytes);
+            fprintf(stderr, "Partion inside a docker container found. This should not happen: %u:%u rbytes=%lld wbytes=%lld\n", major_number, minor_number, rbytes, wbytes);
             exit(1);
         }
         disk_io.rbytes += rbytes;

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -31,8 +31,8 @@ static int user_id = -1;
 static unsigned int msleep_time=1000;
 
 static disk_io_t get_disk_cgroup(char* filename) {
-    long long int rbytes = -1;
-    long long int wbytes = -1;
+    unsigned long long int rbytes = 0;
+    unsigned long long int wbytes = 0;
     unsigned int major_number;
     unsigned int minor_number;
     disk_io_t disk_io = {0};
@@ -43,7 +43,7 @@ static disk_io_t get_disk_cgroup(char* filename) {
         exit(1);
     }
 
-    while (fscanf(fd, "%u:%u rbytes=%lld wbytes=%lld rios=%*u wios=%*u dbytes=%*u dios=%*u", &major_number, &minor_number, &rbytes, &wbytes) == 4) {
+    while (fscanf(fd, "%u:%u rbytes=%llu wbytes=%llu rios=%*u wios=%*u dbytes=%*u dios=%*u", &major_number, &minor_number, &rbytes, &wbytes) == 4) {
 
         // 1    Memory devices (e.g., /dev/mem, /dev/null)
         // 2    Floppy disk controller
@@ -74,7 +74,7 @@ static disk_io_t get_disk_cgroup(char* filename) {
             continue;
         }
         if (minor_number % 16 != 0) {
-            fprintf(stderr, "Partion inside a docker container found. This should not happen: %u:%u rbytes=%lld wbytes=%lld\n", major_number, minor_number, rbytes, wbytes);
+            fprintf(stderr, "Partion inside a docker container found. This should not happen: %u:%u rbytes=%llu wbytes=%llu\n", major_number, minor_number, rbytes, wbytes);
             exit(1);
         }
         disk_io.rbytes += rbytes;

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -33,6 +33,8 @@ static unsigned int msleep_time=1000;
 static disk_io_t get_disk_cgroup(char* filename) {
     long long int rbytes = -1;
     long long int wbytes = -1;
+    unsigned int major_number;
+    unsigned int minor_number;
     disk_io_t disk_io = {0};
 
     FILE * fd = fopen(filename, "r");
@@ -41,7 +43,40 @@ static disk_io_t get_disk_cgroup(char* filename) {
         exit(1);
     }
 
-    while (fscanf(fd, "%*u:%*u rbytes=%lld wbytes=%lld rios=%*u wios=%*u dbytes=%*u dios=%*u", &rbytes, &wbytes) == 2) {
+    while (fscanf(fd, "%u:%u rbytes=%lld wbytes=%lld rios=%*u wios=%*u dbytes=%*u dios=%*u", &major_number, &minor_number, &rbytes, &wbytes) == 4) {
+
+        // 1    Memory devices (e.g., /dev/mem, /dev/null)
+        // 2    Floppy disk controller
+        // 3    IDE hard disks (primary controller)
+        // 7    Loopback devices (e.g., /dev/loop0)
+        // 8    SCSI disks (including SATA and NVMe drives)
+        // 9    Metadisk (RAID systems)
+        // 11    SCSI CD-ROM (e.g., /dev/sr0)
+        // 13    Input devices (e.g., /dev/input/event*)
+        // 21    SCSI tape drives
+        // 22    ESDI hard disks
+        // 29    Network block devices (e.g., /dev/nbd)
+        // 36    Accelerated Graphics Port (AGP)
+        // 89    iSCSI devices
+        // 116    ALSA (Advanced Linux Sound Architecture)
+        // 180    USB devices
+        // 202    Xen virtual block devices
+        // 254    Device-mapper (e.g., LVM, cryptsetup)
+
+        if (
+            major_number == 1 || // 1    Memory devices (e.g., /dev/mem, /dev/null)
+            major_number == 2 || // 2    Floppy disk controller
+            major_number == 7 || // 7    Loopback devices (e.g., /dev/loop0)
+            major_number == 11 || // 11    SCSI CD-ROM (e.g., /dev/sr0)
+            major_number == 116 || // 116    ALSA (Advanced Linux Sound Architecture)
+            major_number == 202 // 202    Xen virtual block devices
+        ) {
+            continue;
+        }
+        if (minor_number % 16 != 0) {
+            fprintf(stderr, "Partion inside a docker container found. This should not happen: %s:%s rbytes=%lld wbytes=%lld\n", major_number, minor_number, rbytes, wbytes);
+            exit(1);
+        }
         disk_io.rbytes += rbytes;
         disk_io.wbytes += wbytes;
     }

--- a/metric_providers/disk/io/procfs/system/source.c
+++ b/metric_providers/disk/io/procfs/system/source.c
@@ -39,8 +39,8 @@ static void output_get_disk_procfs() {
         // sender side as not dropped.
         // Since we are iterating over all relevant docker containers we should catch these packets at least in one /proc/net/dev file
         match_result = sscanf(buf, "%u %u %15s %*u %*u %llu %*u %*u %*u %llu", &major_number, &minor_number, device_name, &sectors_read, &sectors_written);
-        if (match_result != 4) {
-            fprintf(stderr, "Could not match /proc/diskstats pattern\n");
+        if (match_result != 5) {
+            fprintf(stderr, "Could not match /proc/diskstats pattern in %s. Amount was %d\n", buf, match_result);
             exit(1);
         }
 

--- a/metric_providers/disk/io/procfs/system/source.c
+++ b/metric_providers/disk/io/procfs/system/source.c
@@ -19,7 +19,8 @@ static unsigned int msleep_time=1000;
 static void output_get_disk_procfs() {
     unsigned long long int sectors_read = 0;
     unsigned long long int sectors_written = 0;
-    int minor_number = -1;
+    int minor_number;
+    int major_number;
     char device_name[16];
     int match_result = 0;
     char buf[1024];
@@ -37,7 +38,7 @@ static void output_get_disk_procfs() {
         // We are not counting dropped packets, as we believe they will at least show up in the
         // sender side as not dropped.
         // Since we are iterating over all relevant docker containers we should catch these packets at least in one /proc/net/dev file
-        match_result = sscanf(buf, "%*u %d %15s %*u %*u %llu %*u %*u %*u %llu", &minor_number, device_name, &sectors_read, &sectors_written);
+        match_result = sscanf(buf, "%u %u %15s %*u %*u %llu %*u %*u %*u %llu", &major_number, &minor_number, device_name, &sectors_read, &sectors_written);
         if (match_result != 4) {
             fprintf(stderr, "Could not match /proc/diskstats pattern\n");
             exit(1);

--- a/metric_providers/disk/io/procfs/system/source.c
+++ b/metric_providers/disk/io/procfs/system/source.c
@@ -42,11 +42,39 @@ static void output_get_disk_procfs() {
             fprintf(stderr, "Could not match /proc/diskstats pattern\n");
             exit(1);
         }
-        if (minor_number != 0) {
-            continue; // we skip when we have found a non root level device (aka partition)
+
+
+        // 1    Memory devices (e.g., /dev/mem, /dev/null)
+        // 2    Floppy disk controller
+        // 3    IDE hard disks (primary controller)
+        // 7    Loopback devices (e.g., /dev/loop0)
+        // 8    SCSI disks (including SATA and NVMe drives)
+        // 9    Metadisk (RAID systems)
+        // 11    SCSI CD-ROM (e.g., /dev/sr0)
+        // 13    Input devices (e.g., /dev/input/event*)
+        // 21    SCSI tape drives
+        // 22    ESDI hard disks
+        // 29    Network block devices (e.g., /dev/nbd)
+        // 36    Accelerated Graphics Port (AGP)
+        // 89    iSCSI devices
+        // 116    ALSA (Advanced Linux Sound Architecture)
+        // 180    USB devices
+        // 202    Xen virtual block devices
+        // 254    Device-mapper (e.g., LVM, cryptsetup)
+
+        if (
+            major_number == 1 || // 1    Memory devices (e.g., /dev/mem, /dev/null)
+            major_number == 2 || // 2    Floppy disk controller
+            major_number == 7 || // 7    Loopback devices (e.g., /dev/loop0)
+            major_number == 11 || // 11    SCSI CD-ROM (e.g., /dev/sr0)
+            major_number == 116 || // 116    ALSA (Advanced Linux Sound Architecture)
+            major_number == 202 // 202    Xen virtual block devices
+        ) {
+            continue;
         }
-        if(!strncmp(device_name,"loop",4)) {
-            continue; // we skip loop devices
+
+        if (minor_number % 16 != 0) {
+            continue; // we skip when we have found a non root level device (aka partition)
         }
 
         printf("%ld%06ld %llu %llu %s\n", now.tv_sec, now.tv_usec, sectors_read, sectors_written, device_name);


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Enhanced disk I/O metric providers with improved device filtering and partition handling for more accurate system measurements across both cgroup and procfs implementations.

- Added comprehensive major number filtering to exclude virtual devices (memory, floppy, loopback, CD-ROM, ALSA, Xen) in `/metric_providers/disk/io/cgroup/container/source.c` and `/metric_providers/disk/io/procfs/system/source.c`
- Updated partition detection logic from `minor_number != 0` to `minor_number % 16 != 0` for better accuracy in both providers
- Changed rbytes/wbytes from signed to unsigned long long in cgroup provider for proper large value handling
- Added error handling for unexpected partition scenarios inside containers in cgroup provider



<!-- /greptile_comment -->