### PR TITLE
Add option to print stats to CLI

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1897,7 +1897,7 @@ if __name__ == '__main__':
 
 
         if args.print_phase_stats:
-            data = DB().fetch_all('SELECT metric,detail_name, value type, unit FROM phase_stats WHERE run_id = %s and phase LIKE %s ', params=(runner._run_id, f"%{args.print_phase_stats}"))
+            data = DB().fetch_all('SELECT metric, detail_name, value, type, unit FROM phase_stats WHERE run_id = %s and phase LIKE %s ', params=(runner._run_id, f"%{args.print_phase_stats}"))
             print(f"Data for phase {args.print_phase_stats}")
             for el in data:
                 print(el)

--- a/runner.py
+++ b/runner.py
@@ -1811,6 +1811,7 @@ if __name__ == '__main__':
     parser.add_argument('--dev-no-phase-stats', action='store_true', help='Do not calculate phase stats.')
     parser.add_argument('--dev-cache-build', action='store_true', help='Checks if a container image is already in the local cache and will then not build it. Also doesn\'t clear the images after a run. Please note that skipping builds only works the second time you make a run since the image has to be built at least initially to work.')
     parser.add_argument('--dev-no-optimizations', action='store_true', help='Disable analysis after run to find possible optimizations.')
+    parser.add_argument('--print-phase-stats', type=str, help='Prints the stats for the given phase to the CLI for quick verification without the Dashboard. Try "[RUNTIME]" as argument.')
     parser.add_argument('--print-logs', action='store_true', help='Prints the container and process logs to stdout')
 
     args = parser.parse_args()
@@ -1893,6 +1894,14 @@ if __name__ == '__main__':
         print(TerminalColors.OKGREEN,'\n\n####################################################################################')
         print(f"Please access your report on the URL {GlobalConfig().config['cluster']['metrics_url']}/stats.html?id={runner._run_id}")
         print('####################################################################################\n\n', TerminalColors.ENDC)
+
+
+        if args.print_phase_stats:
+            data = DB().fetch_all('SELECT metric,detail_name, value type, unit FROM phase_stats WHERE run_id = %s and phase LIKE %s ', params=(runner._run_id, f"%{args.print_phase_stats}"))
+            print(f"Data for phase {args.print_phase_stats}")
+            for el in data:
+                print(el)
+            print('')
 
     except FileNotFoundError as e:
         error_helpers.log_error('File or executable not found', exception=e, previous_exception=e.__context__, run_id=runner._run_id)


### PR DESCRIPTION
For quick debugging or for mouse lazy people I added a CLI printing option for the stats.

Will probalby be refined in the future but is nice to have for now.

Triggered by `--print-phase-stats "[RUNTIME]"`

Or --print-phase-stats "Other phase name"

Looks like this:

```

####################################################################################
Please access your report on the URL http://metrics.green-coding.internal:9142/stats.html?id=a2c521a3-00ca-4b01-a11d-5b2a3d464ae0
####################################################################################


Data for phase [RUNTIME]
('embodied_carbon_share_machine', '[SYSTEM]', 7278, 'ug')
('psu_carbon_ac_sdia_machine', '[machine]', 10212, 'ug')
('psu_power_ac_sdia_machine', '[machine]', 16625, 'mW')
('psu_energy_ac_sdia_machine', '[machine]', 84322525, 'uJ')
('cpu_utilization_mach_system', '[system]', 1596, 'Ratio')
('phase_time_syscall_system', '[SYSTEM]', 5071919, 'us')
```

<!-- greptile_comment -->

## Greptile Summary

This pull request adds a new CLI option (--print-phase-stats) in runner.py to print phase statistics directly from the database for quick debugging. It also fixes the SQL syntax within the query to ensure proper column separation.

- Updated /runner.py to parse the '--print-phase-stats' argument and execute a corresponding database query.
- Corrected SQL syntax by inserting missing commas between column names.
- Integrates with existing logging and error handling frameworks.



<!-- /greptile_comment -->