### PR TITLE
Logs previous exception if present

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -54,7 +54,8 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         headers=obfuscate_authentication_token(request.headers),
         body=exc.body,
         details=exc.errors(),
-        exception=exc
+        exception=exc,
+        previous_exception=exc.__context__
     )
     return ORJSONResponse(
         status_code=422, # HTTP_422_UNPROCESSABLE_ENTITY
@@ -72,7 +73,8 @@ async def http_exception_handler(request, exc):
         headers=obfuscate_authentication_token(request.headers),
         body=body,
         details=exc.detail,
-        exception=exc
+        exception=exc,
+        previous_exception=exc.__context__
     )
     return ORJSONResponse(
         status_code=exc.status_code,
@@ -94,7 +96,8 @@ async def catch_exceptions_middleware(request: Request, call_next):
             client=request.client,
             headers=obfuscate_authentication_token(request.headers),
             body=body,
-            exception=exc
+            exception=exc,
+            previous_exception=exc.__context__
         )
         return ORJSONResponse(
             content={

--- a/cron/client.py
+++ b/cron/client.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
                     error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, stdout=exc.stdout, stderr=exc.stderr, run_id=job._run_id, machine=config_main['machine']['description'], name=job._name, url=job._url)
                 except Exception as exc: # pylint: disable=broad-except
                     set_status('job_error', current_temperature, last_cooldown_time, data=str(exc), run_id=job._run_id)
-                    error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, run_id=job._run_id, machine=config_main['machine']['description'], name=job._name, url=job._url)
+                    error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, previous_exception=exc.__context__, run_id=job._run_id, machine=config_main['machine']['description'], name=job._name, url=job._url)
                 finally:
                     if not args.testing:
                         do_cleanup(current_temperature, last_cooldown_time)
@@ -201,4 +201,4 @@ if __name__ == '__main__':
                 break
 
     except Exception as exc: # pylint: disable=broad-except
-        error_helpers.log_error(f'Processing in {__file__} failed.', exception=exc, machine=config_main['machine']['description'])
+        error_helpers.log_error(f'Processing in {__file__} failed.', exception=exc, previous_exception=exc.__context__, machine=config_main['machine']['description'])

--- a/cron/client.py
+++ b/cron/client.py
@@ -171,17 +171,17 @@ if __name__ == '__main__':
                 except ConfigurationCheckError as exc: # ConfigurationChecks indicate that before the job ran, some setup with the machine was incorrect. So we soft-fail here with sleeps
                     set_status('job_error', current_temperature, last_cooldown_time, data=str(exc), run_id=job._run_id)
                     if exc.status == Status.WARN: # Warnings is something like CPU% too high. Here short sleep
-                        error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, status=exc.status, run_id=job._run_id, name=job._name, url=job._url, machine=config_main['machine']['description'], sleep_duration=600)
+                        error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, previous_exception=exc.__context__, status=exc.status, run_id=job._run_id, name=job._name, url=job._url, machine=config_main['machine']['description'], sleep_duration=600)
                         if not args.testing:
                             time.sleep(600)
                     else: # Hard fails won't resolve on it's own. We sleep until next cluster validation
-                        error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, status=exc.status, run_id=job._run_id, name=job._name, url=job._url, machine=config_main['machine']['description'], sleep_duration=client_main['time_between_control_workload_validations'])
+                        error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, previous_exception=exc.__context__, status=exc.status, run_id=job._run_id, name=job._name, url=job._url, machine=config_main['machine']['description'], sleep_duration=client_main['time_between_control_workload_validations'])
                         if not args.testing:
                             time.sleep(client_main['time_between_control_workload_validations'])
 
                 except subprocess.CalledProcessError as exc:
                     set_status('job_error', current_temperature, last_cooldown_time, data=str(exc), run_id=job._run_id)
-                    error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, stdout=exc.stdout, stderr=exc.stderr, run_id=job._run_id, machine=config_main['machine']['description'], name=job._name, url=job._url)
+                    error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, previous_exception=exc.__context__, stdout=exc.stdout, stderr=exc.stderr, run_id=job._run_id, machine=config_main['machine']['description'], name=job._name, url=job._url)
                 except Exception as exc: # pylint: disable=broad-except
                     set_status('job_error', current_temperature, last_cooldown_time, data=str(exc), run_id=job._run_id)
                     error_helpers.log_error('Job processing in cluster failed (client.py)', exception=exc, previous_exception=exc.__context__, run_id=job._run_id, machine=config_main['machine']['description'], name=job._name, url=job._url)

--- a/runner.py
+++ b/runner.py
@@ -1888,13 +1888,13 @@ if __name__ == '__main__':
         print('####################################################################################\n\n', TerminalColors.ENDC)
 
     except FileNotFoundError as e:
-        error_helpers.log_error('File or executable not found', exception=e, run_id=runner._run_id)
+        error_helpers.log_error('File or executable not found', exception=e, previous_exception=e.__context__, run_id=runner._run_id)
     except subprocess.CalledProcessError as e:
-        error_helpers.log_error('Command failed', stdout=e.stdout, stderr=e.stderr, run_id=runner._run_id)
+        error_helpers.log_error('Command failed', stdout=e.stdout, stderr=e.stderr, previous_exception=e.__context__, run_id=runner._run_id)
     except RuntimeError as e:
-        error_helpers.log_error('RuntimeError occured in runner.py', exception=e, run_id=runner._run_id)
+        error_helpers.log_error('RuntimeError occured in runner.py', exception=e, previous_exception=e.__context__, run_id=runner._run_id)
     except BaseException as e:
-        error_helpers.log_error('Base exception occured in runner.py', exception=e, run_id=runner._run_id)
+        error_helpers.log_error('Base exception occured in runner.py', exception=e, previous_exception=e.__context__, run_id=runner._run_id)
     finally:
         if args.print_logs:
             for container_id_outer, std_out in runner.get_logs().items():


### PR DESCRIPTION
Previous exception messages are now also listed. Before it was easily masked what the true cause of the error was.

It could happen, that the container did not boot correctly and then the metrics could not be read also. However as error only the fail in reading the metrics was reported.

## This is now changed from:

```log
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 0_o >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Error: RuntimeError occured in runner.py

Exception (RuntimeError): PowermetricsProvider returned error message: Metrics provider powermetrics seems to have not produced any measurements. Metrics log file was empty. Either consider having a higher sample rate or turn off provider.
...
``` 

## To:

```log
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 0_o >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Error: RuntimeError occured in runner.py

Exception (RuntimeError): PowermetricsProvider returned error message: Metrics provider powermetrics seems to have not produced any measurements. Metrics log file was empty. Either consider having a higher sample rate or turn off provider.
Initial_exceptions (OSError): Docker run failed
Stderr: docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "sleep asd": executable file not found in $PATH: unknown.

```

<!-- greptile_comment -->

## Greptile Summary

Enhanced error logging across the application by including previous exception information, improving the ability to diagnose root causes of cascading failures, particularly for container boot and metric reading issues.

- Added `previous_exception=exc.__context__` parameter in error logging calls throughout `/cron/client.py`
- Modified error handling blocks to capture complete exception chain instead of just final error
- Improved error messages now show full error trace from initial container failure to subsequent metric reading errors
- Consistent error handling approach with `/api/main.py` and `/runner.py` changes



<!-- /greptile_comment -->