### PR TITLE
Redirecting port 80 to SSL

### DIFF
--- a/docker/nginx/api.conf.example
+++ b/docker/nginx/api.conf.example
@@ -1,3 +1,11 @@
+server { # only to block also port 80 requests in pre-fetchers
+    listen 80;
+    server_name __API_URL__;
+
+    # Redirect HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
 server {
 
 #__DEFAULT__    listen [::]:9142;
@@ -9,7 +17,7 @@ server {
 #__SSL__    ssl_certificate_key /etc/ssl/production.key;
 
 
-    server_name __API_URL__ ;
+    server_name __API_URL__;
 
     location = /favicon.ico {
          root /var/www/green-metrics-tool/frontend;

--- a/docker/nginx/block.conf.example
+++ b/docker/nginx/block.conf.example
@@ -1,3 +1,11 @@
+server { # only to block also port 80 requests in pre-fetchers
+    listen 80;
+    server_name _;
+
+    # Redirect HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
 server {
 
 #__DEFAULT__    listen [::]:9142 default_server;

--- a/docker/nginx/frontend.conf.example
+++ b/docker/nginx/frontend.conf.example
@@ -1,3 +1,11 @@
+server { # only to block also port 80 requests in pre-fetchers
+    listen 80;
+    server_name __METRICS_URL__;
+
+    # Redirect HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
 server {
 
 #__DEFAULT__    listen [::]:9142;


### PR DESCRIPTION
We had a very weird error that when accessing an SSL url ala `https://api.green-coding.io/v1/ci/badge/get/?repo=green-coding-solutions/green-metrics-tool&branch=main&workflow=45267393&mode=totals&metric=carbon&duration_days=30` the NGINX server would issue a 307 redirect to HTTP.

Suprisingly in browsers this was ignored but smaller clients like *cURL* or pre-fetchers choked on this.

This PR forces a port 80 redirect to SSL. Will only be active in production setups as in local dev port 80 is not forwarded and NGINX inside the container is used.

Only production setups might use external NGINX configurations

<!-- greptile_comment -->

## Greptile Summary

This PR updates NGINX configuration examples to enforce secure traffic by redirecting HTTP requests to HTTPS using 301 redirects, addressing issues with clients misinterpreting 307 redirects.

- Updated `/docker/nginx/block.conf.example` to include a port 80 server block redirecting all traffic to HTTPS.
- Revised `/docker/nginx/api.conf.example` with a similar HTTP to HTTPS redirect for API endpoints.
- Modified `/docker/nginx/frontend.conf.example` to enforce HTTPS for frontend traffic via a 301 redirect.



<!-- /greptile_comment -->