### PR TITLE
Adds the runner arguments as 'Switches' menu item to the stats.html

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -180,7 +180,7 @@ def get_run_info(user, run_id):
                     LEFT JOIN categories as t on t.id = elements) as categories,
                 filename, start_measurement, end_measurement,
                 measurement_config, machine_specs, machine_id, usage_scenario,
-                created_at, invalid_run, phases, logs, failed, gmt_hash
+                created_at, invalid_run, phases, logs, failed, gmt_hash, runner_arguments
             FROM runs
             WHERE
                 (TRUE = %s OR user_id = ANY(%s::int[]))

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -86,7 +86,9 @@ const fetchAndFillRunData = async (url_params) => {
     const run_data = run.data
 
     for (const item in run_data) {
-        if (item == 'machine_specs') {
+        if (item == 'runner_arguments') {
+            fillRunTab('#runner-arguments', run_data[item]); // recurse
+        } else if (item == 'machine_specs') {
             fillRunTab('#machine-specs', run_data[item]); // recurse
         } else if(item == 'usage_scenario') {
             document.querySelector("#usage-scenario").insertAdjacentHTML('beforeend', `<pre class="usage-scenario">${json2yaml(run_data?.[item])}</pre>`)

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -47,12 +47,14 @@
                     <div class="ui secondary menu">
                         <a class="item active" data-tab="one">General</a>
                         <a class="item" data-tab="two">Measurement</a>
-                        <a class="item" data-tab="three">Badges</a>
+                        <a class="item" data-tab="three">Switches</a>
                         <a class="item" data-tab="four">Machine</a>
                         <a class="item" data-tab="five">Usage Scenario</a>
                         <a class="item" data-tab="six">Logs</a>
                         <a class="item" data-tab="seven">Network</a>
                         <a class="item" data-tab="eight">Optimizations<div class="ui red label" id="optimization_count">0</div></a>
+                        <a class="item" data-tab="nine">Badges</a>
+
                     </div>
                     <div class="ui tab segment" data-tab="one">
                         <table class="table-hover" id="run-data-top"></table>
@@ -69,21 +71,7 @@
                         <table class="table-hover" id="measurement-config"></table>
                     </div>
                     <div class="ui active tab segment" data-tab="three">
-                        <div id="run-badges">
-                        </div>
-                        <div class="ui icon message warning">
-                            <i class="info circle icon"></i>
-                            <div class="content">
-                                <div class="header">
-                                    Badge missing or not showing data?
-                                </div>
-                                <ul>
-                                    <li>Badges are for Runtime phase only by default. Append <b>&amp;phase=ENTER_PHASE_NAME</b> to img src show specific phase</li>
-                                    <li>Badges are only visible for the default user. If you are logged in with a different account badges cannot show. Please use a HTTP proxy like Cloudflare workers to tunnel the page if needed or enable user visibility.</li>
-
-                                </ul>
-                            </div>
-                        </div>
+                        <table class="table-hover" id="runner-arguments"></table>
                     </div>
                     <div class="ui tab segment" data-tab="four" id="machine-specs-tab">
                         <table class="table-hover" id="machine-specs"></table>
@@ -105,7 +93,23 @@
                         <p>&NonBreakingSpace;</p>
                         <div id="optimizationsContainer" class="ui container"></div>
                     </div>
+                    <div class="ui active tab segment" data-tab="nine">
+                        <div id="run-badges">
+                        </div>
+                        <div class="ui icon message warning">
+                            <i class="info circle icon"></i>
+                            <div class="content">
+                                <div class="header">
+                                    Badge missing or not showing data?
+                                </div>
+                                <ul>
+                                    <li>Badges are for Runtime phase only by default. Append <b>&amp;phase=ENTER_PHASE_NAME</b> to img src show specific phase</li>
+                                    <li>Badges are only visible for the default user. If you are logged in with a different account badges cannot show. Please use a HTTP proxy like Cloudflare workers to tunnel the page if needed or enable user visibility.</li>
 
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
 
 
                 </div>


### PR DESCRIPTION
<img width="1079" alt="Screenshot 2025-04-09 at 11 39 38 AM" src="https://github.com/user-attachments/assets/fce1e6de-54c4-4ccd-8a05-2d9ab0a71e9f" />


<!-- greptile_comment -->

## Greptile Summary

This PR integrates a new "Switches" tab for runner arguments by updating the stats UI and backend data retrieval.

- Modified `/frontend/js/stats.js` to detect and render the new `runner_arguments` key in a dedicated UI tab.
- Updated `/api/api_helpers.py` to include `runner_arguments` in the run data query.
- Adjusted `/frontend/stats.html` to introduce a "Switches" menu item, with potential tab conflicts from multiple active segments noted.



<!-- /greptile_comment -->