### PR TITLE
Added note column to be sent to eco-ci

### DIFF
--- a/api/eco_ci.py
+++ b/api/eco_ci.py
@@ -109,6 +109,10 @@ async def post_ci_measurement_add(
     params.append(used_client_ip)
     params.append(user._id)
 
+    if measurement.note is not None and measurement.note.strip() == '':
+        measurement.note = None
+    params.append(measurement.note)
+
     query = f"""
         INSERT INTO
             ci_measurements (energy_uj,
@@ -133,12 +137,13 @@ async def post_ci_measurement_add(
                             filter_machine,
                             filter_tags,
                             ip_address,
-                            user_id
+                            user_id,
+                            note
                             )
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                 %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                 {tags_replacer},
-                %s, %s)
+                %s, %s, %s)
 
         """
 

--- a/api/object_specifications.py
+++ b/api/object_specifications.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, constr
 from typing import Optional
 
 from fastapi.exceptions import RequestValidationError
@@ -86,6 +86,7 @@ class CI_Measurement(BaseModel):
     carbon_intensity_g: Optional[int] = None
     carbon_ug: Optional[int] = None
     ip: Optional[str] = None
+    note: Optional[constr(max_length=1024)] = None
 
     model_config = ConfigDict(extra='forbid')
 

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -315,6 +315,7 @@ CREATE TABLE ci_measurements (
     carbon_intensity_g int,
     carbon_ug bigint,
     ip_address INET,
+    note text CHECK (length(note) <= 1024),
     filter_type text NOT NULL,
     filter_project text NOT NULL,
     filter_machine text NOT NULL,

--- a/migrations/2025_04_11_eco_ci_note.sql
+++ b/migrations/2025_04_11_eco_ci_note.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."ci_measurements" ADD COLUMN your_column_name TEXT CHECK (LENGTH("note") <= 1024);

--- a/migrations/2025_04_11_eco_ci_note.sql
+++ b/migrations/2025_04_11_eco_ci_note.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "public"."ci_measurements" ADD COLUMN your_column_name TEXT CHECK (LENGTH("note") <= 1024);
+ALTER TABLE "public"."ci_measurements" ADD COLUMN "note" TEXT CHECK (LENGTH("note") <= 1024);


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds a 'note' column to the ci_measurements table for storing additional information with CI measurements, with implementation across database schema, API, and data model.

- Fixed error in migration file: `migrations/2025_04_11_eco_ci_note.sql` uses incorrect column name `your_column_name` instead of `note`
- Added proper note field in `api/object_specifications.py` with 1024 character limit
- Updated `api/eco_ci.py` to handle the note parameter in the v2 endpoint
- Added note column with length constraint in `docker/structure.sql` for new installations

Greptile AI



<!-- /greptile_comment -->