### PR TITLE
(Feature): Frontend now remembers when description texts are closed

### DIFF
--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -313,15 +313,20 @@ $(document).ready(function () {
     }
 });
 
+if (localStorage.getItem('closed_descriptions') == null) {
+    localStorage.setItem('closed_descriptions', '');
+}
+
 $(window).on('load', function() {
     $("body").removeClass("preload"); // activate tranisition CSS properties again
-    $('.close')
-      .on('click', function() {
-        $(this)
-          .closest('.ui')
-          .transition('fade')
-        ;
-      })
-    ;
+    const closed_descriptions = localStorage.getItem('closed_descriptions');
+    $('.close').on('click', function() {
+        $(this).closest('.ui').transition('fade');
+        localStorage.setItem('closed_descriptions', `${closed_descriptions},${window.location.pathname}`)
+    });
+    if (closed_descriptions.indexOf(window.location.pathname) !== -1) {
+        document.querySelectorAll('i.close.icon').forEach(el => { el.closest('.ui').remove()}
+        )
+    }
 });
 

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -30,6 +30,10 @@ const toggleTimeSeriesAVG = () => {
     window.location.reload();
 }
 
+const resetHelpTexts = () => {
+    localStorage.setItem('closed_descriptions', '');
+    document.querySelector('#reset-help-texts-button').innerText = 'OK!';
+}
 
 (() => {
 

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -64,6 +64,11 @@
                           <td><span id="time-series-avg-display"></span></td>
                           <td><button class="ui positive small button" onclick="toggleTimeSeriesAVG();">Toggle</button></td>
                         </tr>
+                        <tr>
+                          <td>Reset hidden help texts</td>
+                          <td><span id="reset-help-texts"></span></td>
+                          <td><button id="reset-help-texts-button" class="ui positive small button" onclick="resetHelpTexts();">Reset</button></td>
+                        </tr>
                       </tbody>
                     </table>
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added functionality to remember and manage help text visibility across the frontend, with the ability to reset hidden descriptions through the settings page.

- Added `resetHelpTexts()` function in `/frontend/js/settings.js` to clear closed descriptions from localStorage
- Added localStorage initialization and management for `closed_descriptions` in `/frontend/js/helpers/main.js`
- Added UI controls in `/frontend/settings.html` for resetting help text visibility
- Implemented automatic hiding of previously closed descriptions on page load through event handlers



<!-- /greptile_comment -->