### PR TITLE
Badges with selectable unit

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -521,14 +521,18 @@ async def get_timeline_stats(uri: str, machine_id: int, branch: str | None = Non
 ## A complex case to allow public visibility of the badge but restricting everything else would be to have
 ## User 1 restricted to only this route but a fully populated 'visible_users' array
 @app.get('/v1/badge/timeline')
-async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch: str | None = None, filename: str | None = None, metrics: str | None = None, user: User = Depends(authenticate)):
+async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch: str | None = None, filename: str | None = None, metrics: str | None = None, unit: str = 'watt-hours', user: User = Depends(authenticate)):
     if uri is None or uri.strip() == '':
         raise RequestValidationError('URI is empty')
 
     if detail_name is None or detail_name.strip() == '':
         raise RequestValidationError('Detail Name is mandatory')
 
-    if artifact := get_artifact(ArtifactType.BADGE, f"{user._id}_{uri}_{filename}_{machine_id}_{branch}_{metrics}_{detail_name}"):
+    if unit not in ('watt-hours', 'joules'):
+        raise RequestValidationError('Requested unit is not in allow list: watt-hours, joules')
+
+    # we believe that there is no injection possible to the artifact store and any string can be constructured here ...
+    if artifact := get_artifact(ArtifactType.BADGE, f"{user._id}_{uri}_{filename}_{machine_id}_{branch}_{metrics}_{detail_name}_{unit}"):
         return Response(content=str(artifact), media_type="image/svg+xml")
 
     query, params = get_timeline_query(user, uri,filename,machine_id, branch, metrics, '[RUNTIME]', detail_name=detail_name, limit_365=True)
@@ -551,7 +555,8 @@ async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch
         return Response(status_code=204) # No-Content
 
     cost = data[1]/data[0]
-    [rescaled_cost, rescaled_unit] = convert_value(cost, data[3], False)
+    display_in_watthours = True if unit == 'watt-hours' else False
+    [rescaled_cost, rescaled_unit] = convert_value(cost, data[3], display_in_watthours)
     rescaled_cost = f"+{rescaled_cost:.2f}" if abs(cost) == cost else f"{rescaled_cost:.2f}"
 
     badge = anybadge.Badge(
@@ -562,7 +567,7 @@ async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch
 
     badge_str = str(badge)
 
-    store_artifact(ArtifactType.BADGE, f"{user._id}_{uri}_{filename}_{machine_id}_{branch}_{metrics}_{detail_name}", badge_str, ex=60*60*12) # 12 hour storage
+    store_artifact(ArtifactType.BADGE, f"{user._id}_{uri}_{filename}_{machine_id}_{branch}_{metrics}_{detail_name}_{unit}", badge_str, ex=60*60*12) # 12 hour storage
 
     return Response(content=badge_str, media_type="image/svg+xml")
 
@@ -571,12 +576,16 @@ async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch
 ## A complex case to allow public visibility of the badge but restricting everything else would be to have
 ## User 1 restricted to only this route but a fully populated 'visible_users' array
 @app.get('/v1/badge/single/{run_id}')
-async def get_badge_single(run_id: str, metric: str = 'ml-estimated', user: User = Depends(authenticate)):
+async def get_badge_single(run_id: str, metric: str = 'ml-estimated', unit: str = 'watt-hours', user: User = Depends(authenticate)):
 
     if run_id is None or not is_valid_uuid(run_id):
         raise RequestValidationError('Run ID is not a valid UUID or empty')
 
-    if artifact := get_artifact(ArtifactType.BADGE, f"{user._id}_{run_id}_{metric}"):
+    if unit not in ('watt-hours', 'joules'):
+        raise RequestValidationError('Requested unit is not in allow list: watt-hours, joules')
+
+    # we believe that there is no injection possible to the artifact store and any string can be constructured here ...
+    if artifact := get_artifact(ArtifactType.BADGE, f"{user._id}_{run_id}_{metric}_{unit}"):
         return Response(content=str(artifact), media_type="image/svg+xml")
 
     query = '''
@@ -617,7 +626,8 @@ async def get_badge_single(run_id: str, metric: str = 'ml-estimated', user: User
     if data is None or data == [] or data[1] is None: # special check for data[1] as this is aggregate query which always returns result
         badge_value = 'No metric data yet'
     else:
-        [metric_value, energy_unit] = convert_value(data[0], data[1])
+        display_in_watthours = True if unit == 'watt-hours' else False
+        [metric_value, energy_unit] = convert_value(data[0], data[1], display_in_watthours)
         badge_value= f"{metric_value:.2f} {energy_unit} {via}"
 
     badge = anybadge.Badge(
@@ -629,7 +639,7 @@ async def get_badge_single(run_id: str, metric: str = 'ml-estimated', user: User
     badge_str = str(badge)
 
     if badge_value != 'No metric data yet':
-        store_artifact(ArtifactType.BADGE, f"{user._id}_{run_id}_{metric}", badge_str)
+        store_artifact(ArtifactType.BADGE, f"{user._id}_{run_id}_{metric}_{unit}", badge_str)
 
     return Response(content=badge_str, media_type="image/svg+xml")
 

--- a/frontend/js/energy-timeline.js
+++ b/frontend/js/energy-timeline.js
@@ -48,7 +48,7 @@ $(document).ready(function () {
                                     <i class="question circle icon link"></i>
                                 </i>
                             </div>
-                            <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?uri=${url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}" target="_blank"><img src="${API_URL}/v1/badge/timeline?uri=${url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}&metrics=${metric_name}&detail_name=${detail_name}" alt="Image Failed to Load" onerror="this.closest('.field').style.display='none'"></a></span>
+                            <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?uri=${url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}" target="_blank"><img src="${API_URL}/v1/badge/timeline?uri=${url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}&metrics=${metric_name}&detail_name=${detail_name}&unit=joules" alt="Image Failed to Load" onerror="this.closest('.field').style.display='none'"></a></span>
                             <a class="copy-badge"><i class="copy icon"></i></a>
                         </div>
                         </div>

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -173,7 +173,7 @@ const loadCharts = async () => {
                             <i class="question circle icon link"></i>
                         </i>
                     </div>
-                    <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?${buildQueryParams()}" target="_blank"><img src="${API_URL}/v1/badge/timeline?${buildQueryParams(skip_dates=false,metric_override=series[my_series].metric_name,detail_name=series[my_series].detail_name)}"></a></span>
+                    <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?${buildQueryParams()}" target="_blank"><img src="${API_URL}/v1/badge/timeline?${buildQueryParams(skip_dates=false,metric_override=series[my_series].metric_name,detail_name=series[my_series].detail_name)}&unit=joules"></a></span>
                     <a class="copy-badge"><i class="copy icon"></i></a>
                 </div>
                 <p></p>`

--- a/tests/api/test_api_eco_ci.py
+++ b/tests/api/test_api_eco_ci.py
@@ -184,6 +184,11 @@ def test_ci_badge_get_last():
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=last", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'Last run energy used' in response.text, Tests.assertion_info('success', response.text)
+    assert '0.01 Wh' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=last&unit=joules", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Last run energy used' in response.text, Tests.assertion_info('success', response.text)
     assert '28.95 J' in response.text, Tests.assertion_info('success', response.text)
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=last&metric=carbon", timeout=15)
@@ -198,12 +203,18 @@ def test_ci_badge_get_totals():
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'All runs total energy used' in response.text, Tests.assertion_info('success', response.text)
+    assert '13.62 Wh' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals&unit=joules", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'All runs total energy used' in response.text, Tests.assertion_info('success', response.text)
     assert '49022.55 J' in response.text, Tests.assertion_info('success', response.text)
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo=green-coding-solutions/ci-carbon-testing&branch=main&workflow=48163287&mode=totals&metric=carbon", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'All runs total carbon emitted' in response.text, Tests.assertion_info('success', response.text)
     assert '15.56 g' in response.text, Tests.assertion_info('success', response.text)
+
 
 def test_ci_badge_get_average():
 
@@ -221,12 +232,15 @@ def test_ci_badge_get_average():
         response = requests.post(f"{API_URL}/v2/ci/measurement/add", json=measurement_model, timeout=15)
         assert response.status_code == 204, Tests.assertion_info('success', response.text)
 
-
+    response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5&unit=joules", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Per run moving average (5 days) energy used' in response.text, Tests.assertion_info('success', response.text)
+    assert '307.62 J' in response.text, Tests.assertion_info('success', response.text)
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'Per run moving average (5 days) energy used' in response.text, Tests.assertion_info('success', response.text)
-    assert '307.62 J' in response.text, Tests.assertion_info('success', response.text)
+    assert '0.09 Wh' in response.text, Tests.assertion_info('success', response.text)
 
     response = requests.get(f"{API_URL}/v1/ci/badge/get?repo={MEASUREMENT_MODEL_NEW['repo']}&branch={MEASUREMENT_MODEL_NEW['branch']}&workflow={MEASUREMENT_MODEL_NEW['workflow']}&mode=avg&duration_days=5&metric=carbon", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)

--- a/tests/api/test_api_helpers.py
+++ b/tests/api/test_api_helpers.py
@@ -1,3 +1,4 @@
+import math
 from pydantic import BaseModel
 
 from api import api_helpers
@@ -24,11 +25,31 @@ class CI_Measurement(BaseModel):
 
 
 def test_convert_value():
-    assert api_helpers.convert_value(100, 'uJ') == [0.0001, 'J']
+    [value, unit] = api_helpers.convert_value(100, 'uJ')
 
-    assert api_helpers.convert_value(10000, 'uJ') == [0.01, 'J']
+    assert unit == 'Wh'
+    assert math.isclose(value, 0.00000002777777777777777, rel_tol=1e-10)
 
-    assert api_helpers.convert_value(324_000_000_000, 'uJ') == [324000, 'J']
+    [value, unit] = api_helpers.convert_value(10000, 'uJ')
+
+    assert unit == 'Wh'
+    assert math.isclose(value, 0.000002777777777777777, rel_tol=1e-10)
+
+    [value, unit] = api_helpers.convert_value(10000, 'mJ')
+
+    assert unit == 'Wh'
+    assert math.isclose(value, 0.002777777777777, rel_tol=1e-10)
+
+    assert api_helpers.convert_value(324_000_000_000, 'uJ') == [90, 'Wh']
+
+    assert api_helpers.convert_value(100, 'uJ', False) == [0.0001, 'J']
+
+    assert api_helpers.convert_value(10000, 'uJ', False) == [0.01, 'J']
+
+    assert api_helpers.convert_value(324_000_000_000, 'uJ', False) == [324000, 'J']
+
+    assert api_helpers.convert_value(10000, 'mJ', False) == [10, 'J']
+
 
     assert api_helpers.convert_value(324_000_000_000, 'ugCO2e/Page Request') == [324000, 'gCO2e/Page Request']
 
@@ -41,7 +62,6 @@ def test_convert_value():
 
     assert api_helpers.convert_value(100, 'uj') == [100, 'uj']
 
-    assert api_helpers.convert_value(10000, 'mJ') == [10, 'J']
 
 def test_escape_dict():
     messy_dict = {"link": '<a href="http://www.github.com">Click me</a>'}

--- a/tests/api/test_api_helpers.py
+++ b/tests/api/test_api_helpers.py
@@ -28,17 +28,17 @@ def test_convert_value():
     [value, unit] = api_helpers.convert_value(100, 'uJ')
 
     assert unit == 'Wh'
-    assert math.isclose(value, 0.00000002777777777777777, rel_tol=1e-10)
+    assert math.isclose(value, 0.00000002777, rel_tol=1e-3)
 
     [value, unit] = api_helpers.convert_value(10000, 'uJ')
 
     assert unit == 'Wh'
-    assert math.isclose(value, 0.000002777777777777777, rel_tol=1e-10)
+    assert math.isclose(value, 0.000002777, rel_tol=1e-3)
 
     [value, unit] = api_helpers.convert_value(10000, 'mJ')
 
     assert unit == 'Wh'
-    assert math.isclose(value, 0.002777777777777, rel_tol=1e-10)
+    assert math.isclose(value, 0.002777, rel_tol=1e-3)
 
     assert api_helpers.convert_value(324_000_000_000, 'uJ') == [90, 'Wh']
 

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -190,7 +190,7 @@ def test_stats():
     phase_duration = new_page.locator("#runtime-steps > div.ui.bottom.attached.active.tab.segment > div.ui.segment.secondary > phase-metrics > div.ui.four.cards.stackable > div.ui.card.phase-duration > div > div.description > div.ui.fluid.mini.statistic > div > span").text_content()
 
 
-    assert energy_value.strip() == '76.10'
+    assert energy_value.strip() == '0.02'
     assert phase_duration.strip() == '5.20'
 
     # fetch time series
@@ -312,10 +312,10 @@ def test_repositories_and_compare():
     assert first_metric.strip() == 'CPU Energy (Package)'
 
     first_value = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(6)").text_content()
-    assert first_value.strip() == '8.91'
+    assert first_value.strip() == '0.00'
 
     first_unit = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(7)").text_content()
-    assert first_unit.strip() == 'J'
+    assert first_unit.strip() == 'Wh'
 
     first_stddev = new_page.locator("#main > div.ui.tab.attached.segment.secondary.active > phase-metrics > div.ui.accordion > div.content.active > table > tbody > tr:nth-child(2) > td:nth-child(8)").text_content()
     assert first_stddev.strip() == '± 13.68%'
@@ -373,7 +373,7 @@ def test_settings():
     page.wait_for_load_state("load") # ALL JS should be done
 
     energy_display = page.locator('#energy-display').text_content()
-    assert energy_display.strip() == 'Currently showing Joules'
+    assert energy_display.strip() == 'Currently showing Watt-Hours'
 
 
     units_display = page.locator('#units-display').text_content()


### PR DESCRIPTION
- Badges accept now unit parameter to show either joules or watt-hours;
- TImeline badges default still Joules for resolution

<!-- greptile_comment -->

## Greptile Summary

Added unit parameter support for badges in the Green Metrics Tool, enabling users to toggle between joules and watt-hours for energy measurement display.

- Added unit parameter handling in `/api/eco_ci.py` for badge generation with joules/watt-hours options
- Updated `/frontend/js/timeline.js` and `/frontend/js/energy-timeline.js` to support unit selection in badge URLs
- Enhanced `/tests/api/test_api_helpers.py` with precise floating-point comparisons for unit conversions
- Added test coverage in `/tests/api/test_api_eco_ci.py` for unit parameter validation



<!-- /greptile_comment -->