### PR TITLE
Machine names have now nice names in Dashboard and some QoL

### DIFF
--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -47,7 +47,20 @@ $(document).ready( (e) => {
         comparison_identifiers = comparison_identifiers.join(' vs. ')
         document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Comparison Type</strong></td><td>${phase_stats_data.comparison_case}</td></tr>`)
         document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Number of runs compared</strong></td><td>${run_count}</td></tr>`)
-        document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${comparison_identifiers}</td></tr>`)
+        if (phase_stats_data.comparison_case == 'Machine') {
+            const regex = /(\d+)\s+vs\.\s+(\d+)/;
+            const match = comparison_identifiers.match(regex);
+
+            if (match) {
+                const num1 = parseInt(match[1], 10); // First number
+                const num2 = parseInt(match[2], 10); // Second number
+                document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${num1} (${GMT_MACHINES[num1]}) vs. ${num2} (${GMT_MACHINES[num2]})</td></tr>`)
+            } else {
+                document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${GMT_MACHINES[comparison_identifiers] || comparison_identifiers}</td></tr>`)
+            }
+        } else {
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${comparison_identifiers}</td></tr>`)
+        }
         Object.keys(phase_stats_data['common_info']).forEach(function(key) {
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${key}</strong></td><td>${phase_stats_data['common_info'][key]}</td></tr>`)
           });

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -1,3 +1,17 @@
+const GMT_MACHINES = JSON.parse(localStorage.getItem('gmt_machines')) || {}; // global variable. dynamically resolved via resolveMachinesToGlobalVariable
+
+// tricky to make this async as some other functions will depend on the value of the variable
+// but if it is not set yet it will populate in a later call
+const resolveMachinesToGlobalVariable = async () => {
+    if (Object.keys(GMT_MACHINES).length === 0) {
+        const api_data = await makeAPICall('/v1/machines')
+        api_data.data.forEach(el => {
+            GMT_MACHINES[el[0]] = el[1];
+        })
+    }
+    localStorage.setItem('gmt_machines', JSON.stringify(GMT_MACHINES));
+}
+
 /*
     WebComponent function without ShadowDOM
     to expand the menu in the HTML pages
@@ -335,7 +349,7 @@ if (localStorage.getItem('closed_descriptions') == null) {
     localStorage.setItem('closed_descriptions', '');
 }
 
-$(window).on('load', function() {
+$(document).ready(() => {
     $("body").removeClass("preload"); // activate tranisition CSS properties again
     const closed_descriptions = localStorage.getItem('closed_descriptions');
     $('.close').on('click', function() {
@@ -346,5 +360,6 @@ $(window).on('load', function() {
         document.querySelectorAll('i.close.icon').forEach(el => { el.closest('.ui').remove()}
         )
     }
+    resolveMachinesToGlobalVariable();
 });
 

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -86,7 +86,9 @@ const fetchAndFillRunData = async (url_params) => {
     const run_data = run.data
 
     for (const item in run_data) {
-        if (item == 'machine_specs') {
+        if (item == 'machine_id') {
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${run_data?.[item]} (${GMT_MACHINES[run_data?.[item]] || run_data?.[item]})</td></tr>`)
+        } else if (item == 'machine_specs') {
             fillRunTab('#machine-specs', run_data[item]); // recurse
         } else if(item == 'usage_scenario') {
             document.querySelector("#usage-scenario").insertAdjacentHTML('beforeend', `<pre class="usage-scenario">${json2yaml(run_data?.[item])}</pre>`)
@@ -100,11 +102,12 @@ const fetchAndFillRunData = async (url_params) => {
             if (run_data?.[item] == null) continue; // some old runs did not save it
             let commit_link = buildCommitLink(run_data);
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td><a href="${commit_link}" target="_blank">${run_data?.[item]}</a></td></tr>`)
-        } else if(item == 'name' || item == 'filename') {
+        } else if(item == 'name' || item == 'filename' || item == 'branch') {
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${run_data?.[item]}</td></tr>`)
         } else if(item == 'failed' && run_data?.[item] == true) {
             document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Status</strong></td><td><span class="ui red horizontal label">This run has failed. Please see logs for details</span></td></tr>`)
-
+        } else if(item == 'start_measurement' || item == 'end_measurement' || item == 'created_at' ) {
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td title="${run_data?.[item]}">${new Date(run_data?.[item])}</td></tr>`)
         } else if(item == 'uri') {
             let entry = run_data?.[item];
             if(run_data?.[item].indexOf('http') === 0) entry = `<a href="${run_data?.[item]}">${run_data?.[item]}</a>`;
@@ -117,7 +120,9 @@ const fetchAndFillRunData = async (url_params) => {
     // create new custom field
     // timestamp is in microseconds, therefore divide by 10**6
     const measurement_duration_in_s = (run_data.end_measurement - run_data.start_measurement) / 1000000
-    document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>duration</strong></td><td>${measurement_duration_in_s} s</td></tr>`)
+    const measurement_duration_display = (measurement_duration_in_s > 60) ? `${numberFormatter.format(measurement_duration_in_s / 60)} min` : `${numberFormatter.format(measurement_duration_in_s)} s`
+
+    document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>duration</strong></td><td title="${measurement_duration_in_s} seconds">${measurement_duration_display}</td></tr>`)
 
     if (run_data.invalid_run) {
         showNotification('Run measurement has been marked as invalid', run_data.invalid_run);

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -399,7 +399,7 @@ def test_expert_compare_mode():
 
     assert new_page.locator("#run-data-top > tbody:nth-child(3) > tr > td:nth-child(1)").text_content() == 'Machine'
 
-    assert new_page.locator("#run-data-top > tbody:nth-child(3) > tr > td:nth-child(2)").text_content() == '1'
+    assert new_page.locator("#run-data-top > tbody:nth-child(3) > tr > td:nth-child(2)").text_content() == 'Local machine'
 
 
     new_page.close()


### PR DESCRIPTION
At the moment when doing machine comparisons only the ID of the machine is shown.

This PR:
- Shows nice names for machines instead of IDs
- Moves crucial info of the run like the branch above the fold in the "stats.html" view
- Total duration of the run is now parsed into minutes if > 60 s
![Screenshot 2025-04-09 at 9 16 07 AM](https://github.com/user-attachments/assets/4492d22e-9050-4d36-9496-879521add328)
![Screenshot 2025-04-09 at 9 15 48 AM](https://github.com/user-attachments/assets/b4420d30-7138-493b-be08-939e4f0e2386)


<!-- greptile_comment -->

## Greptile Summary

This PR refines the dashboard’s UX by replacing raw machine IDs with user-friendly names, prominently displaying branch info, and enhancing run duration formatting. 

- Modified **/frontend/js/stats.js** to use the GMT_MACHINES mapping for machine IDs, include branch details above the fold, and display durations in minutes when >60 seconds.
- Updated **/frontend/js/compare.js** to extract and map machine IDs via regex, ensuring a smooth transition to friendly names.
- Enhanced **/frontend/js/helpers/main.js** by fetching and caching machine mapping without error handling, which may warrant additional error management.



<!-- /greptile_comment -->