### PR TITLE
HealthCheck JSON errors are now scraped

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1013,7 +1013,7 @@ class Runner:
                                 if ps.returncode != 0 or health == '<nil>':
                                     raise RuntimeError(f"Health check for service '{dependent_service}' was requested by '{service_name}', but service has no healthcheck implemented! (Output was: {health})")
                                 if health == 'unhealthy':
-                                    healthcheck_errors = subprocess.check_output(['docker', 'inspect', "--format='{{json .State.Health}}'", dependent_container_name], encoding='UTF-8')
+                                    healthcheck_errors = subprocess.check_output(['docker', 'inspect', "--format={{json .State.Health}}", dependent_container_name], encoding='UTF-8')
                                     raise RuntimeError(f'Health check of container "{dependent_container_name}" failed terminally with status "unhealthy" after {time_waited}s. Health check errors: {healthcheck_errors}')
                             elif condition == 'service_started':
                                 pass
@@ -1029,7 +1029,7 @@ class Runner:
                     if state != 'running':
                         raise RuntimeError(f"State check of dependent services of '{service_name}' failed! Container '{dependent_container_name}' is not running but '{state}' after waiting for {time_waited} sec! Consider checking your service configuration, the entrypoint of the container or the logs of the container.")
                     if health != 'healthy':
-                        healthcheck_errors = subprocess.check_output(['docker', 'inspect', "--format='{{json .State.Health}}'", dependent_container_name], encoding='UTF-8')
+                        healthcheck_errors = subprocess.check_output(['docker', 'inspect', "--format={{json .State.Health}}", dependent_container_name], encoding='UTF-8')
                         raise RuntimeError(f"Health check of dependent services of '{service_name}' failed! Container '{dependent_container_name}' is not healthy but '{health}' after waiting for {time_waited} sec!\nHealth check errors: {healthcheck_errors}")
 
             if 'command' in service:  # must come last


### PR DESCRIPTION
This PR adds a more detailed error message in case the HealthCheck of the docker containers failed.

This behaviour was needed as some startup failed to pass through the NetworkConnectionsProxyContainerProvider provider

Thanks @davidkopp for bringing this up

New error message looks similar like this:

```log
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 0_o >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Error: RuntimeError occured in runner.py

Exception (RuntimeError): Health check of dependent services of 'k6' failed! Container 'modulith' is not healthy but 'starting' after waiting for 5 sec!
Health check errors: '{"Status":"starting","FailingStreak":0,"Log":[{"Start":"2025-03-20T06:12:03.47192226Z","End":"2025-03-20T06:12:03.537165968Z","ExitCode":1,"Output":"Error:\nrequest error: CONNECT proxy failed: proxy server responded 500/500\n\n\n"}]}'

Previous_exception (NoneType): None
Run_id (UUID): 07a3f88f-5fd2-40d8-a125-4b0b1bca4308
Run-ID Link: http://metrics.green-coding.internal:9142/stats.html?id=07a3f88f-5fd2-40d8-a125-4b0b1bca4308

<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 0_o >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
```

<!-- greptile_comment -->

## Greptile Summary

Enhanced Docker container health check error reporting by improving JSON output formatting and readability when health checks fail, making container startup issues easier to diagnose.

- Modified `runner.py` to remove single quotes from `docker inspect` format string for cleaner JSON output
- Added test scenarios in `/tests/data/usage_scenarios/healthcheck_error_container_unhealthy.yml` to validate unhealthy container states
- Added test case `/tests/data/usage_scenarios/healthcheck_error_max_waiting_time.yml` for timeout validation
- Added test case `/tests/data/usage_scenarios/healthcheck_missing_start_period.yml` for start period validation



<!-- /greptile_comment -->