### PR TITLE
Optimizations can get data without HTTP

### DIFF
--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -69,6 +69,9 @@ services:
       - green-coding-redis-data:/data
     command: redis-server --save 60 1 --loglevel warning
     restart: always
+    ports:
+      - "127.0.0.1:6379:6379"  # Only accessible from localhost
+
 
 
 # Although it would help us very much performance-wise the

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -153,7 +153,7 @@ function prepare_config() {
 
     if [[ $modify_hosts == true ]] ; then
 
-        local etc_hosts_line_1="127.0.0.1 green-coding-postgres-container"
+        local etc_hosts_line_1="127.0.0.1 green-coding-postgres-container green-coding-redis-container"
         local etc_hosts_line_2="127.0.0.1 ${host_api_url} ${host_metrics_url}"
 
         print_message "Writing to /etc/hosts file..."

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -60,7 +60,7 @@ class RunJob(Job):
             print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
             optimization_providers.base.import_reporters()
             print(TerminalColors.HEADER, '\nRunning optimization reporters ...', TerminalColors.ENDC)
-            optimization_providers.base.run_reporters(runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
+            optimization_providers.base.run_reporters(runner._user_id, runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
 
             if self._email:
                 Job.insert(

--- a/optimization_providers/base.py
+++ b/optimization_providers/base.py
@@ -118,7 +118,10 @@ async def query_all_data(user_id, run_id):
 
 
 #pylint: disable=dangerous-default-value
-def run_reporters(user_id, run_id, repo_path, optimizations_ignore=[]):
+def run_reporters(user_id, run_id, repo_path, optimizations_ignore=None):
+
+    if not optimizations_ignore:
+        optimizations_ignore = []
 
     run_data, measurements_data, network_data, notes_data, phase_stats_data = asyncio.run(query_all_data(user_id, run_id))
 

--- a/runner.py
+++ b/runner.py
@@ -1870,7 +1870,7 @@ if __name__ == '__main__':
 
             print(TerminalColors.HEADER, '\nRunning optimization reporters ...', TerminalColors.ENDC)
 
-            optimization_providers.base.run_reporters(runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
+            optimization_providers.base.run_reporters(runner._user_id, runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
 
         if args.file_cleanup:
             shutil.rmtree(runner._tmp_folder)

--- a/tests/edit-etc-hosts.sh
+++ b/tests/edit-etc-hosts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-etc_hosts_line_1="127.0.0.1 test-green-coding-postgres-container"
+etc_hosts_line_1="127.0.0.1 test-green-coding-postgres-container test-green-coding-redis-container"
 
 echo "Writing to /etc/hosts file..."
 if ! grep -Fxq "$etc_hosts_line_1" /etc/hosts; then

--- a/tools/optimization.py
+++ b/tools/optimization.py
@@ -13,6 +13,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('run_id', help='Please supply a run_id')
+    parser.add_argument('user_id', help='Please supply a user_id')
 
     args = parser.parse_args()  # script will exit if arguments not present
 
@@ -21,4 +22,4 @@ if __name__ == '__main__':
 
     print(TerminalColors.HEADER, '\nRunning optimization reporters ...', TerminalColors.ENDC)
 
-    optimization_providers.base.run_reporters(args.run_id, '/tmp/green-metrics-tool')
+    optimization_providers.base.run_reporters(args.user_id, args.run_id, '/tmp/green-metrics-tool')


### PR DESCRIPTION
This PR introduces a fallback method that we plan to make the default for getting optimizations data.

It does not use the old HTTP transport mechanism, but queries the database directly.

Pros:
- It can handle authentication seprately and thus allow for users in shared environments, which however have restricted view configurations for the API

Downs:
- It bypasses Redis caching. Howver at the point in time where the optimizations run no Redis cache has been built anyway. However we loose the chance to write to the cache here.

Optimizations can still happen asynchronously if wanted on a different box 

<!-- greptile_comment -->

## Greptile Summary

Introduced direct database access for optimization data retrieval, replacing HTTP transport with authenticated database queries while maintaining async capabilities in shared environments.

- Added `query_all_data` function in `/optimization_providers/base.py` for direct DB access with user authentication
- Modified Redis exposure in `/docker/compose.yml.example` to localhost:6379 with network isolation
- Changed `run_reporters` function to require `user_id` parameter for proper authentication
- Bypasses Redis caching but executes before cache population, minimizing impact
- Fixed mutable default argument issue in `run_reporters` function's `optimizations_ignore` parameter



<!-- /greptile_comment -->