### PR TITLE
Timeline badges rework

### DIFF
--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -402,8 +402,12 @@ async def get_timeline_stats(uri: str, machine_id: int, branch: str | None = Non
 # Show the timeline badges with regression trend
 ## A complex case to allow public visibility of the badge but restricting everything else would be to have
 ## User 1 restricted to only this route but a fully populated 'visible_users' array
+##
+## Technically we allow detail_name to not be mandatory. But a regression over two CPU cores where one is not used and one is increasing in use can lead to
+## an unexpected result because they occur at same timepoints but the trend assumes them to be at sequential timepoints.
+## You might get unexpected results, but generally it is desireable to have a regression of all CPU cores for instance forthe cpu energy reporter
 @router.get('/v1/badge/timeline')
-async def get_timeline_badge(metric: str, detail_name: str, uri: str, machine_id: int | None, branch: str | None = None, filename: str | None = None, unit: str = 'watt-hours', user: User = Depends(authenticate)):
+async def get_timeline_badge(metric: str, uri: str, detail_name: str | None, machine_id: int | None, branch: str | None = None, filename: str | None = None, unit: str = 'watt-hours', user: User = Depends(authenticate)):
     if uri is None or uri.strip() == '':
         raise RequestValidationError('URI is empty')
 

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -315,9 +315,12 @@ const renderBadges = async (url_params, phase_stats) => {
 
     const phase_stats_keys = Object.keys(phase_stats);
 
+
     const badge_container = document.querySelector('#run-badges')
 
     phase_stats_keys.forEach(metric_name => {
+        if (phase_stats[metric_name].type != 'TOTAL') return; // skip averaged metrics
+
         badge_container.innerHTML += `
             <div class="inline field">
                 <a href="${METRICS_URL}/stats.html?id=${url_params['id']}">

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -97,8 +97,8 @@ const buildQueryParams = (skip_dates=false,metric_override=null,detail_name=null
     if($('select[name="machine_id"]').val() !== '') api_url = `${api_url}&machine_id=${$('select[name="machine_id"]').val()}`
     if($('input[name="filename"]').val() !== '') api_url = `${api_url}&filename=${$('input[name="filename"]').val()}`
 
-    if(metric_override != null) api_url = `${api_url}&metrics=${metric_override}`
-    else if($('input[name="metrics"]:checked').val() !== '') api_url = `${api_url}&metrics=${$('input[name="metrics"]:checked').val()}`
+    if(metric_override != null) api_url = `${api_url}&metric=${metric_override}`
+    else if($('input[name="metrics"]:checked').val() !== '') api_url = `${api_url}&metric=${$('input[name="metrics"]:checked').val()}`
 
     if(detail_name != null) api_url = `${api_url}&detail_name=${detail_name}`
 

--- a/tests/api/test_api_scenario_runner.py
+++ b/tests/api/test_api_scenario_runner.py
@@ -175,12 +175,12 @@ def test_get_badge():
 def test_get_badge_with_phase():
     Tests.import_demo_data()
 
-    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=psu_power_dc_rapl_msr_machine", timeout=15)
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=psu_energy_dc_rapl_msr_machine", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
-    assert 'Machine Power' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
-    assert '14.80 W' in response.text, Tests.assertion_info('success', response.text)
+    assert 'Machine Energy' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
+    assert '21.81 mWh' in response.text, Tests.assertion_info('success', response.text)
 
-    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=psu_power_dc_rapl_msr_machine&phase=[BOOT]", timeout=15)
+    response = requests.get(f"{API_URL}/v1/badge/single/{RUN_3}?metric=psu_energy_dc_rapl_msr_machine&phase=[BOOT]", timeout=15)
     assert response.status_code == 200, Tests.assertion_info('success', response.text)
-    assert 'Machine Power {[BOOT]}' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
-    assert '21.46 W' in response.text, Tests.assertion_info('success', response.text)
+    assert 'Machine Energy {[BOOT]}' in response.text, Tests.assertion_info('success', response.text) # nice name - important if JS file was parsed correctly
+    assert '1.85 mWh' in response.text, Tests.assertion_info('success', response.text)


### PR DESCRIPTION
- Totals Badges could be shown for metrics that are averaged. This was wrong (See Screenshot)
<img width="604" alt="Screenshot 2025-04-20 at 12 47 15 PM" src="https://github.com/user-attachments/assets/640de280-d324-4c9b-a738-a8f85848ae61" />
Although the feature could be introduced with weighted average we deemed it to high complexity for such a nice feature and rather drop support

- Safeguards if requested badges are over multiple units
- Allowing more flexibility in timeline badges to have detail_name not mandatory anymore
- Requiring metric as required field as it makes no sense to average over CPU Utilizatuion and network traffic in parallel for instance

<!-- greptile_comment -->

## Greptile Summary

This PR improves timeline badge handling by preventing averaged metrics from being incorrectly displayed as totals and adding safeguards around unit consistency and metric selection.

- Modified `renderBadges` in `frontend/js/stats.js` to skip averaged metrics, preventing incorrect total displays
- Added validation in `api/scenario_runner.py` to prevent mixing metrics with different units and ensure only totaled metrics (energy, network, carbon) are used
- Made `metric` parameter mandatory and `detail_name` optional in timeline badges for more flexibility
- Changed query parameter from `metrics` to `metric` in `frontend/js/timeline.js` to enforce single metric selection
- Added safeguards in `api/api_helpers.py` against SQL injection and improved error handling for metric validation



<!-- /greptile_comment -->