### PR TITLE
Added init support

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -101,6 +101,7 @@ class SchemaChecker():
 
             Optional("services"): {
                 Use(self.contains_no_invalid_chars): {
+                    Optional("init"): bool,
                     Optional("type"): Use(self.valid_service_types),
                     Optional("image"): And(str, Use(self.not_empty)),
                     Optional("build"): Or(Or({And(str, Use(self.not_empty)):And(str, Use(self.not_empty))},list),And(str, Use(self.not_empty))),

--- a/runner.py
+++ b/runner.py
@@ -850,6 +850,9 @@ class Runner:
                         docker_run_string.append('--mount')
                         docker_run_string.append(f"type=bind,source={path},target={vol[1]},readonly")
 
+            if service.get('init', False):
+                docker_run_string.append('--init')
+
             if 'ports' in service:
                 if self._allow_unsafe:
                     if not isinstance(service['ports'], list):


### PR DESCRIPTION
Adds `--init` support for docker containers.

Nice if you need a process to reap zombie processes in the container

<!-- greptile_comment -->

## Greptile Summary

Added support for Docker's --init flag in services configuration to handle zombie process reaping, with schema validation and runner implementation.

- Added optional `init` boolean field in `lib/schema_checker.py` services schema
- Implemented `--init` flag handling in `runner.py` Docker container creation
- Follows existing schema validation and Docker run argument patterns
- Provides clean solution for zombie process management in containers



<!-- /greptile_comment -->