### PR TITLE
Moving to milli-watt hours

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -74,12 +74,12 @@ def convert_value(value, unit, display_in_joules=False):
         if display_in_joules:
             return [value / 1_000, unit[1:]]
         else:
-            return [value / (1_000 * 3_600) , f"Wh{unit[2:]}"]
+            return [value / (3_600) , f"mWh{unit[2:]}"]
     elif compare_unit == 'uJ':
         if display_in_joules:
             return [value / 1_000_000, unit[1:]]
         else:
-            return [value / (1_000_000 * 3_600), f"Wh{unit[2:]}"]
+            return [value / (1_000 * 3_600), f"mWh{unit[2:]}"]
     elif compare_unit == 'mW':
         return [value / 1_000, unit[1:]]
     elif compare_unit == 'Ratio':

--- a/frontend/js/helpers/converters.js
+++ b/frontend/js/helpers/converters.js
@@ -21,12 +21,12 @@ const convertValue = (value, unit) => {
             if (display_in_joules)
                 return [transformIfNotNull(value, 1_000), unit.substr(1)];
             else
-                return [transformIfNotNull(value, 1_000 * 3_600), `Wh${unit.substr(2)}`];
+                return [transformIfNotNull(value, 3_600), `mWh${unit.substr(2)}`];
         case 'uJ':
             if (display_in_joules)
                 return [transformIfNotNull(value, 1_000_000), unit.substr(1)];
             else
-                return [transformIfNotNull(value, 1_000_000 * 3_600), `Wh${unit.substr(2)}`];
+                return [transformIfNotNull(value, 1_000 * 3_600), `mWh${unit.substr(2)}`];
         case 'mW':
             return [transformIfNotNull(value, 1_000), unit.substr(1)];
         case 'Ratio':

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -45,7 +45,7 @@ const toggleJoules = () => {
 }
 const showDisplayTextJoules = (display_in_joules) => {
     if(display_in_joules) $("#energy-display").html("Currently showing <b>Joules</b>");
-    else $("#energy-display").html("Currently showing <b>Watt-Hours</b>");
+    else $("#energy-display").html("Currently showing <b>milli-Watt-Hours</b>");
 }
 
 const toggleTimelinesEnergyPower = () => {


### PR DESCRIPTION
This PR moves GMT to milli-watt-hours by default.

See Discussion: https://github.com/green-coding-solutions/green-metrics-tool/discussions/1132