### PR TITLE
Charts now display absolute StdDev

### DIFF
--- a/frontend/js/helpers/charts.js
+++ b/frontend/js/helpers/charts.js
@@ -190,7 +190,7 @@ const getLineBarChartOptions = (legend, labels, series, x_axis_name=null, y_axis
                 },
                 data: [
                     [
-                        { yAxis: mean + stddev, name: `StdDev: ${(stddev/mean * 100).toFixed(2)} %`},
+                        { yAxis: mean + stddev, name: `StdDev: ${stddev.toFixed(2)} (${(stddev/mean * 100).toFixed(2)} %)`},
                         { yAxis: mean - stddev},
                     ]
 

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -241,7 +241,7 @@ const loadCharts = async () => {
             const [ mean, stddev ] = calculateStatistics(data.slice(startIndex, endIndex+1), true);
 
             let options = chart_instance.getOption()
-            options.series[2].markArea.data[0][0].name = `StdDev: ${(stddev/mean * 100).toFixed(2)} %`
+            options.series[2].markArea.data[0][0].name = `StdDev: ${stddev.toFixed(2)} (${(stddev/mean * 100).toFixed(2)} %)`
             options.series[2].markArea.data[0][0].yAxis = mean + stddev
             options.series[2].markArea.data[0][1].yAxis = mean - stddev;
             chart_instance.setOption(options)


### PR DESCRIPTION
<img width="1127" alt="Screenshot 2025-04-18 at 11 19 17 AM" src="https://github.com/user-attachments/assets/2dc07493-b596-42d2-9859-ae84059c0264" />

Was needed as often the relative StdDev is identical but in a different ballpark of absolute StdDev. This is misleading when just taking a quick glimpse.