### PR TITLE
Software add now returns job_id on insert; Jobs API now allows filter for job_id

### DIFF
--- a/tests/api/test_api_software_add.py
+++ b/tests/api/test_api_software_add.py
@@ -20,18 +20,26 @@ def test_post_run_add_github_one_off():
     run = Software(name=run_name, repo_url='https://github.com/green-coding-solutions/green-metrics-tool', email='testEmail', branch='', filename='', machine_id=1, schedule_mode='one-off')
     response = requests.post(f"{API_URL}/v1/software/add", json=run.model_dump(), timeout=15)
     assert response.status_code == 202, Tests.assertion_info('success', response.text)
+    data = response.json()
+    assert isinstance(data['data'], list)
+    assert len(data['data']) == 1
 
-    job_id = get_job_id(run_name)
-    assert job_id is not None
+    job_ids = get_job_ids(run_name)
+    assert job_ids == data['data']
+
+
 
 def test_post_run_add_github_tags():
     run_name = 'test_' + utils.randomword(12)
     run = Software(name=run_name, image_url="test-image", repo_url='https://github.com/green-coding-solutions/green-metrics-tool', email='testEmail', branch='', filename='', machine_id=1, schedule_mode='tag')
     response = requests.post(f"{API_URL}/v1/software/add", json=run.model_dump(), timeout=15)
     assert response.status_code == 202, Tests.assertion_info('success', response.text)
+    data = response.json()
+    assert isinstance(data['data'], list)
+    assert len(data['data']) == 1
 
-    job_id = get_job_id(run_name)
-    assert job_id is not None
+    job_ids = get_job_ids(run_name)
+    assert job_ids == data['data']
 
     watchlist_item = utils.get_watchlist_item('https://github.com/green-coding-solutions/green-metrics-tool')
 
@@ -45,13 +53,25 @@ def test_post_run_add_github_commit():
     response = requests.post(f"{API_URL}/v1/software/add", json=run.model_dump(), timeout=15)
     assert response.status_code == 202, Tests.assertion_info('success', response.text)
 
-    job_id = get_job_id(run_name)
-    assert job_id is not None
+    data = response.json()
+    assert isinstance(data['data'], list)
+    assert len(data['data']) == 3
+
+    job_ids = get_job_ids(run_name)
+    assert job_ids == data['data']
 
     watchlist_item = utils.get_watchlist_item('https://github.com/green-coding-solutions/green-metrics-tool')
     assert re.match(r'^[a-fA-F0-9]{40}$',watchlist_item['last_marker'])
     assert watchlist_item['schedule_mode'] == 'commit-variance'
     assert watchlist_item['image_url'] == ''
+
+    # also retrieve from API
+    response = requests.get(f"{API_URL}/v1/jobs?id={job_ids[0]}", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    data = response.json()
+
+    assert data['data'][0][0] == job_ids[0]
+    assert data['data'][0][3] == 'https://github.com/green-coding-solutions/green-metrics-tool'
 
 
 def test_post_run_add_gitlab_commit():
@@ -139,7 +159,7 @@ def test_post_run_add_non_existent_repo():
 
 
 ## helpers
-def get_job_id(run_name):
+def get_job_ids(run_name):
     query = """
             SELECT
                 id
@@ -147,7 +167,7 @@ def get_job_id(run_name):
                 jobs
             WHERE name = %s
             """
-    data = DB().fetch_one(query, (run_name, ))
+    data = DB().fetch_all(query, (run_name, ))
     if data is None or data == []:
         return None
-    return data[0]
+    return [el[0] for el in data] # unpack


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added job ID filtering to the jobs API endpoint and modified software_add endpoint to return job IDs of newly created jobs, with corresponding test updates.

- Added `job_id` parameter to `/v1/jobs` endpoint for filtering jobs by ID
- Modified `/v1/software/add` endpoint to return list of created job IDs in response
- Updated `get_job_ids()` helper function to return list instead of single ID
- Added test case to verify job retrieval through jobs API endpoint
- Updated variance mode tests to handle multiple job ID responses



<!-- /greptile_comment -->