### PR TITLE
Checking int fields for params and limiting retrieval amount

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -27,7 +27,7 @@ from api.api_helpers import (ORJSONResponseObjKeep, add_phase_stats_statistics,
                          html_escape_multi, get_phase_stats, get_phase_stats_object,
                          is_valid_uuid, convert_value, get_timeline_query,
                          get_run_info, get_machine_list, get_artifact, store_artifact,
-                         authenticate)
+                         authenticate, check_int_field_api)
 
 from lib.global_config import GlobalConfig
 from lib.db import DB
@@ -179,7 +179,7 @@ async def get_jobs(
     machine_id_condition = ''
     state_condition = ''
 
-    if machine_id is not None:
+    if machine_id and check_int_field_api(machine_id, 'machine_id', 1024):
         machine_id_condition = 'AND j.machine_id = %s'
         params.append(machine_id)
 
@@ -276,7 +276,7 @@ async def get_repositories(uri: str | None = None, branch: str | None = None, ma
         query = f"{query} AND r.filename LIKE %s  \n"
         params.append(f"%{filename}%")
 
-    if machine_id:
+    if machine_id and check_int_field_api(machine_id, 'machine_id', 1024):
         query = f"{query} AND m.id = %s \n"
         params.append(machine_id)
 
@@ -302,7 +302,7 @@ async def get_repositories(uri: str | None = None, branch: str | None = None, ma
 
 # A route to return all of the available entries in our catalog.
 @app.get('/v1/runs')
-async def get_runs(uri: str | None = None, branch: str | None = None, machine_id: int | None = None, machine: str | None = None, filename: str | None = None, limit: int | None = None, uri_mode = 'none', user: User = Depends(authenticate)):
+async def get_runs(uri: str | None = None, branch: str | None = None, machine_id: int | None = None, machine: str | None = None, filename: str | None = None, limit: int = 5, uri_mode = 'none', user: User = Depends(authenticate)):
 
     query = '''
             SELECT r.id, r.name, r.uri, r.branch, r.created_at, r.invalid_run, r.filename, m.description, r.commit_hash, r.end_measurement, r.failed, r.machine_id
@@ -329,7 +329,7 @@ async def get_runs(uri: str | None = None, branch: str | None = None, machine_id
         query = f"{query} AND r.filename LIKE %s  \n"
         params.append(f"%{filename}%")
 
-    if machine_id:
+    if machine_id and check_int_field_api(machine_id, 'machine_id', 1024):
         query = f"{query} AND m.id = %s \n"
         params.append(machine_id)
 
@@ -339,9 +339,9 @@ async def get_runs(uri: str | None = None, branch: str | None = None, machine_id
 
     query = f"{query} ORDER BY r.created_at DESC"
 
-    if limit:
-        query = f"{query} LIMIT %s"
-        params.append(limit)
+    check_int_field_api(limit, 'limit', 50)
+    query = f"{query} LIMIT %s"
+    params.append(limit)
 
 
     data = DB().fetch_all(query, params=params)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added integer field validation and retrieval limits to the API endpoints to enhance security and prevent excessive data retrieval.

- Added `check_int_field_api()` in `api/api_helpers.py` to validate integer parameters with type, minimum and maximum value checks
- Implemented validation for `machine_id` parameter (max 1024) across API endpoints in `api/main.py`
- Added required `limit` parameter with default=5 and max=50 for `/v1/runs` endpoint
- Added validation before using integer parameters in database queries to prevent SQL injection and overflow attacks



<!-- /greptile_comment -->