### PR TITLE
Timeline and badge value transform

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,7 +30,8 @@ disable=missing-function-docstring,
     invalid-name,
     wrong-import-position,
     wrong-import-order,
-    ungrouped-imports
+    ungrouped-imports,
+    no-else-return
 
 [MASTER]
 ignore=env

--- a/api/eco_ci.py
+++ b/api/eco_ci.py
@@ -5,7 +5,7 @@ from fastapi import Request, Response, Depends
 from fastapi.responses import ORJSONResponse
 from fastapi.exceptions import RequestValidationError
 
-from api.api_helpers import authenticate, html_escape_multi, get_connecting_ip, rescale_metric_value
+from api.api_helpers import authenticate, html_escape_multi, get_connecting_ip, convert_value
 from api.object_specifications import CI_Measurement_Old, CI_Measurement
 
 import anybadge
@@ -368,8 +368,8 @@ async def get_ci_badge_get(repo: str, branch: str, workflow:str, mode: str = 'la
 
     metric_value = data[0]
 
-    [metric_value, metric_unit] = rescale_metric_value(metric_value, metric_unit)
-    badge_value= f"{metric_value:.2f} {metric_unit}"
+    [transformed_value, transformed_unit] = convert_value(metric_value, metric_unit)
+    badge_value= f"{transformed_value:.2f} {transformed_unit}"
 
     badge = anybadge.Badge(
         label=label,

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -140,13 +140,14 @@ const loadCharts = async () => {
     phase_stats_data.forEach( (data) => {
         let [run_id, run_name, created_at, metric_name, detail_name, phase, value, unit, commit_hash, commit_timestamp, gmt_hash] = data
 
+        const [transformed_value, transformed_unit] = convertValue(value, unit)
 
         if (series[`${metric_name} - ${detail_name}`] == undefined) {
-            series[`${metric_name} - ${detail_name}`] = {labels: [], values: [], notes: [], unit: unit, metric_name: metric_name, detail_name: detail_name}
+            series[`${metric_name} - ${detail_name}`] = {labels: [], values: [], notes: [], unit: transformed_unit, metric_name: metric_name, detail_name: detail_name}
         }
 
         series[`${metric_name} - ${detail_name}`].labels.push(commit_timestamp)
-        series[`${metric_name} - ${detail_name}`].values.push({value: value, commit_hash: commit_hash, gmt_hash: gmt_hash})
+        series[`${metric_name} - ${detail_name}`].values.push({value: transformed_value, commit_hash: commit_hash, gmt_hash: gmt_hash})
         series[`${metric_name} - ${detail_name}`].notes.push({
             run_name: run_name,
             created_at: created_at,

--- a/tests/api/test_api_eco_ci.py
+++ b/tests/api/test_api_eco_ci.py
@@ -189,7 +189,7 @@ def test_ci_badge_get_last():
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=last&metric=carbon", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'Last run carbon emitted' in response.text, Tests.assertion_info('success', response.text)
-    assert '17.32 mg' in response.text, Tests.assertion_info('success', response.text)
+    assert '0.02 g' in response.text, Tests.assertion_info('success', response.text)
 
 
 def test_ci_badge_get_totals():
@@ -198,7 +198,7 @@ def test_ci_badge_get_totals():
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'All runs total energy used' in response.text, Tests.assertion_info('success', response.text)
-    assert '49.02 kJ' in response.text, Tests.assertion_info('success', response.text)
+    assert '49022.55 J' in response.text, Tests.assertion_info('success', response.text)
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals&metric=carbon", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
@@ -232,7 +232,7 @@ def test_ci_badge_get_average():
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
 
     assert 'Per run moving average (5 days) carbon emitted' in response.text, Tests.assertion_info('success', response.text)
-    assert '751.00 mg' in response.text, Tests.assertion_info('success', response.text)
+    assert '0.75 g' in response.text, Tests.assertion_info('success', response.text)
 
 
 ## helpers

--- a/tests/api/test_api_helpers.py
+++ b/tests/api/test_api_helpers.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel
 
 from api import api_helpers
-import pytest
 
 class Run(BaseModel):
     name: str
@@ -24,28 +23,25 @@ class CI_Measurement(BaseModel):
     duration: int
 
 
-def test_rescale_metric_value():
-    assert api_helpers.rescale_metric_value(100, 'uJ') == [100, 'uJ']
+def test_convert_value():
+    assert api_helpers.convert_value(100, 'uJ') == [0.0001, 'J']
 
-    assert api_helpers.rescale_metric_value(10000, 'uJ') == [10, 'mJ']
+    assert api_helpers.convert_value(10000, 'uJ') == [0.01, 'J']
 
-    assert api_helpers.rescale_metric_value(324_000_000_000, 'uJ') == [324, 'kJ']
+    assert api_helpers.convert_value(324_000_000_000, 'uJ') == [324000, 'J']
 
-    assert api_helpers.rescale_metric_value(324_000_000_000, 'ugCO2e/Page Request') == [324, 'kgCO2e/Page Request']
+    assert api_helpers.convert_value(324_000_000_000, 'ugCO2e/Page Request') == [324000, 'gCO2e/Page Request']
 
-    assert api_helpers.rescale_metric_value(222_000_000_000_000, 'ugCO2e/Kill') == [222, 'MgCO2e/Kill']
+    assert api_helpers.convert_value(222_000_000_000_000, 'ugCO2e/Kill') == [222000000, 'gCO2e/Kill']
 
-    assert api_helpers.rescale_metric_value(0.0003, 'ugCO2e/Kill') == [0.3, 'ngCO2e/Kill']
+    assert api_helpers.convert_value(0.0003, 'ugCO2e/Kill') == [0.0000000003, 'gCO2e/Kill']
 
 
-    with pytest.raises(ValueError):
-        api_helpers.rescale_metric_value(100, 'xJ')
+    assert api_helpers.convert_value(100, 'xJ') == [100, 'xJ']
 
-    with pytest.raises(ValueError):
-        api_helpers.rescale_metric_value(100, 'uj')
+    assert api_helpers.convert_value(100, 'uj') == [100, 'uj']
 
-    with pytest.raises(ValueError):
-        assert api_helpers.rescale_metric_value(10000, 'mJ') == [10, 'J']
+    assert api_helpers.convert_value(10000, 'mJ') == [10, 'J']
 
 def test_escape_dict():
     messy_dict = {"link": '<a href="http://www.github.com">Click me</a>'}


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR standardizes metric value transformations by replacing the 'rescale_metric_value' function with a more comprehensive 'convert_value' function, improving unit conversion consistency across the codebase.

- Added new `convert_value` function in `api/api_helpers.py` with expanded support for temperature, frequency, and data size units
- Updated badge generation endpoints in `api/eco_ci.py` to use standardized unit conversions (e.g., mg → g, kJ → J)
- Modified timeline visualization in `frontend/js/timeline.js` to incorporate new value transformation logic
- Updated test files `tests/api/test_api_helpers.py` and `tests/api/test_api_eco_ci.py` to validate new conversion behavior



<!-- /greptile_comment -->