### PR TITLE
Resource limits now also from services key; Added tests

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -947,14 +947,24 @@ class ScenarioRunner:
             if 'pause-after-phase' in service:
                 self.__services_to_pause_phase[service['pause-after-phase']] = self.__services_to_pause_phase.get(service['pause-after-phase'], []) + [container_name]
 
-            if 'deploy' in service:
-                if memory := service['deploy'].get('resources', {}).get('limits', {}).get('memory', None):
-                    docker_run_string.append('--memory') # value in bytes
-                    docker_run_string.append(str(memory))
-                if cpus := service['deploy'].get('resources', {}).get('limits', {}).get('cpus', None):
-                    docker_run_string.append('--cpus') # value in cores
-                    docker_run_string.append(str(cpus))
+            # wildly the docker compose spec allows deploy to be None ... thus we need to check and cannot .get()
+            if 'deploy' in service and service['deploy'] is not None and (memory := service['deploy'].get('resources', {}).get('limits', {}).get('memory', None)):
+                docker_run_string.append('--memory') # value in bytes
+                docker_run_string.append(str(memory))
+                print('Applying Memory Limit from deploy')
+            elif memory := service.get('mem_limit', None): # we only need to get resources or cpus. they must align anyway
+                docker_run_string.append('--memory')
+                docker_run_string.append(str(memory))  # value in bytes e.g. "10M"
+                print('Applying Memory Limit from services')
 
+            if 'deploy' in service and service['deploy'] is not None and (cpus := service['deploy'].get('resources', {}).get('limits', {}).get('cpus', None)):
+                docker_run_string.append('--cpus') # value in cores
+                docker_run_string.append(str(cpus))
+                print('Applying CPU Limit from services')
+            elif cpus := service.get('cpus', None): # we only need to get resources or cpus. they must align anyway
+                docker_run_string.append('--cpus')
+                docker_run_string.append(str(cpus)) # value in (fractional) cores
+                print('Applying CPU Limit from deploy')
 
             if 'healthcheck' in service:  # must come last
                 if 'disable' in service['healthcheck'] and service['healthcheck']['disable'] is True:

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -960,11 +960,11 @@ class ScenarioRunner:
             if 'deploy' in service and service['deploy'] is not None and (cpus := service['deploy'].get('resources', {}).get('limits', {}).get('cpus', None)):
                 docker_run_string.append('--cpus') # value in cores
                 docker_run_string.append(str(cpus))
-                print('Applying CPU Limit from services')
+                print('Applying CPU Limit from deploy')
             elif cpus := service.get('cpus', None): # we only need to get resources or cpus. they must align anyway
                 docker_run_string.append('--cpus')
                 docker_run_string.append(str(cpus)) # value in (fractional) cores
-                print('Applying CPU Limit from deploy')
+                print('Applying CPU Limit from services')
 
             if 'healthcheck' in service:  # must come last
                 if 'disable' in service['healthcheck'] and service['healthcheck']['disable'] is True:

--- a/tests/data/usage_scenarios/resource_limits_disalign_cpu.yml
+++ b/tests/data/usage_scenarios/resource_limits_disalign_cpu.yml
@@ -1,0 +1,23 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+
+  test-container-memory-int:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 2
+    cpus: 3
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/data/usage_scenarios/resource_limits_disalign_memory.yml
+++ b/tests/data/usage_scenarios/resource_limits_disalign_memory.yml
@@ -1,0 +1,23 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+
+  test-container-memory-int:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          memory: "10M"
+    mem_limit: "100M"
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/data/usage_scenarios/resource_limits_good.yml
+++ b/tests/data/usage_scenarios/resource_limits_good.yml
@@ -11,13 +11,14 @@ services:
       resources:
         limits:
           cpus: "1.2"
+
   test-container-only-memory:
     type: container
     image: alpine
     deploy:
       resources:
         limits:
-          cpus: "1.2"
+          memory: "100MB"
 
   test-container-both:
     type: container

--- a/tests/data/usage_scenarios/resource_limits_good.yml
+++ b/tests/data/usage_scenarios/resource_limits_good.yml
@@ -1,0 +1,78 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+  test-container-only-cpu:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: "1.2"
+  test-container-only-memory:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: "1.2"
+
+  test-container-both:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: "1.2"
+          memory: "10M"
+
+  test-container-cpu-float:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1.2
+          memory: "10M"
+
+  test-container-cpu-int:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1
+          memory: "10M"
+
+  test-container-limits-partial:
+    type: container
+    image: alpine
+    deploy: # allowed to be None
+
+  test-container-cpu-and-memory-in-both:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1
+          memory: "10M"
+    cpus: 1
+    mem_limit: "10M"
+
+  test-container-limit-only-service-level:
+    type: container
+    image: alpine
+    cpus: 1
+    mem_limit: "10M"
+
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/data/usage_scenarios/resource_limits_memory_float.yml
+++ b/tests/data/usage_scenarios/resource_limits_memory_float.yml
@@ -1,0 +1,22 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+
+  test-container-memory-int:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          memory: 1.2
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/data/usage_scenarios/resource_limits_memory_int.yml
+++ b/tests/data/usage_scenarios/resource_limits_memory_int.yml
@@ -1,0 +1,23 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+
+  test-container-memory-int:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          memory: 1
+
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -54,7 +54,7 @@ def test_resource_limits_good():
     assert 'Applying CPU Limit from deploy' in out.getvalue()
     assert 'Applying CPU Limit from services' in out.getvalue()
     assert 'Applying Memory Limit from deploy' in out.getvalue()
-    assert 'Applying CPU Limit from services' in out.getvalue()
+    assert 'Applying Memory Limit from services' in out.getvalue()
 
 def test_resource_limits_memory_int():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_memory_int.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,91 @@
+# https://docs.docker.com/engine/reference/commandline/port/
+# List port mappings or a specific mapping for the container
+#  docker port CONTAINER [PRIVATE_PORT[/PROTO]]
+
+import io
+import os
+import subprocess
+
+GMT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../')
+
+from contextlib import redirect_stdout, redirect_stderr
+import pytest
+
+from tests import test_functions as Tests
+from lib.scenario_runner import ScenarioRunner
+from lib.schema_checker import SchemaError
+
+## Note:
+# Always do asserts after try:finally: blocks
+# otherwise failing Tests will not run the runner.cleanup() properly
+
+
+# This function runs the runner up to and *including* the specified step
+#pylint: disable=redefined-argument-from-local
+### The Tests for usage_scenario configurations
+
+# environment: [object] (optional)
+# Key-Value pairs for ENV variables inside the container
+
+def get_env_vars():
+    ps = subprocess.run(
+        ['docker', 'exec', 'test-container', '/bin/sh',
+        '-c', 'env'],
+        check=True,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        encoding='UTF-8'
+    )
+    env_var_output = ps.stdout
+    return env_var_output
+
+def test_resource_limits_good():
+
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_good.yml', skip_unsafe=False, skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+
+    out = io.StringIO()
+    err = io.StringIO()
+
+    with redirect_stdout(out), redirect_stderr(err):
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    assert err.getvalue() == ''
+    assert 'Applying CPU Limit from deploy' in out.getvalue()
+    assert 'Applying CPU Limit from services' in out.getvalue()
+    assert 'Applying Memory Limit from deploy' in out.getvalue()
+    assert 'Applying CPU Limit from services' in out.getvalue()
+
+def test_resource_limits_memory_int():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_memory_int.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    with pytest.raises(SchemaError) as e:
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    assert "Or({Optional('resources'): {Optional('limits'): {Optional('cpus'): Or(<class 'str'>, <class 'float'>, <class 'int'>), Optional('memory'): <class 'str'>}}}, None) did not validate {'resources': {'limits': {'memory': 1}}}" in str(e.value)
+    assert "1 should be instance of 'str'" in str(e.value)
+
+def test_resource_limits_memory_float():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_memory_float.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    with pytest.raises(SchemaError) as e:
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    assert "1.2 should be instance of 'str'" in str(e.value)
+
+
+def test_resource_limits_disalign_cpu():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_disalign_cpu.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    with pytest.raises(SchemaError) as e:
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    assert "cpus service top level key and deploy.resources.limits.cpus must be identical" in str(e.value)
+
+def test_resource_limits_disalign_memory():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_disalign_memory.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    with pytest.raises(SchemaError) as e:
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    assert "mem_limit service top level key and deploy.resources.limits.memory must be identical" in str(e.value)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added comprehensive testing and validation for Docker container resource limits, ensuring consistent configuration between service-level and deploy.resources.limits specifications.

- Added schema validation in `lib/schema_checker.py` to enforce memory limits as strings and CPU limits as string/float/int
- Added tests in `tests/test_resource_limits.py` to verify matching CPU/memory limits between deploy and service-level configs
- Fixed container name mismatch in test files between service definitions and flow sections
- Added validation in `lib/scenario_runner.py` to properly handle and apply resource limits from both configuration locations
- Added test cases in `tests/data/usage_scenarios/` for various resource limit scenarios including invalid configurations



<!-- /greptile_comment -->