### PR TITLE
SSH connection and other active user warning

### DIFF
--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -44,6 +44,15 @@ def check_one_energy_and_scope_machine_provider():
     energy_machine_providers = [provider for provider in metric_providers if ".energy" in provider and ".machine" in provider]
     return len(energy_machine_providers) <= 1
 
+def check_ssh_connections():
+    ps = subprocess.run(['pgrep', 'sshd'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    return ps.stdout == b'' and ps.stderr == b'' and ps.returncode == 1
+
+def check_active_users():
+    ps = subprocess.run(['who'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    return ps.stdout == b'' and ps.stderr == b'' and ps.returncode == 0
+
+
 def check_tmpfs_mount():
     return not any(partition.mountpoint == '/tmp' and partition.fstype != 'tmpfs' for partition in psutil.disk_partitions())
 
@@ -96,6 +105,8 @@ start_checks = [
     (check_db, Status.ERROR, 'db online', 'This text will never be triggered, please look in the function itself'),
     (check_one_energy_and_scope_machine_provider, Status.ERROR, 'single energy scope machine provider', 'Please only select one provider with energy and scope machine'),
     (check_tmpfs_mount, Status.INFO, 'tmpfs mount', 'We recommend to mount tmp on tmpfs'),
+    (check_ssh_connections, Status.WARN, 'ssh connections', 'There are open SSH connections on the system. Please terminate all connections before measurement.'),
+    (check_active_users, Status.WARN, 'active users', 'There are active users on the system. We recommend running measurements unattended.'),
     (check_cpu_utilization, Status.WARN, '< 5% CPU utilization', 'Your system seems to be busy. Utilization is above 5%. Consider terminating some processes for a more stable measurement.'),
     (check_free_disk, Status.ERROR, '1 GiB free hdd space', 'We recommend to free up some disk space (< 1GiB available)'),
     (check_free_memory, Status.ERROR, '1 GiB free memory', 'No free memory! Please kill some programs (< 1GiB available)'),

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -44,6 +44,13 @@ GMT_RESOURCES = {
 # skipped for environment reasons (unsupported platform, tool unavailable, etc).
 NOT_CONFIGURED = 'not_configured'
 
+# Sentinel returned by a check when it is skipped because it is not implemented / not
+# applicable on the current platform (macOS, Windows - these checks are Linux-only).
+# Distinct from NOT_CONFIGURED (missing machine.* option) and from None (other
+# environment-specific skips, e.g. a tool being unavailable on an otherwise-supported
+# platform).
+NOT_IMPLEMENTED = 'not_implemented'
+
 ######## CHECK FUNCTIONS ########
 def check_db(*_, **__):
     try:
@@ -133,11 +140,57 @@ def check_docker_daemon(*_, **__):
 
 def check_utf_encoding(*_, **__):
     if host_platform.is_windows():
-        return True
+        return NOT_IMPLEMENTED
     return locale.getpreferredencoding().lower() == sys.getdefaultencoding().lower() == 'utf-8'
 
 def check_tty_attached(*_, **__):
     return not sys.stdin.isatty()
+
+
+def check_ssh_session(*_, **__):
+    if platform.system() in ('Darwin', 'Windows'):
+        return NOT_IMPLEMENTED
+
+    ssh_ports = set()
+    try:
+        with open('/etc/ssh/sshd_config', 'r', encoding='utf-8') as f:
+            for line in f:
+                match = re.match(r'^\s*Port\s+(\d+)', line, re.IGNORECASE)
+                if match:
+                    ssh_ports.add(match.group(1))
+    except OSError as exc:
+        raise RuntimeError('Could not read /etc/ssh/sshd_config to determine SSH configuration to guard GMT against lingering SSH connections measurement noise. If you prefer no SSH checking you can disable via --dev-no-system-checks=check_ssh_session') from exc
+    if not ssh_ports:
+        raise RuntimeError('/etc/ssh/sshd_config did contain no valid SSH port to guard GMT against lingering SSH connections measurement noise. If you prefer no SSH checking you can disable via --dev-no-system-checks=check_ssh_session')
+
+    # ss -tn (without -p) reports established connections and their ports without
+    # needing root - only the process-name lookup (-p) requires privileges, which we
+    # don't need here. This is what lets us check non-standard SSH ports without root.
+    port_filter = ' or '.join(f'sport = :{port} or dport = :{port}' for port in ssh_ports)
+    ss_result = subprocess.run(
+        ['ss', '-Htn', 'state', 'established', f'( {port_filter} )'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        encoding='UTF-8', errors='replace', check=False,
+    )
+    if ss_result.returncode == 0 and ss_result.stdout.strip():
+        return False  # established connection on an SSH port
+
+    # Independent signal: interactive login sessions recorded via utmp, regardless of
+    # which port sshd used. Catches setups ss might miss.
+    who_result = subprocess.run(
+        ['who'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        encoding='UTF-8', errors='replace', check=False,
+    )
+
+    for line in who_result.stdout.splitlines():
+        if 'pts/' not in line or '(' not in line:
+            continue
+        remote = line.rsplit('(', 1)[-1].rstrip(')\n')
+        if remote and remote not in (':0', '0.0'):
+            return False  # remote login session present
+
+    return True
 
 
 def check_swap_disabled(*_, **__):
@@ -621,11 +674,13 @@ start_checks = (
     (check_swap_disabled, Status.WARN, 'swap disabled', 'Your system uses a swap filesystem. This can lead to very instable measurements. Please disable swap.'),
     (check_kernel_watchdog, Status.WARN, 'kernel watchdog disabled', 'A kernel lockup watchdog (kernel.watchdog / nmi_watchdog / soft_watchdog) is active. These periodically fire NMIs/interrupts and can create noise in measurements. Disable via sysctl for reliable benchmarking.'),
     (check_tty_attached, Status.WARN, 'tty attached', 'GMT runs with a TTY attached. This will create relevant overhead. This is usually what you want in local development, but for undisturbed measurements consider going for a measurement cluster [See https://docs.green-coding.io/docs/installation/installation-cluster/].'),
+    (check_ssh_session, Status.WARN, 'ssh session active', 'An active SSH session was detected on this machine. Remote sessions can add CPU/network noise and scheduler interference to measurements. This is usually fine in local development, but for undisturbed measurements consider going for a measurement cluster [See https://docs.green-coding.io/docs/installation/installation-cluster/].'),
 )
 
 end_checks = (
     (check_suspend, Status.ERROR, 'system suspend', 'System has gone into suspend during measurement. This will skew all measurement data. If GMT shall ever be able to correctly account for suspend states please note that metric providers must support CLOCK_BOOTIME. See https://github.com/green-coding-solutions/green-metrics-tool/pull/1229 for discussion.'),
     (check_steal_time, Status.ERROR, 'cpu steal time', 'The CPU has accounted steal time. This means the measurement could have been interrupted and / or the VM that you are running in halted. This will lead to broken measurement data as time jumps can occur.'),
+    (check_ssh_session, Status.WARN, 'ssh session active', 'An active SSH session was detected on this machine. Remote sessions can add CPU/network noise and scheduler interference to measurements. This is usually fine in local development, but for undisturbed measurements consider going for a measurement cluster [See https://docs.green-coding.io/docs/installation/installation-cluster/].'),
 
 )
 
@@ -703,6 +758,8 @@ def system_check(mode='start', system_check_threshold=3, disabled_checks=None, r
             formatted_key = check[2].ljust(max_key_length)
             if retval is NOT_CONFIGURED:
                 output = f"{TerminalColors.OKCYAN}INFO{TerminalColors.ENDC} (Skipped: not configured in config.yml)"
+            elif retval is NOT_IMPLEMENTED:
+                output = f"{TerminalColors.OKCYAN}INFO{TerminalColors.ENDC} (Skipped: not implemented on this platform. Switch to Linux, if possible, to enable this check.)"
             elif retval or retval is None:
                 output = f"{TerminalColors.OKGREEN}OK{TerminalColors.ENDC}"
             else:

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -158,10 +158,13 @@ def check_ssh_session(*_, **__):
                 match = re.match(r'^\s*Port\s+(\d+)', line, re.IGNORECASE)
                 if match:
                     ssh_ports.add(match.group(1))
-    except OSError as exc:
-        raise RuntimeError('Could not read /etc/ssh/sshd_config to determine SSH configuration to guard GMT against lingering SSH connections measurement noise. If you prefer no SSH checking you can disable via --dev-no-system-checks=check_ssh_session') from exc
+    except FileNotFoundError:
+        pass  # sshd_config not present - fall back to the default port below
+    # Any other OSError (e.g. PermissionError - file exists but is not readable) is
+    # intentionally left to propagate: silently falling back to port 22 there could mask
+    # a real SSH session on a different, unreadable-config port, so this must hard fail.
     if not ssh_ports:
-        raise RuntimeError('/etc/ssh/sshd_config did contain no valid SSH port to guard GMT against lingering SSH connections measurement noise. If you prefer no SSH checking you can disable via --dev-no-system-checks=check_ssh_session')
+        ssh_ports.add('22') # If no directive is found in file port 22 is standard.
 
     # ss -tn (without -p) reports established connections and their ports without
     # needing root - only the process-name lookup (-p) requires privileges, which we

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -160,9 +160,15 @@ def check_ssh_session(*_, **__):
                     ssh_ports.add(match.group(1))
     except FileNotFoundError:
         pass  # sshd_config not present - fall back to the default port below
-    # Any other OSError (e.g. PermissionError - file exists but is not readable) is
-    # intentionally left to propagate: silently falling back to port 22 there could mask
-    # a real SSH session on a different, unreadable-config port, so this must hard fail.
+    except OSError as exc:
+        # e.g. PermissionError - file exists but is not readable. Silently falling back to
+        # port 22 here could mask a real SSH session on a different, unreadable-config
+        # port, so this must hard fail rather than degrade quietly.
+        raise RuntimeError(
+            "Could not read /etc/ssh/sshd_config to determine SSH configuration to guard "
+            "GMT against lingering SSH connections measurement noise. If you prefer no SSH "
+            "checking you can disable via --dev-no-system-checks=check_ssh_session"
+        ) from exc
     if not ssh_ports:
         ssh_ports.add('22') # If no directive is found in file port 22 is standard.
 


### PR DESCRIPTION
 - Added warning if there are active SSH connections on the system which could influence measurement
 - Added warning if there are active users on the system whose activity could influence measurement

<!-- greptile_comment -->

## Greptile Summary

Added system checks to warn users about active SSH connections and logged-in users that could affect measurement accuracy in the Green Metrics Tool.

- Added check in `lib/system_checks.py` to detect active SSH connections using pgrep sshd
- Added check in `lib/system_checks.py` to identify active users via the who command
- Both checks are implemented as WARN level to alert without blocking execution
- Checks align with GMT's goal of ensuring accurate energy consumption measurements



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added warning-level SSH session checks for active SSH connections and remote interactive sessions.
- Registered the check in the start and end system-check suites.
- Added `NOT_IMPLEMENTED` handling for unsupported platforms, including Windows encoding checks.
- Added output handling for checks that return `NOT_IMPLEMENTED`.
- Raised errors when SSH configuration cannot be read or contains no valid ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->