### PR TITLE
Added --dev-no-save flag

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -433,7 +433,7 @@ class ScenarioRunner:
         print(TerminalColors.HEADER, '\nRemoving all temporary GMT images', TerminalColors.ENDC)
 
         if self._dev_cache_build:
-            print('Skipping remving of all temporary GMT images skipped due to --dev-cache-build')
+            print('Skipping removing of all temporary GMT images skipped due to --dev-cache-build')
             return
 
         subprocess.run(

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -68,7 +68,7 @@ class ScenarioRunner:
         skip_unsafe=False, verbose_provider_boot=False, full_docker_prune=False,
         dev_no_sleeps=False, dev_cache_build=False, dev_no_metrics=False,
         dev_flow_timetravel=False, dev_no_optimizations=False, docker_prune=False, job_id=None,
-        user_id=1, measurement_flow_process_duration=None, measurement_total_duration=None, disabled_metric_providers=None, allowed_run_args=None, dev_no_phase_stats=False,
+        user_id=1, measurement_flow_process_duration=None, measurement_total_duration=None, disabled_metric_providers=None, allowed_run_args=None, dev_no_phase_stats=False, dev_no_save=False,
         skip_volume_inspect=False, commit_hash_folder=None, usage_scenario_variables=None):
 
         if skip_unsafe is True and allow_unsafe is True:
@@ -93,6 +93,7 @@ class ScenarioRunner:
         self._dev_flow_timetravel = dev_flow_timetravel
         self._dev_no_optimizations = dev_no_optimizations
         self._dev_no_phase_stats = dev_no_phase_stats
+        self._dev_no_save = dev_no_save
         self._uri = uri
         self._uri_type = uri_type
         self._original_filename = filename
@@ -195,10 +196,12 @@ class ScenarioRunner:
         Path(path).mkdir(parents=True, exist_ok=True)
 
     def save_notes_runner(self):
-        if not self._run_id:
+        print(TerminalColors.HEADER, '\nSaving notes: ', TerminalColors.ENDC, self.__notes_helper.get_notes())
+
+        if not self._run_id or self._dev_no_save:
+            print('Skipping saving notes due to missing run_id or --dev-no-save')
             return # Nothing to do, but also no hard error needed
 
-        print(TerminalColors.HEADER, '\nSaving notes: ', TerminalColors.ENDC, self.__notes_helper.get_notes())
         self.__notes_helper.save_to_db(self._run_id)
 
     def clear_caches(self):
@@ -212,7 +215,7 @@ class ScenarioRunner:
     def check_system(self, mode='start'):
         print(TerminalColors.HEADER, '\nChecking system', TerminalColors.ENDC)
         if self._skip_system_checks:
-            print("System check skipped")
+            print('Skipping check system due to --skip-system-checks')
             return
 
         if mode =='start':
@@ -427,10 +430,12 @@ class ScenarioRunner:
                     service['image'] = f"{service_name}_{random.randint(500000,10000000)}"
 
     def remove_docker_images(self):
+        print(TerminalColors.HEADER, '\nRemoving all temporary GMT images', TerminalColors.ENDC)
+
         if self._dev_cache_build:
+            print('Skipping remving of all temporary GMT images skipped due to --dev-cache-build')
             return
 
-        print(TerminalColors.HEADER, '\nRemoving all temporary GMT images', TerminalColors.ENDC)
         subprocess.run(
             'docker images --format "{{.Repository}}:{{.Tag}}" | grep "gmt_run_tmp" | xargs docker rmi -f',
             shell=True,
@@ -466,6 +471,13 @@ class ScenarioRunner:
         machine.register()
 
     def initialize_run(self):
+        print(TerminalColors.HEADER, '\nInitializing run', TerminalColors.ENDC)
+
+        if self._dev_no_save:
+            self._run_id = None
+            print('Skipping initialization of run due to --dev-no-save')
+            return self._run_id
+
         config = GlobalConfig().config
 
         gmt_hash, _ = get_repo_info(GMT_ROOT_DIR)
@@ -487,7 +499,6 @@ class ScenarioRunner:
         measurement_config['allowed_run_args'] = self._allowed_run_args
         measurement_config['disabled_metric_providers'] = self._disabled_metric_providers
         measurement_config['sci'] = self._sci
-
 
         # We issue a fetch_one() instead of a query() here, cause we want to get the RUN_ID
         self._run_id = DB().fetch_one("""
@@ -516,13 +527,14 @@ class ScenarioRunner:
         return self._run_id
 
     def import_metric_providers(self):
-        if self._dev_no_metrics:
-            print(TerminalColors.HEADER, '\nSkipping import of metric providers', TerminalColors.ENDC)
+        print(TerminalColors.HEADER, '\nImporting metric providers', TerminalColors.ENDC)
+
+        if self._dev_no_metrics or self._dev_no_save:
+            print('Skipping import of metric providers due to --dev-no-save or --dev-no-metrics')
             return
 
         config = GlobalConfig().config
 
-        print(TerminalColors.HEADER, '\nImporting metric providers', TerminalColors.ENDC)
 
         metric_providers = utils.get_metric_providers(config)
 
@@ -564,8 +576,10 @@ class ScenarioRunner:
         self.__metric_providers.sort(key=lambda item: 'rapl' not in item.__class__.__name__.lower())
 
     def download_dependencies(self):
+        print(TerminalColors.HEADER, '\nDownloading dependencies', TerminalColors.ENDC)
+
         if self._dev_cache_build:
-            print(TerminalColors.HEADER, '\nSkipping downloading dependencies', TerminalColors.ENDC)
+            print('Skipping downloading dependencies due to --dev-cache-build')
             return
 
         print(TerminalColors.HEADER, '\nDownloading dependencies', TerminalColors.ENDC)
@@ -697,6 +711,8 @@ class ScenarioRunner:
 
     def save_image_and_volume_sizes(self):
 
+        print(TerminalColors.HEADER, '\nSaving image and volume sizes', TerminalColors.ENDC)
+
         for _, service in self._usage_scenario.get('services', {}).items():
             tmp_img_name = self.clean_image_name(service['image'])
 
@@ -725,6 +741,11 @@ class ScenarioRunner:
                     self.__volume_sizes[volume] = int(output.strip().split('\t', maxsplit=1)[0])
                 except Exception as exc:
                     raise RuntimeError('Docker volumes could not be inspected. This can happen if you are storing images in a root only accessible location. Consider switching to docker rootless, running with --skip-volume-inspect or running GMT with sudo.') from exc
+
+        if self._dev_no_save:
+            print('Skipping saving of image and volume sizes due to --dev-no-save')
+            return
+
         DB().query("""
             UPDATE runs
             SET machine_specs = machine_specs || %s
@@ -1170,10 +1191,12 @@ class ScenarioRunner:
                 metric_provider.add_containers(self.__containers)
 
     def start_metric_providers(self, allow_container=True, allow_other=True):
-        if self._dev_no_metrics:
+        print(TerminalColors.HEADER, '\nStarting metric providers', TerminalColors.ENDC)
+
+        if self._dev_no_metrics or self._dev_no_save:
+            print('Skipping start of metric providers due to --dev-no-metrics or --dev-no-save')
             return
 
-        print(TerminalColors.HEADER, '\nStarting metric providers', TerminalColors.ENDC)
 
         # Here we start all container related providers
         # This includes tcpdump, which is only for debugging of the containers itself
@@ -1413,10 +1436,12 @@ class ScenarioRunner:
 
     # this method should never be called twice to avoid double logging of metrics
     def stop_metric_providers(self):
-        if self._dev_no_metrics:
+        print(TerminalColors.HEADER, 'Stopping metric providers and parsing measurements', TerminalColors.ENDC)
+
+        if self._dev_no_metrics or self._dev_no_save:
+            print('Skipping stop of metric providers due to --dev-no-metrics or --dev-no-save')
             return
 
-        print(TerminalColors.HEADER, 'Stopping metric providers and parsing measurements', TerminalColors.ENDC)
         errors = []
         for metric_provider in self.__metric_providers:
             if not metric_provider.has_started():
@@ -1518,10 +1543,12 @@ class ScenarioRunner:
         self.__notes_helper.add_note({'note': 'End of measurement', 'detail_name': '[NOTES]', 'timestamp': self.__end_measurement})
 
     def update_start_and_end_times(self):
-        if not self._run_id:
+        print(TerminalColors.HEADER, '\nUpdating start and end measurement times', TerminalColors.ENDC)
+
+        if not self._run_id or self._dev_no_save:
+            print('Skipping update of start and end times due to missing run id or --dev-no-save')
             return # Nothing to do, but also no hard error needed
 
-        print(TerminalColors.HEADER, '\nUpdating start and end measurement times', TerminalColors.ENDC)
         DB().query("""
             UPDATE runs
             SET start_measurement=%s, end_measurement=%s
@@ -1531,7 +1558,10 @@ class ScenarioRunner:
 
 
     def set_run_failed(self):
-        if not self._run_id:
+        print(TerminalColors.HEADER, '\nMarking run as failed', TerminalColors.ENDC)
+
+        if not self._run_id or self._dev_no_save:
+            print('Skipping marking run to failed due to missing run id or --dev-no-save')
             return # Nothing to do, but also no hard error needed
 
         DB().query("""
@@ -1542,10 +1572,12 @@ class ScenarioRunner:
 
 
     def store_phases(self):
-        if not self._run_id:
+        print(TerminalColors.HEADER, '\nUpdating phases in DB', TerminalColors.ENDC)
+
+        if not self._run_id or self._dev_no_save:
+            print('Skipping updating phases in DB due to missing run id or --dev-no-save')
             return # Nothing to do, but also no hard error needed
 
-        print(TerminalColors.HEADER, '\nUpdating phases in DB', TerminalColors.ENDC)
         # internally PostgreSQL stores JSON ordered. This means our name-indexed dict will get
         # re-ordered. Therefore we change the structure and make it a list now.
         # We did not make this before, as we needed the duplicate checking of dicts
@@ -1591,10 +1623,12 @@ class ScenarioRunner:
                 self.add_to_log(container_id, f"stderr: {log.stderr}")
 
     def save_stdout_logs(self):
-        if not self._run_id:
+        print(TerminalColors.HEADER, '\nSaving logs to DB', TerminalColors.ENDC)
+
+        if not self._run_id or self._dev_no_save:
+            print('Skipping savings logs to DB due to missing run id or --dev-no-save')
             return # Nothing to do, but also no hard error needed
 
-        print(TerminalColors.HEADER, '\nSaving logs to DB', TerminalColors.ENDC)
         logs_as_str = '\n\n'.join([f"{k}:{v}" for k,v in self.__stdout_logs.items()])
         logs_as_str = logs_as_str.replace('\x00','')
         if logs_as_str:
@@ -1611,25 +1645,37 @@ class ScenarioRunner:
     #    - Turbo Boost became active during run
     #    - etc.
     def identify_invalid_run(self):
+        print(TerminalColors.HEADER, '\nTrying to identify if run is invalid', TerminalColors.ENDC)
+
         # on macOS we run our tests inside the VM. Thus measurements are not reliable as they contain the overhead and reproducability is quite bad.
         if platform.system() == 'Darwin':
             invalid_message = 'Measurements are not reliable as they are done on a Mac in a virtualized docker environment with high overhead and low reproducability.\n'
-            DB().query('''
-                UPDATE runs
-                SET invalid_run = COALESCE(invalid_run, '') || %s
-                WHERE id=%s''',
-                params=(invalid_message, self._run_id)
-            )
+            print(TerminalColors.WARNING, invalid_message, TerminalColors.ENDC)
 
-        for argument in self._arguments:
-            if (argument.startswith('dev_') or argument == 'skip_system_checks')  and self._arguments[argument] not in (False, None):
-                invalid_message = 'Development switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n'
+            if not self._run_id or self._dev_no_save:
+                print(TerminalColors.WARNING, '\nSkipping saving identification if run is invalid due to missing run id or --dev-no-save', TerminalColors.ENDC)
+            else:
                 DB().query('''
                     UPDATE runs
                     SET invalid_run = COALESCE(invalid_run, '') || %s
                     WHERE id=%s''',
                     params=(invalid_message, self._run_id)
                 )
+
+        for argument in self._arguments:
+            if (argument.startswith('dev_') or argument == 'skip_system_checks')  and self._arguments[argument] not in (False, None):
+                invalid_message = 'Development switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n'
+                print(TerminalColors.WARNING, invalid_message, TerminalColors.ENDC)
+
+                if not self._run_id or self._dev_no_save:
+                    print(TerminalColors.WARNING, '\nSkipping saving identification if run is invalid due to missing run id or --dev-no-save', TerminalColors.ENDC)
+                else:
+                    DB().query('''
+                        UPDATE runs
+                        SET invalid_run = COALESCE(invalid_run, '') || %s
+                        WHERE id=%s''',
+                        params=(invalid_message, self._run_id)
+                    )
                 break # one is enough
 
     def cleanup(self, continue_measurement=False):
@@ -1837,7 +1883,7 @@ class ScenarioRunner:
                                 raise exc
                             finally:
                                 try:
-                                    if self._run_id and self._dev_no_phase_stats is False:
+                                    if self._run_id and self._dev_no_phase_stats is False and self._dev_no_save is False:
                                         # After every run, even if it failed, we want to generate phase stats.
                                         # They will not show the accurate data, but they are still neded to understand how
                                         # much a failed run has accrued in total energy and carbon costs

--- a/runner.py
+++ b/runner.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     parser.add_argument('--dev-no-phase-stats', action='store_true', help='Do not calculate phase stats.')
     parser.add_argument('--dev-cache-build', action='store_true', help='Checks if a container image is already in the local cache and will then not build it. Also doesn\'t clear the images after a run. Please note that skipping builds only works the second time you make a run since the image has to be built at least initially to work.')
     parser.add_argument('--dev-no-optimizations', action='store_true', help='Disable analysis after run to find possible optimizations.')
-    parser.add_argument('--dev-no-save', action='store_true', help='Will save no data to the DB. This impcitiely activates --dev-no-phase-stats, --dev-no-metrics and --dev-no-optimizations')
+    parser.add_argument('--dev-no-save', action='store_true', help='Will save no data to the DB. This implicitly activates --dev-no-phase-stats, --dev-no-metrics and --dev-no-optimizations')
     parser.add_argument('--print-phase-stats', type=str, help='Prints the stats for the given phase to the CLI for quick verification without the Dashboard. Try "[RUNTIME]" as argument.')
     parser.add_argument('--print-logs', action='store_true', help='Prints the container and process logs to stdout')
 
@@ -130,7 +130,7 @@ if __name__ == '__main__':
         # In a cloud setup it however makes sense to free the measurement machine as soon as possible
         # So this code should be individually callable, separate from the runner
 
-        if not runner._dev_no_optimizations and not runner._dev_no_save:
+        if runner._dev_no_optimizations is False and runner._dev_no_save is False:
             import optimization_providers.base  # We need to import this here as we need the correct config file
             print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
             optimization_providers.base.import_reporters()

--- a/runner.py
+++ b/runner.py
@@ -53,6 +53,7 @@ if __name__ == '__main__':
     parser.add_argument('--dev-no-phase-stats', action='store_true', help='Do not calculate phase stats.')
     parser.add_argument('--dev-cache-build', action='store_true', help='Checks if a container image is already in the local cache and will then not build it. Also doesn\'t clear the images after a run. Please note that skipping builds only works the second time you make a run since the image has to be built at least initially to work.')
     parser.add_argument('--dev-no-optimizations', action='store_true', help='Disable analysis after run to find possible optimizations.')
+    parser.add_argument('--dev-no-save', action='store_true', help='Will save no data to the DB. This impcitiely activates --dev-no-phase-stats, --dev-no-metrics and --dev-no-optimizations')
     parser.add_argument('--print-phase-stats', type=str, help='Prints the stats for the given phase to the CLI for quick verification without the Dashboard. Try "[RUNTIME]" as argument.')
     parser.add_argument('--print-logs', action='store_true', help='Prints the container and process logs to stdout')
 
@@ -113,10 +114,11 @@ if __name__ == '__main__':
                     skip_system_checks=args.skip_system_checks,
                     skip_unsafe=args.skip_unsafe,verbose_provider_boot=args.verbose_provider_boot,
                     full_docker_prune=args.full_docker_prune, dev_no_sleeps=args.dev_no_sleeps,
-                    dev_cache_build=args.dev_cache_build, dev_no_metrics=args.dev_no_metrics,
+                    dev_cache_build=args.dev_cache_build, dev_no_metrics=args.dev_no_metrics, dev_no_save=args.dev_no_save,
                     dev_flow_timetravel=args.dev_flow_timetravel, dev_no_optimizations=args.dev_no_optimizations,
                     docker_prune=args.docker_prune, dev_no_phase_stats=args.dev_no_phase_stats, user_id=args.user_id,
-                    skip_volume_inspect=args.skip_volume_inspect, commit_hash_folder=args.commit_hash_folder, usage_scenario_variables=variables_dict)
+                    skip_volume_inspect=args.skip_volume_inspect, commit_hash_folder=args.commit_hash_folder,
+                    usage_scenario_variables=variables_dict)
 
     # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
     #pylint: disable=broad-except
@@ -128,7 +130,7 @@ if __name__ == '__main__':
         # In a cloud setup it however makes sense to free the measurement machine as soon as possible
         # So this code should be individually callable, separate from the runner
 
-        if not runner._dev_no_optimizations:
+        if not runner._dev_no_optimizations and not runner._dev_no_save:
             import optimization_providers.base  # We need to import this here as we need the correct config file
             print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
             optimization_providers.base.import_reporters()
@@ -140,17 +142,22 @@ if __name__ == '__main__':
         if args.file_cleanup:
             shutil.rmtree(runner._tmp_folder)
 
-        print(TerminalColors.OKGREEN,'\n\n####################################################################################')
-        print(f"Please access your report on the URL {GlobalConfig().config['cluster']['metrics_url']}/stats.html?id={runner._run_id}")
-        print('####################################################################################\n\n', TerminalColors.ENDC)
+        if not runner._dev_no_save:
+            print(TerminalColors.OKGREEN,'\n\n####################################################################################')
+            print(f"Please access your report on the URL {GlobalConfig().config['cluster']['metrics_url']}/stats.html?id={runner._run_id}")
+            print('####################################################################################\n\n', TerminalColors.ENDC)
 
 
-        if args.print_phase_stats:
-            phase_stats = DB().fetch_all('SELECT metric, detail_name, value, type, unit FROM phase_stats WHERE run_id = %s and phase LIKE %s ', params=(runner._run_id, f"%{args.print_phase_stats}"))
-            print(f"Data for phase {args.print_phase_stats}")
-            for el in phase_stats:
-                print(el)
-            print('')
+            if args.print_phase_stats:
+                phase_stats = DB().fetch_all('SELECT metric, detail_name, value, type, unit FROM phase_stats WHERE run_id = %s and phase LIKE %s ', params=(runner._run_id, f"%{args.print_phase_stats}"))
+                print(f"Data for phase {args.print_phase_stats}")
+                for el in phase_stats:
+                    print(el)
+                print('')
+        else:
+            print(TerminalColors.OKGREEN,'\n\n####################################################################################')
+            print('Run finished | --dev-no-save was active and nothing was written to DB')
+            print('####################################################################################\n\n', TerminalColors.ENDC)
 
     except FileNotFoundError as e:
         error_helpers.log_error('File or executable not found', exception=e, previous_exception=e.__context__, run_id=runner._run_id)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added a new `--dev-no-save` flag to prevent database writes during test runs, with automatic activation of related development flags for consistent dry-run behavior.

- Added `--dev-no-save` parameter in `runner.py` that prevents database writes and implicitly activates `--dev-no-phase-stats`, `--dev-no-metrics`, and `--dev-no-optimizations`
- Modified `lib/scenario_runner.py` to check `_dev_no_save` flag and skip database operations when enabled
- Added appropriate logging messages in `lib/scenario_runner.py` when database operations are skipped
- Ensured consistent propagation of the flag across all database-writing operations



<!-- /greptile_comment -->