### PR TITLE
Installer negate

### DIFF
--- a/.devcontainer/codespace-setup.sh
+++ b/.devcontainer/codespace-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-/workspaces/green-metrics-tool/install_linux.sh -p testpw -a "https://${CODESPACE_NAME}-9142.app.github.dev" -m "https://${CODESPACE_NAME}-9143.app.github.dev" -t -i -s -l -z -Z
+/workspaces/green-metrics-tool/install_linux.sh -p testpw -a "https://${CODESPACE_NAME}-9142.app.github.dev" -m "https://${CODESPACE_NAME}-9143.app.github.dev" -T -I -S -L -z -Z -f
 source venv/bin/activate
 
 # Also add XGBoost, as we need it

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -40,9 +40,9 @@ runs:
       working-directory: ${{ inputs.gmt-directory }}
       run: |
         if ${{inputs.ee}}; then
-          ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -b -t -l -z -f -j -d -g -e github-actions-test
+          ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -B -T -L -z -f -j -d -g -e github-actions-test
         else
-          ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -b -t -l -z -f -j
+          ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -B -T -L -z -f -j
         fi
         source venv/bin/activate
       env:

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -355,7 +355,7 @@ function check_optarg() {
     fi
 }
 
-while getopts ":p:a:m:nhtbisurlc:k:e:zZdDgGfFjJ" o; do
+while getopts ":p:a:m:NhTBISuRLc:k:e:zZdDgGfFjJ" o; do
     case "$o" in
         \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
         :)  echo "Error: Option -$OPTARG requires an argument" >&2; exit 1 ;;
@@ -371,35 +371,35 @@ while getopts ":p:a:m:nhtbisurlc:k:e:zZdDgGfFjJ" o; do
             check_optarg 'm' $OPTARG
             metrics_url=${OPTARG}
             ;;
-        b)
+        B)
             build_docker_containers=false
             ;;
-        w)
+        W)
             modify_hosts=false
             ;;
-        n)
+        N)
             install_python_packages=false
             ;;
-        t)
+        T)
             ask_tmpfs=false
             ;;
-        i)
+        I)
             install_ipmi=false
             ;;
-        s)
+        S)
             install_sensors=false
             ;;
-        r)
+        R)
             install_msr_tools=false
             ;;
         u)
             use_system_site_packages=true
             ;;
-        l)
+        L)
             enable_ssl=false
             ask_ssl=false
             ;;
-        x)
+        X)
             build_sgx=false
             ;;
         c)
@@ -457,22 +457,22 @@ while getopts ":p:a:m:nhtbisurlc:k:e:zZdDgGfFjJ" o; do
             ;;
 
         h)
-            echo 'usage: ./install_XXX [p:] [a:] [m:] [n] [h] [t] [b] [i] [s] [u] [r] [l] [c:] [k:] [e:] [z] [Z] [d] [D] [g] [G] [f] [F] [j] [J]'
+            echo 'usage: ./install_XXX [p:] [a:] [m:] [N] [h] [T] [B] [I] [S] [u] [R] [L] [c:] [k:] [e:] [z] [Z] [d] [D] [g] [G] [f] [F] [j] [J]'
             echo ''
             echo 'options:'
             echo -e '  -p DB_PW:\t\tSupply DB password'
             echo -e '  -a API_URL:\t\tSupply API URL'
             echo -e '  -m METRICS_URL:\tSupply Dashboard URL'
-            echo -e '  -b:\t\t\tBuild docker containers'
-            echo -e '  -w:\t\t\tModify hosts'
-            echo -e '  -n:\t\t\tInstall Python packages'
-            echo -e '  -t:\t\t\tAsk for tmpfs remounting'
-            echo -e '  -i:\t\t\tInstall IPMI drivers'
-            echo -e '  -s:\t\t\tInstall lm-sensors package'
-            echo -e '  -r:\t\t\tInstall MSR tools'
+            echo -e '  -B:\t\t\tDo not build docker containers'
+            echo -e '  -W:\t\t\tDo not Modify hosts'
+            echo -e '  -N:\t\t\tDo not install Python packages'
+            echo -e '  -T:\t\t\t Do not ask for tmpfs remounting'
+            echo -e '  -I:\t\t\tDo not install IPMI drivers'
+            echo -e '  -S:\t\t\tDo not install lm-sensors package'
+            echo -e '  -R:\t\t\tDo not install MSR tools'
             echo -e '  -u:\t\t\tUse Python system packages'
-            echo -e '  -l:\t\t\tEnable SSL'
-            echo -e '  -x:\t\t\tBuild SGX checking binaries'
+            echo -e '  -L:\t\t\tDisable SSL'
+            echo -e '  -X:\t\t\tDo not build SGX checking binaries'
             echo -e '  -c:\t\t\tSupply SSL .crt file'
             echo -e '  -k:\t\t\tSupply SSL .key file'
             echo -e '  -e: EE_TOKEN\t\tActivate enterprise features and store token'

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -355,7 +355,7 @@ function check_optarg() {
     fi
 }
 
-while getopts ":p:a:m:NhTBISuRLc:k:e:zZdDgGfFjJ" o; do
+while getopts ":p:a:m:NhTBWISuRLc:k:e:zZdDgGfFjJ" o; do
     case "$o" in
         \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
         :)  echo "Error: Option -$OPTARG requires an argument" >&2; exit 1 ;;
@@ -466,7 +466,7 @@ while getopts ":p:a:m:NhTBISuRLc:k:e:zZdDgGfFjJ" o; do
             echo -e '  -B:\t\t\tDo not build docker containers'
             echo -e '  -W:\t\t\tDo not Modify hosts'
             echo -e '  -N:\t\t\tDo not install Python packages'
-            echo -e '  -T:\t\t\t Do not ask for tmpfs remounting'
+            echo -e '  -T:\t\t\tDo not ask for tmpfs remounting'
             echo -e '  -I:\t\t\tDo not install IPMI drivers'
             echo -e '  -S:\t\t\tDo not install lm-sensors package'
             echo -e '  -R:\t\t\tDo not install MSR tools'


### PR DESCRIPTION
- Install help was telling switches are positive. They are negative though
- Brought capital switches to codepaces. Activating GMT

<!-- greptile_comment -->

## Greptile Summary

This PR standardizes command-line flags in the GMT installer scripts to use uppercase letters for disabling features, making the interface more consistent and intuitive.

- Changed lowercase flags to uppercase in `install_linux.sh` (-b, -t, -l → -B, -T, -L) to properly reflect their negative meaning
- Updated `codespace-setup.sh` with uppercase flags (-T, -I, -S, -L) and added XGBoost provider configuration
- Modified help messages in `install_shared.sh` to accurately describe uppercase flags as feature disablers
- Added port 9143 configuration for frontend access in GitHub Codespaces



<!-- /greptile_comment -->