### PR TITLE
Introduces phase to badge

### DIFF
--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -473,7 +473,7 @@ async def get_badge_single(run_id: str, metric: str = 'cpu_energy_rapl_msr_compo
         phase = f"%_{phase}"
     else:
         phase_label = None
-        phase = f"%_[RUNTIME]"
+        phase = '%_[RUNTIME]'
 
     # we believe that there is no injection possible to the artifact store and any string can be constructured here ...
     if artifact := get_artifact(ArtifactType.BADGE, f"{user._id}_{run_id}_{metric}_{unit}_{phase}"):

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -71,6 +71,19 @@
                     <div class="ui active tab segment" data-tab="three">
                         <div id="run-badges">
                         </div>
+                        <div class="ui icon message warning">
+                            <i class="info circle icon"></i>
+                            <div class="content">
+                                <div class="header">
+                                    Badge missing or not showing data?
+                                </div>
+                                <ul>
+                                    <li>Badges are for Runtime phase only by default. Append <b>&amp;phase=ENTER_PHASE_NAME</b> to img src show specific phase</li>
+                                    <li>Badges are only visible for the default user. If you are logged in with a different account badges cannot show. Please use a HTTP proxy like Cloudflare workers to tunnel the page if needed or enable user visibility.</li>
+
+                                </ul>
+                            </div>
+                        </div>
                     </div>
                     <div class="ui tab segment" data-tab="four" id="machine-specs-tab">
                         <table class="table-hover" id="machine-specs"></table>

--- a/tests/api/test_api_scenario_runner.py
+++ b/tests/api/test_api_scenario_runner.py
@@ -150,12 +150,37 @@ def test_get_insights():
 def test_get_badge():
     Tests.import_demo_data()
 
-    response = requests.get(f"{API_URL}/v1/badge/single/a416057b-235f-41d8-9fb8-9bcc70a308e7?metric=cpu_energy_rapl_msr_component", timeout=15)
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=cpu_energy_rapl_msr_component", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'CPU Energy (Package)' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
     assert '0.01 Wh' in response.text, Tests.assertion_info('success', response.text)
 
-    response = requests.get(f"{API_URL}/v1/badge/single/a416057b-235f-41d8-9fb8-9bcc70a308e7?metric=cpu_energy_rapl_msr_component&unit=joules", timeout=15)
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=cpu_energy_rapl_msr_component&unit=joules", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
     assert 'CPU Energy (Package)' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
-    assert '45.05 J' in response.text, Tests.assertion_info('success', response.text)
+    assert '46.77 J' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=phase_time_syscall_system", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Phase Duration' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
+    assert '5.31 s' in response.text, Tests.assertion_info('success', response.text)
+
+    # will not react to Joules
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=phase_time_syscall_system&unit=joules", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Phase Duration' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
+    assert '5.31 s' in response.text, Tests.assertion_info('success', response.text)
+
+
+def test_get_badge_with_phase():
+    Tests.import_demo_data()
+
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=psu_power_dc_rapl_msr_machine", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Machine Power' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
+    assert '14.80 W' in response.text, Tests.assertion_info('success', response.text)
+
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=psu_power_dc_rapl_msr_machine&phase=[BOOT]", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert 'Machine Power {[BOOT]}' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
+    assert '21.46 W' in response.text, Tests.assertion_info('success', response.text)


### PR DESCRIPTION
Runtime default phase
![Screenshot 2025-03-29 at 9 53 06 AM](https://github.com/user-attachments/assets/4c9aa660-f1be-49f2-a700-25ab0c71956b)

Custom Phase
![Screenshot 2025-03-29 at 9 53 02 AM](https://github.com/user-attachments/assets/4d71fdd4-17e5-48bc-8b45-bebe9845e761)



<!-- greptile_comment -->

## Greptile Summary

This PR adds an optional phase parameter to the get_badge_single endpoint, updating both SQL and artifact key construction, and extends the test suite to cover badge phase scenarios.

- Modified api/scenario_runner.py to incorporate a phase parameter, defaulting to '%_[RUNTIME]' and updating SQL match logic.
- Updated tests/api/test_api_scenario_runner.py to validate default and custom phase badge outputs, including adjusting energy conversion values.
- Adjustments ensure badge customization correctly reflects phase data in label and power conversion outputs.



<!-- /greptile_comment -->