### PR TITLE
Timeline badges are now for 30 days

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -189,7 +189,7 @@ def get_run_info(user, run_id):
     params = (user.is_super_user(), user.visible_users(), run_id)
     return DB().fetch_one(query, params=params, fetch_mode='dict')
 
-def get_timeline_query(user, uri, filename, machine_id, branch, metrics, phase, start_date=None, end_date=None, detail_name=None, limit_365=False, sorting='run'):
+def get_timeline_query(user, uri, filename, machine_id, branch, metrics, phase, start_date=None, end_date=None, detail_name=None, sorting='run'):
 
     if filename is None or filename.strip() == '':
         filename =  'usage_scenario.yml'
@@ -223,10 +223,6 @@ def get_timeline_query(user, uri, filename, machine_id, branch, metrics, phase, 
         detail_name_condition =  "AND p.detail_name = %s"
         params.append(detail_name)
 
-    limit_365_condition = ''
-    if limit_365:
-        limit_365_condition = "AND r.created_at >= CURRENT_DATE - INTERVAL '365 days'"
-
     sorting_condition = 'r.commit_timestamp ASC, r.created_at ASC'
     if sorting is not None and sorting.strip() == 'run':
         sorting_condition = 'r.created_at ASC, r.commit_timestamp ASC'
@@ -252,7 +248,6 @@ def get_timeline_query(user, uri, filename, machine_id, branch, metrics, phase, 
                 {start_date_condition}
                 {end_date_condition}
                 {detail_name_condition}
-                {limit_365_condition}
                 AND r.commit_timestamp IS NOT NULL
                 AND r.failed IS FALSE
             ORDER BY

--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -1,7 +1,7 @@
 
 import orjson
 from xml.sax.saxutils import escape as xml_escape
-from datetime import date
+from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Response, Depends
 from fastapi.responses import ORJSONResponse
@@ -413,7 +413,9 @@ async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch
     if artifact := get_artifact(ArtifactType.BADGE, f"{user._id}_{uri}_{filename}_{machine_id}_{branch}_{metrics}_{detail_name}_{unit}"):
         return Response(content=str(artifact), media_type="image/svg+xml")
 
-    query, params = get_timeline_query(user, uri,filename,machine_id, branch, metrics, '[RUNTIME]', detail_name=detail_name, limit_365=True)
+    date_30_days_ago = datetime.now() - timedelta(days=30)
+
+    query, params = get_timeline_query(user, uri,filename,machine_id, branch, metrics, '[RUNTIME]', detail_name=detail_name, start_date=date_30_days_ago.strftime('%Y-%m-%d'), end_date=datetime.now())
 
     # query already contains user access check. No need to have it in aggregate query too
     query = f"""
@@ -432,14 +434,14 @@ async def get_timeline_badge(detail_name: str, uri: str, machine_id: int, branch
     if data is None or data == [] or data[1] is None: # special check for data[1] as this is aggregate query which always returns result
         return Response(status_code=204) # No-Content
 
-    cost = data[1]/data[0]
+    cost = data[1]
     display_in_joules = (unit == 'joules') #pylint: disable=superfluous-parens
     [rescaled_cost, rescaled_unit] = convert_value(cost, data[3], display_in_joules)
     rescaled_cost = f"+{rescaled_cost:.2f}" if abs(cost) == cost else f"{rescaled_cost:.2f}"
 
     badge = anybadge.Badge(
         label=xml_escape('Run Trend'),
-        value=xml_escape(f"{rescaled_cost} {rescaled_unit} per day"),
+        value=xml_escape(f"{rescaled_cost} {rescaled_unit} per run"),
         num_value_padding_chars=1,
         default_color='orange')
 

--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -84,7 +84,7 @@
                                         <div class="header">
                                             Badge Info
                                         </div>
-                                        <p>Badges are showing always the trend over the last 365 days and calculations will always be on the Runtime phase as well as calculated by sorting on commit timestamp.</p>
+                                        <p>Badges are showing always the trend over the last 30 days and calculations will always be on the Runtime phase as well as calculated by sorting on commit timestamp.</p>
                                         <p>Badges are cached and will only update once per day, even if the charts already show new data.</p>
                                     </div>
                                 </div>


### PR DESCRIPTION
- Timeline badges now are for 30 days (max) instead of 365 days
- Timeline trend was normalized over measurements. This is now removed and correct slope is shown per run

<!-- greptile_comment -->

## Greptile Summary

Modified timeline badge functionality to focus on 30-day windows instead of 365 days and updated trend calculations to show actual per-run changes rather than normalized values.

- Changed time window from 365 to 30 days in `api/api_helpers.py` by removing `limit_365` parameter
- Removed trend normalization in `api/scenario_runner.py` to show actual slope per run instead of normalized daily values
- Updated badge label from 'per day' to 'per run' in `api/scenario_runner.py` to reflect the new calculation method
- Modified badge info message in `frontend/timeline.html` to indicate 30-day period



<!-- /greptile_comment -->