### PR TITLE
Ignore unsupported docker compose keys

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -88,6 +88,7 @@ class SchemaChecker():
             "description": And(str, Use(self.not_empty)),
             Optional("ignore-unsupported-compose"): bool,
             Optional("version"): str, # is part of compose. we ignore it
+            Optional("architecture"): And(str, Use(self.not_empty)),
 
             Optional("networks"): Or(list, dict),
 

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -110,7 +110,10 @@ class SchemaChecker():
                         Optional('start_interval'): And(str, Use(self.not_empty)),
                         Optional('disable'): bool,
                     },
-                    Optional("setup-commands"): [And(str, Use(self.not_empty))],
+                    Optional("setup-commands"): [{
+                        'command': And(str, Use(self.not_empty)),
+                        Optional("shell"): And(str, Use(self.not_empty)),
+                    }],
                     Optional("volumes"): self.single_or_list(str),
                     Optional("folder-destination"):And(str, Use(self.not_empty)),
                     Optional("entrypoint"): Or(str, [str]),

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -2,16 +2,8 @@ import os
 import string
 import re
 from schema import Schema, SchemaError, Optional, Or, Use, And, Regex
-#
-# networks documentation is different than what i see in the wild!
-    # name: str
-    # also isn't networks optional?
-    # fix documentation - name not needed, also netowrks optional
-    # add check in runner.py networks parsing, make sure its valid_string
-    # is services/type optional?
 
-# services /type missing from documentation?
-
+from lib import error_helpers
 
 # https://github.com/compose-spec/compose-spec/blob/master/spec.md
 
@@ -96,6 +88,7 @@ class SchemaChecker():
             "name": str,
             "author": And(str, Use(self.not_empty)),
             "description": And(str, Use(self.not_empty)),
+            Optional("ignore-extra-keys"): bool,
 
             Optional("networks"): Or(list, dict),
 
@@ -152,15 +145,25 @@ class SchemaChecker():
             }],
 
             Optional("compose-file"): Use(self.validate_compose_include)
-        }, ignore_extra_keys=True)
-
+        }, ignore_extra_keys=bool(usage_scenario.get('skip-unsupported-compose', False)))
 
         # First we check the general structure. Otherwise we later cannot even iterate over it
         try:
             usage_scenario_schema.validate(usage_scenario)
         except SchemaError as e: # This block filters out the too long error message that include the parsing structure
-            if len(e.autos) > 2:
-                raise SchemaError(e.autos[2:]) from e
+
+            autos_error_start = e.autos[0]
+            error_message = e.autos
+
+            if len(e.autos) == 3:
+                error_message = f"{e.autos[0]} - {e.autos[2]}"
+                autos_error_start = e.autos[2]
+            elif len(e.autos) > 3:
+                error_helpers.log_error('Unexpected SchemaError length encountered', schema_error_length=len(e.autos), exception=e.autos)
+
+            if autos_error_start.startswith('Wrong key'):
+                raise SchemaError(f"Your compose file does contain a key that GMT does not support - Please check if the container will still run as intended: {error_message}") from e
+
             raise SchemaError(e.autos) from e
 
 
@@ -170,7 +173,7 @@ class SchemaChecker():
             self.validate_networks_no_invalid_chars(usage_scenario['networks'])
 
         known_container_names = []
-        for service_name, service in usage_scenario.get('services').items():
+        for service_name, service in usage_scenario.get('services', {}).items():
             if 'container_name' in service:
                 container_name = service['container_name']
             else:

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -86,7 +86,7 @@ class SchemaChecker():
             "name": str,
             "author": And(str, Use(self.not_empty)),
             "description": And(str, Use(self.not_empty)),
-            Optional("ignore-extra-keys"): bool,
+            Optional("ignore-unsupported-compose"): bool,
             Optional("version"): str, # is part of compose. we ignore it
 
             Optional("networks"): Or(list, dict),
@@ -147,7 +147,7 @@ class SchemaChecker():
             }],
 
             Optional("compose-file"): Use(self.validate_compose_include)
-        }, ignore_extra_keys=bool(usage_scenario.get('skip-unsupported-compose', False)))
+        }, ignore_extra_keys=bool(usage_scenario.get('ignore-unsupported-compose', False)))
 
         # First we check the general structure. Otherwise we later cannot even iterate over it
         try:

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -3,8 +3,6 @@ import string
 import re
 from schema import Schema, SchemaError, Optional, Or, Use, And, Regex
 
-from lib import error_helpers
-
 # https://github.com/compose-spec/compose-spec/blob/master/spec.md
 
 class SchemaChecker():
@@ -152,19 +150,15 @@ class SchemaChecker():
             usage_scenario_schema.validate(usage_scenario)
         except SchemaError as e: # This block filters out the too long error message that include the parsing structure
 
-            autos_error_start = e.autos[0]
             error_message = e.autos
 
-            if len(e.autos) == 3:
-                error_message = f"{e.autos[0]} - {e.autos[2]}"
-                autos_error_start = e.autos[2]
-            elif len(e.autos) > 3:
-                error_helpers.log_error('Unexpected SchemaError length encountered', schema_error_length=len(e.autos), exception=e.autos)
+            if len(e.autos) >= 3:
+                error_message = e.autos[2:]
 
-            if autos_error_start.startswith('Wrong key'):
+            if 'Wrong key' in e.code:
                 raise SchemaError(f"Your compose file does contain a key that GMT does not support - Please check if the container will still run as intended: {error_message}") from e
 
-            raise SchemaError(e.autos) from e
+            raise SchemaError(error_message) from e
 
 
         # This check is necessary to do in a seperate pass. If tried to bake into the schema object above,

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -87,6 +87,7 @@ class SchemaChecker():
             "author": And(str, Use(self.not_empty)),
             "description": And(str, Use(self.not_empty)),
             Optional("ignore-extra-keys"): bool,
+            Optional("version"): str, # is part of compose. we ignore it
 
             Optional("networks"): Or(list, dict),
 

--- a/runner.py
+++ b/runner.py
@@ -1097,14 +1097,12 @@ class Runner:
 
             print('Stdout:', container_id)
 
-            if 'setup-commands' not in service:
-                continue  # setup commands are optional
             print('Running commands')
-            for cmd in service['setup-commands']:
-                if shell := service.get('shell', False):
-                    d_command = ['docker', 'exec', container_name, shell, '-c', cmd] # This must be a list!
+            for cmd in service.get('setup-commands', []):
+                if shell := cmd.get('shell', False):
+                    d_command = ['docker', 'exec', container_name, shell, '-c', cmd['command']] # This must be a list!
                 else:
-                    d_command = ['docker', 'exec', container_name, *shlex.split(cmd)] # This must be a list!
+                    d_command = ['docker', 'exec', container_name, *shlex.split(cmd['command'])] # This must be a list!
 
                 print('Running command: ', ' '.join(d_command))
 

--- a/tests/data/usage_scenarios/basic_stress.yml
+++ b/tests/data/usage_scenarios/basic_stress.yml
@@ -2,7 +2,6 @@
 name: Test Stress
 author: Dan Mateas
 description: test
-description: test
 
 services:
   test-container:

--- a/tests/data/usage_scenarios/import_two_compose.yml
+++ b/tests/data/usage_scenarios/import_two_compose.yml
@@ -2,4 +2,4 @@ services:
   my-database:
     some-key: 'something'
     setup-commands:
-      - this should be overwritten with the cp string. This allows us to modify things in the imported file.
+      - command: this should be overwritten with the cp string. This allows us to modify things in the imported file.

--- a/tests/data/usage_scenarios/import_two_root.yml
+++ b/tests/data/usage_scenarios/import_two_root.yml
@@ -7,4 +7,4 @@ compose-file: !include import_two_compose.yml
 services:
   my-database:
     setup-commands:
-      - cp /tmp/repo/test_1MB.jpg /usr/local/apache2/htdocs/test_1MB.jpg
+      - command: cp /tmp/repo/test_1MB.jpg /usr/local/apache2/htdocs/test_1MB.jpg

--- a/tests/data/usage_scenarios/setup_commands_multiple_stress.yml
+++ b/tests/data/usage_scenarios/setup_commands_multiple_stress.yml
@@ -11,9 +11,9 @@ services:
     build:
       context: ../stress-application
     setup-commands:
-      - echo hello world
-      - ps -a
-      - echo goodbye world
+      - command: echo hello world
+      - command: ps -a
+      - command: echo goodbye world
 
 flow:
   - name: Stress

--- a/tests/data/usage_scenarios/setup_commands_stress.yml
+++ b/tests/data/usage_scenarios/setup_commands_stress.yml
@@ -2,7 +2,6 @@
 name: Test Stress
 author: Dan Mateas
 description: test
-description: test
 
 services:
   test-container:
@@ -11,8 +10,8 @@ services:
     build:
       context: ../stress-application
     setup-commands:
-      - ps -a
-    shell: sh
+      - command: ps -a
+        shell: sh
 
 flow:
   - name: Stress

--- a/tests/data/usage_scenarios/skip_unsupported_compose.yml
+++ b/tests/data/usage_scenarios/skip_unsupported_compose.yml
@@ -3,7 +3,7 @@ name: Container name invalid test
 author: Arne Tarara
 description: Container name invalid test
 
-skip-unsupported-compose: True
+ignore-unsupported-compose: True
 
 services:
   highload-api-cont:

--- a/tests/data/usage_scenarios/skip_unsupported_compose.yml
+++ b/tests/data/usage_scenarios/skip_unsupported_compose.yml
@@ -1,0 +1,21 @@
+---
+name: Container name invalid test
+author: Arne Tarara
+description: Container name invalid test
+
+skip-unsupported-compose: True
+
+services:
+  highload-api-cont:
+    image: alpine
+    blkio_config:
+      weight: 300
+
+flow:
+  - name: Small-Stress
+    container: highload-api-cont
+    commands:
+      - type: console
+        command: echo "asd"
+        shell: bash
+        note: Starting a little stress

--- a/tests/data/usage_scenarios/subdir_parent_context/subdir/usage_scenario_fail.yml
+++ b/tests/data/usage_scenarios/subdir_parent_context/subdir/usage_scenario_fail.yml
@@ -1,6 +1,5 @@
 name: Cat Subdir
 author: Arne Tarara <arne@green-coding.io>
-version: 1
 description: Cat Subdir
 
 services:

--- a/tests/data/usage_scenarios/subdir_parent_context/subdir/usage_scenario_ok.yml
+++ b/tests/data/usage_scenarios/subdir_parent_context/subdir/usage_scenario_ok.yml
@@ -1,6 +1,5 @@
 name: Cat Subdir
 author: Arne Tarara <arne@green-coding.io>
-version: 1
 description: Cat Subdir
 
 services:

--- a/tests/data/usage_scenarios/subdir_volume_loading/subdir/usage_scenario_subdir.yml
+++ b/tests/data/usage_scenarios/subdir_volume_loading/subdir/usage_scenario_subdir.yml
@@ -1,6 +1,5 @@
 name: Cat Subdir
 author: Arne Tarara <arne@green-coding.io>
-version: 1
 description: Cat Subdir
 
 services:

--- a/tests/data/usage_scenarios/unsupported_compose.yml
+++ b/tests/data/usage_scenarios/unsupported_compose.yml
@@ -1,0 +1,19 @@
+---
+name: Container name invalid test
+author: Arne Tarara
+description: Container name invalid test
+
+services:
+  highload-api-cont:
+    image: alpine
+    blkio_config:
+      weight: 300
+
+flow:
+  - name: Small-Stress
+    container: highload-api-cont
+    commands:
+      - type: console
+        command: echo "asd"
+        shell: bash
+        note: Starting a little stress

--- a/tests/data/usage_scenarios/volume_load_etc_hosts.yml
+++ b/tests/data/usage_scenarios/volume_load_etc_hosts.yml
@@ -9,7 +9,6 @@ services:
       context: ../stress-application
     image: gcb_stress
     container_name: test-container
-    restart: always
     volumes:
       - /etc/hosts:/tmp/hosts
 

--- a/tests/data/usage_scenarios/volume_load_non_bind_mounts.yml
+++ b/tests/data/usage_scenarios/volume_load_non_bind_mounts.yml
@@ -9,7 +9,6 @@ services:
       context: ../stress-application
     image: gcb_stress
     container_name: test-container
-    restart: always
     volumes:
       - test-volume:/tmp/test-volume
 

--- a/tests/data/usage_scenarios/volume_load_references.yml
+++ b/tests/data/usage_scenarios/volume_load_references.yml
@@ -9,7 +9,6 @@ services:
       context: ../stress-application
     image: gcb_stress
     container_name: test-container
-    restart: always
     volumes: &test-volume
       - ../mounts/test-file:/tmp/test-file
 
@@ -18,7 +17,6 @@ services:
       context: ../stress-application
     image: gcb_stress
     container_name: test-container-2
-    restart: always
     volumes: *test-volume
 
 flow:

--- a/tests/data/usage_scenarios/volume_load_symlinks_negative.yml
+++ b/tests/data/usage_scenarios/volume_load_symlinks_negative.yml
@@ -9,7 +9,6 @@ services:
       context: ../stress-application
     image: gcb_stress
     container_name: test-container
-    restart: always
     volumes:
       - ../tmp/symlink:/tmp/hosts
 

--- a/tests/data/usage_scenarios/volume_load_within_proj.yml
+++ b/tests/data/usage_scenarios/volume_load_within_proj.yml
@@ -9,7 +9,6 @@ services:
       context: ../stress-application
     image: gcb_stress
     container_name: test-container
-    restart: always
     volumes:
       - ../mounts/test-file:/tmp/test-file
 

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -189,7 +189,7 @@ def test_unsupported_compose():
     with pytest.raises(SchemaError) as e:
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
-    assert str(e.value) == "Your compose file does contain a key that GMT does not support - Please check if the container will still run as intended: Key 'services' error: - Wrong key 'blkio_config' in {'image': 'alpine', 'blkio_config': {'weight': 300}}"
+    assert str(e.value) == 'Your compose file does contain a key that GMT does not support - Please check if the container will still run as intended: ["Wrong key \'blkio_config\' in {\'image\': \'alpine\', \'blkio_config\': {\'weight\': 300}}"]'
 
 def test_skip_unsupported_compose():
     runner = Runner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/skip_unsupported_compose.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -44,7 +44,6 @@ def get_env_vars():
     env_var_output = ps.stdout
     return env_var_output
 
-# Test allowed characters
 def test_env_variable_allowed_characters():
 
     runner = Runner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/env_vars_stress_allowed.yml', skip_unsafe=False, skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
@@ -184,6 +183,19 @@ def test_context_include_escape():
     assert str(e.value).startswith('../../../../../../ must not be in folder above root repo folder') , \
         Tests.assertion_info('Root directory escape', str(e.value))
 
+def test_unsupported_compose():
+    runner = Runner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/unsupported_compose.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+
+    with pytest.raises(SchemaError) as e:
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+    assert str(e.value) == "Your compose file does contain a key that GMT does not support - Please check if the container will still run as intended: Key 'services' error: - Wrong key 'blkio_config' in {'image': 'alpine', 'blkio_config': {'weight': 300}}"
+
+def test_skip_unsupported_compose():
+    runner = Runner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/skip_unsupported_compose.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+
+    with Tests.RunUntilManager(runner) as context:
+        context.run_until('import_metric_providers')
 
 # setup-commands: [array] (optional)
 # Array of commands to be run before actual load testing.

--- a/tests/test_yml_parsing.py
+++ b/tests/test_yml_parsing.py
@@ -35,9 +35,11 @@ class TestYML(unittest.TestCase):
                       'author': 'Arne Tarara',
                       'description': 'test',
                       'services': {'my-database':
-                                   {'some-key': 'something',
-                                    'setup-commands':
-                                    ['cp /tmp/repo/test_1MB.jpg /usr/local/apache2/htdocs/test_1MB.jpg']}}}
+                                    {'some-key': 'something',
+                                      'setup-commands': [{'command': 'cp /tmp/repo/test_1MB.jpg /usr/local/apache2/htdocs/test_1MB.jpg'}]
+                                   }
+                                 }
+                     }
 
         print(f"actual: {runner._usage_scenario}")
         print(f"expect: {result_obj}")


### PR DESCRIPTION
This PR adds the warning to GMT when a compose file with unsupported features is encountered.

The issue has been discussed in:
- https://github.com/green-coding-solutions/green-metrics-tool/issues/580

As requested the error that is raised can be turned off by setting the top level element:
`- ignore-unsupported-compose: True`

Furthermore this PR corrects that `shell` for `setup-commands` was not part of a command list, but also a top-level services element.

All changes are now reflected in the documentation

<!-- greptile_comment -->

## Greptile Summary

This PR adds functionality to handle unsupported Docker Compose features and fixes setup-commands structure, allowing users to skip validation of unsupported features via a new 'skip-unsupported-compose' flag.

- Added schema validation for unsupported Docker Compose keys in `/lib/schema_checker.py` with configurable warning behavior
- Restructured setup-commands in YAML files to properly include 'command' and 'shell' as command list items
- Added test files `/tests/data/usage_scenarios/skip_unsupported_compose.yml` and `unsupported_compose.yml` to validate new functionality
- Modified `/tests/test_usage_scenario.py` to include test cases for unsupported compose features
- Removed redundant 'version' field from usage scenario files as it's now optional



<!-- /greptile_comment -->