### PR TITLE
Check container health also for containers without dependencies

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -83,7 +83,8 @@ measurement:
   post-test-sleep: 5
   phase-transition-time: 1
   boot:
-    wait_time_dependencies: 60
+    wait_time_container_started: 30
+    wait_time_container_healthy: 300
   metric-providers:
 
   # Please select the needed providers according to the working ones on your system

--- a/tests/data/usage_scenarios/healthcheck_without_dependency.yml
+++ b/tests/data/usage_scenarios/healthcheck_without_dependency.yml
@@ -1,0 +1,28 @@
+---
+name: Test healthcheck
+author: David Kopp
+description: test
+
+services:
+  test-container-1:
+    build:
+      context: ../slow-start-application
+    healthcheck:
+      test: pgrep 'tail'
+      interval: 1s
+      retries: 10
+
+  test-container-2:
+    build:
+      context: ../slow-start-application
+    healthcheck:
+      test: pgrep 'tail'
+      interval: 1s
+      retries: 10
+
+flow:
+  - name: dummy
+    container: test-container-1
+    commands:
+      - type: console
+        command: pwd

--- a/tests/test-config-duplicate-psu-providers.yml
+++ b/tests/test-config-duplicate-psu-providers.yml
@@ -64,7 +64,8 @@ measurement:
   post-test-sleep: 0
   phase-transition-time: 0
   boot:
-    wait_time_dependencies: 10
+    wait_time_container_started: 30
+    wait_time_container_healthy: 300
   metric-providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:

--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -64,7 +64,8 @@ measurement:
   post-test-sleep: 0
   phase-transition-time: 0
   boot:
-    wait_time_dependencies: 10
+    wait_time_container_started: 5
+    wait_time_container_healthy: 10
   metric-providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:


### PR DESCRIPTION
I had the issue that a container has a long startup time (due to database migrations), but GMT didn't checked the health condition, so the flow was already starting, but the container was not ready yet.

I think it makes sense to check all containers if they are started and if they are healthy (if a healthcheck is implemented) in the end of the boot phase before starting with the next phase (idle / runtime). This should be independent of whether or not there are dependencies between services.

This PR adds such a health check to the end of the boot phase. To avoid duplicated code I had to refactor the depends_on implementation.

The PR also changes a config parameter (`wait_time_dependencies`). Is this is problem?

I have set the waiting time for a container to become healthy to 300 seconds. Is this too long? The application I have mentioned in the beginning takes on my laptop around 200 seconds to boot.