### PR TITLE
Better Key Metrics Display

### DIFF
--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -6,7 +6,7 @@ class PhaseMetrics extends HTMLElement {
    connectedCallback() {
         this.innerHTML = `
         <h3 class="ui dividing header print-page-break">Key metrics</h3>
-        <div class="ui four cards stackable">
+        <div class="ui six cards stackable">
             <div class="ui card phase-duration">
                 <div class="ui content">
                     <div class="ui top attached purple label overflow-ellipsis">Phase Duration <span class="si-unit"></span></div>
@@ -44,16 +44,73 @@ class PhaseMetrics extends HTMLElement {
                     </div>
                 </div>
             </div>
-            <div class="ui card machine-energy">
+            <div class="ui card machine-power">
                 <div class="ui content">
-                    <div class="ui top attached blue label overflow-ellipsis">Machine Energy <span class="si-unit"></span></div>
+                    <div class="ui top attached orange label overflow-ellipsis">CPU Power <span class="si-unit"></span></div>
                     <div class="description">
                         <div class="ui fluid mini statistic">
                             <div class="value">
-                                <i class="battery three quarters icon"></i> <span>N/A</span>
+                                <i class="power off icon"></i> <span>N/A</span>
                             </div>
                         </div>
-                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Energy of all hardware components during current usage phase.">
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Power of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-power">
+                <div class="ui content">
+                    <div class="ui top attached orange label overflow-ellipsis">DRAM Power <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="power off icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Power of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-power">
+                <div class="ui content">
+                    <div class="ui top attached orange label overflow-ellipsis">SDD/HDD Power <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="power off icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Power of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-power">
+                <div class="ui content">
+                    <div class="ui top attached orange label overflow-ellipsis">GPU Power <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="power off icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Power of all hardware components during current usage phase.">
                             <span class="source"></span>
                             <i class="question circle icon"></i>
                         </div>
@@ -74,6 +131,101 @@ class PhaseMetrics extends HTMLElement {
                         </div>
                         <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Estimated external energy cost for network infrastructure. See details under formula.">
                             <u><a href="https://www.green-coding.io/co2-formulas/">via Formula</a></u>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-energy">
+                <div class="ui content">
+                    <div class="ui top attached blue label overflow-ellipsis">Machine Energy <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="battery three quarters icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Energy of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-energy">
+                <div class="ui content">
+                    <div class="ui top attached blue label overflow-ellipsis">Machine Energy <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="battery three quarters icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Energy of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-energy">
+                <div class="ui content">
+                    <div class="ui top attached blue label overflow-ellipsis">Machine Energy <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="battery three quarters icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Energy of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-energy">
+                <div class="ui content">
+                    <div class="ui top attached blue label overflow-ellipsis">Machine Energy <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="battery three quarters icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Energy of all hardware components during current usage phase.">
+                            <span class="source"></span>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="ui card machine-energy">
+                <div class="ui content">
+                    <div class="ui top attached blue label overflow-ellipsis">Machine Energy <span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="battery three quarters icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="Energy of all hardware components during current usage phase.">
+                            <span class="source"></span>
                             <i class="question circle icon"></i>
                         </div>
                         <div class="ui bottom left attached label">


### PR DESCRIPTION
We want to add more key metrics directly in the quick view of the Dashboard.

Currently the values provide limited value for new users, as they lack some expected  components (CPU, DRAM etc) and show however some harder to understand values (Embodied Carbon Machine, Operational carbon machine).

In this idea we want to list power values for CPU, DRAM, GPU, SDD/HDD and Network directly in the quick view.
Furthmore for each value the carbon should also be directly highlighted.

Adding just more values looks gruesome.

here is a design idea to make it more columnar. The idea is to show power and carbon directly.

Hiding detailes like the split of embodied and operational in the detailed metrics.
What somehow needs to be put somewhere is the phase runtime stil ...

@ribalba what do you think?

<img width="1512" alt="Screenshot 2025-03-15 at 7 38 53 PM (2)" src="https://github.com/user-attachments/assets/c92c7777-e1e8-4163-a684-21b3a3c4d7ee" />

