### PR TITLE
Fix invalid run markers

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1563,7 +1563,7 @@ class Runner:
 
         for argument in self._arguments:
             if (argument.startswith('dev_') or argument == 'skip_system_checks')  and self._arguments[argument] not in (False, None):
-                invalid_message = 'Development switches or skip_system_checks were active for this run. This will likely produced skewed measurement data.\n'
+                invalid_message = 'Development switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n'
                 DB().query('''
                     UPDATE runs
                     SET invalid_run = COALESCE(invalid_run, '') || %s
@@ -1644,8 +1644,6 @@ class Runner:
         try:
             config = GlobalConfig().config
             self.start_measurement() # we start as early as possible to include initialization overhead
-            self.identify_invalid_run()
-
             self.clear_caches()
             self.check_system('start')
             self.initialize_folder(self._tmp_folder)

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -38,7 +38,7 @@ def setup_module(module):
         subprocess.run(['docker', 'compose', '-f', GMT_DIR+folder+'compose.yml', 'build'], check=True)
 
         # Run the application
-        runner = Runner(name=RUN_NAME, uri=GMT_DIR, filename=folder+filename, uri_type='folder', dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=False, skip_system_checks=False)
+        runner = Runner(name=RUN_NAME, uri=GMT_DIR, filename=folder+filename, uri_type='folder', dev_cache_build=False, dev_no_sleeps=False, dev_no_metrics=False, skip_system_checks=False)
         runner.run()
 
     #pylint: disable=global-statement

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -2,6 +2,7 @@ import io
 import os
 import subprocess
 import re
+import platform
 
 GMT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../')
 
@@ -128,3 +129,17 @@ def test_db_rows_are_written_and_presented():
 
     if not 'PowermetricsProvider' in metric_providers:
         assert len(metric_providers) == 0
+
+def test_run_is_not_invalidated():
+    if platform.system() == 'Darwin':
+        return
+
+    run_id = utils.get_run_data(RUN_NAME)['id']
+    query = """
+            SELECT id, invalid_run
+            FROM runs
+            WHERE id = %s
+            """
+    data = DB().fetch_one(query, (run_id,))
+    assert data[0] == run_id
+    assert data[1] is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -74,6 +74,6 @@ def test_runner_run_invalidated():
     assert data[0] == run_id
 
     if platform.system() == 'Darwin':
-        assert data[1] == 'Measurements are not reliable as they are done on a Mac in a virtualized docker environment with high overhead and low reproducability.\nDevelopment switches or skip_system_checks were active for this run. This will likely produced skewed measurement data.\n'
+        assert data[1] == 'Measurements are not reliable as they are done on a Mac in a virtualized docker environment with high overhead and low reproducability.\nDevelopment switches or skip_system_checks were active for this run. This will produce skewed skewed measurement data.\n'
     else:
-        assert data[1] == 'Development switches or skip_system_checks were active for this run. This will likely produced skewed measurement data.\n'
+        assert data[1] == 'Development switches or skip_system_checks were active for this run. This will produce skewed skewed measurement data.\n'

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -74,6 +74,6 @@ def test_runner_run_invalidated():
     assert data[0] == run_id
 
     if platform.system() == 'Darwin':
-        assert data[1] == 'Measurements are not reliable as they are done on a Mac in a virtualized docker environment with high overhead and low reproducability.\nDevelopment switches or skip_system_checks were active for this run. This will produce skewed skewed measurement data.\n'
+        assert data[1] == 'Measurements are not reliable as they are done on a Mac in a virtualized docker environment with high overhead and low reproducability.\nDevelopment switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n'
     else:
-        assert data[1] == 'Development switches or skip_system_checks were active for this run. This will produce skewed skewed measurement data.\n'
+        assert data[1] == 'Development switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n'


### PR DESCRIPTION
Invalid run is now set when the _dev or _skip_system_checks flags are set.

However there was a bug in this setting and also we had no tests. Now added

<!-- greptile_comment -->

## Greptile Summary

Improved invalid run detection and testing in the Green Metrics Tool, ensuring proper marking of runs with development flags or system check skips.

- Added `test_run_is_not_invalidated()` in `tests/smoke_test.py` to verify normal runs aren't marked invalid
- Added `test_runner_run_invalidated()` in `tests/test_runner.py` to validate proper invalid run marking with dev flags
- Modified `runner.py` to improve invalid run message handling using COALESCE and proper message concatenation
- Enhanced invalid run detection to include `skip_system_checks` flag and proper dev flag validation



<!-- /greptile_comment -->