### PR TITLE
Removing ee visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,21 @@ tools/sgx_enable
 /tests/test-config.js
 /templates/ai/usage_scenario.yml.tmp
 /templates/website/usage_scenario.yml.tmp
+
+## Files that will be created if Enterprise Version gets installed with valid license
 /ee
+/cron/delete_expired_data.py
+/cron/carbondb_copy_over_and_remove_duplicates.py
+/cron/carbondb_compress.py
+/tests/cron/test_carbondb_compress.py
+/tests/frontend/test_frontend_ee.py
+/tests/api/test_api_hog.py
+/tests/api/hog_data.py
+/tests/api/test_api_carbondb.py
+/tools/rebuild_carbondb.py
+/frontend/js/hog-details.js
+/frontend/js/carbondb.js
+/frontend/js/hog.js
+/frontend/hog-details.html
+/frontend/hog.html
+/frontend/carbondb.html

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ tools/sgx_enable
 /tests/cron/test_carbondb_compress.py
 /tests/frontend/test_frontend_ee.py
 /tests/api/test_api_hog.py
-/tests/api/hog_data.py
 /tests/api/test_api_carbondb.py
 /tools/rebuild_carbondb.py
 /frontend/js/hog-details.js

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tools/sgx_enable
 /tests/test-config.js
 /templates/ai/usage_scenario.yml.tmp
 /templates/website/usage_scenario.yml.tmp
+/ee

--- a/cron/carbondb_compress.py
+++ b/cron/carbondb_compress.py
@@ -1,1 +1,0 @@
-../ee/cron/carbondb_compress.py

--- a/cron/carbondb_copy_over_and_remove_duplicates.py
+++ b/cron/carbondb_copy_over_and_remove_duplicates.py
@@ -1,1 +1,0 @@
-../ee/cron/carbondb_copy_over_and_remove_duplicates.py

--- a/cron/delete_expired_data.py
+++ b/cron/delete_expired_data.py
@@ -1,1 +1,0 @@
-../ee/cron/delete_expired_data.py

--- a/frontend/carbondb.html
+++ b/frontend/carbondb.html
@@ -1,1 +1,0 @@
-../ee/frontend/carbondb.html

--- a/frontend/hog-details.html
+++ b/frontend/hog-details.html
@@ -1,1 +1,0 @@
-../ee/frontend/hog-details.html

--- a/frontend/hog.html
+++ b/frontend/hog.html
@@ -1,1 +1,0 @@
-../ee/frontend/hog.html

--- a/frontend/js/carbondb.js
+++ b/frontend/js/carbondb.js
@@ -1,1 +1,0 @@
-../../ee/frontend/js/carbondb.js

--- a/frontend/js/hog-details.js
+++ b/frontend/js/hog-details.js
@@ -1,1 +1,0 @@
-../../ee/frontend/js/hog-details.js

--- a/frontend/js/hog.js
+++ b/frontend/js/hog.js
@@ -1,1 +1,0 @@
-../../ee/frontend/js/hog.js

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -267,15 +267,36 @@ function checkout_submodules() {
     if [[ $(uname) != "Darwin" ]]; then
         git submodule update --init lib/sgx-software-enable
     fi
+
     git submodule update --init metric_providers/psu/energy/ac/xgboost/machine/model
+
     if [[ $enterprise == true ]] ; then
-        git submodule update --init ee
+        if [[ ! -d "ee" ]]; then
+            git clone git@github.com:green-coding-solutions/gmt-enterprise.git ee
+        fi
 
         if [[ ! -z $ee_branch ]]; then
             echo "Checking out ee branch $ee_branch"
             git -C ee fetch origin
             git -C ee checkout $ee_branch
         fi
+
+        ln -sf ee/cron/delete_expired_data.py cron/delete_expired_data.py
+        ln -sf ee/cron/carbondb_copy_over_and_remove_duplicates.py cron/carbondb_copy_over_and_remove_duplicates.py
+        ln -sf ee/cron/carbondb_compress.py cron/carbondb_compress.py
+        ln -sf ee/tests/cron/test_carbondb_compress.py tests/cron/test_carbondb_compress.py
+        ln -sf ee/tests/frontend/test_frontend_ee.py tests/frontend/test_frontend_ee.py
+        ln -sf ee/tests/api/test_api_hog.py tests/api/test_api_hog.py
+        ln -sf ee/tests/api/hog_data.py tests/api/hog_data.py
+        ln -sf ee/tests/api/test_api_carbondb.py tests/api/test_api_carbondb.py
+        ln -sf ee/tests/cron/test_carbondb_compress.py tests/cron/test_carbondb_compress.py
+        ln -sf ee/tools/rebuild_carbondb.py tools/rebuild_carbondb.py
+        ln -sf ee/frontend/js/hog-details.js frontend/js/hog-details.js
+        ln -sf ee/frontend/js/carbondb.js frontend/js/carbondb.js
+        ln -sf ee/frontend/js/hog.js frontend/js/hog.js
+        ln -sf ee/frontend/hog-details.html frontend/hog-details.html
+        ln -sf ee/frontend/hog.html frontend/hog.html
+        ln -sf ee/frontend/carbondb.html frontend/carbondb.html
     fi
 }
 

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -281,22 +281,21 @@ function checkout_submodules() {
             git -C ee checkout $ee_branch
         fi
 
-        ln -sf ee/cron/delete_expired_data.py cron/delete_expired_data.py
-        ln -sf ee/cron/carbondb_copy_over_and_remove_duplicates.py cron/carbondb_copy_over_and_remove_duplicates.py
-        ln -sf ee/cron/carbondb_compress.py cron/carbondb_compress.py
-        ln -sf ee/tests/cron/test_carbondb_compress.py tests/cron/test_carbondb_compress.py
-        ln -sf ee/tests/frontend/test_frontend_ee.py tests/frontend/test_frontend_ee.py
-        ln -sf ee/tests/api/test_api_hog.py tests/api/test_api_hog.py
-        ln -sf ee/tests/api/hog_data.py tests/api/hog_data.py
-        ln -sf ee/tests/api/test_api_carbondb.py tests/api/test_api_carbondb.py
-        ln -sf ee/tests/cron/test_carbondb_compress.py tests/cron/test_carbondb_compress.py
-        ln -sf ee/tools/rebuild_carbondb.py tools/rebuild_carbondb.py
-        ln -sf ee/frontend/js/hog-details.js frontend/js/hog-details.js
-        ln -sf ee/frontend/js/carbondb.js frontend/js/carbondb.js
-        ln -sf ee/frontend/js/hog.js frontend/js/hog.js
-        ln -sf ee/frontend/hog-details.html frontend/hog-details.html
-        ln -sf ee/frontend/hog.html frontend/hog.html
-        ln -sf ee/frontend/carbondb.html frontend/carbondb.html
+        ln -sf ../ee/cron/delete_expired_data.py cron/delete_expired_data.py
+        ln -sf ../ee/cron/carbondb_copy_over_and_remove_duplicates.py cron/carbondb_copy_over_and_remove_duplicates.py
+        ln -sf ../ee/cron/carbondb_compress.py cron/carbondb_compress.py
+        ln -sf ../../ee/tests/cron/test_carbondb_compress.py tests/cron/test_carbondb_compress.py
+        ln -sf ../../ee/tests/frontend/test_frontend_ee.py tests/frontend/test_frontend_ee.py
+        ln -sf ../../ee/tests/api/test_api_hog.py tests/api/test_api_hog.py
+        ln -sf ../../ee/tests/api/test_api_carbondb.py tests/api/test_api_carbondb.py
+        ln -sf ../../ee/tests/cron/test_carbondb_compress.py tests/cron/test_carbondb_compress.py
+        ln -sf ../ee/tools/rebuild_carbondb.py tools/rebuild_carbondb.py
+        ln -sf ../../ee/frontend/js/hog-details.js frontend/js/hog-details.js
+        ln -sf ../../ee/frontend/js/carbondb.js frontend/js/carbondb.js
+        ln -sf ../../ee/frontend/js/hog.js frontend/js/hog.js
+        ln -sf ../ee/frontend/hog-details.html frontend/hog-details.html
+        ln -sf ../ee/frontend/hog.html frontend/hog.html
+        ln -sf ../ee/frontend/carbondb.html frontend/carbondb.html
     fi
 }
 

--- a/tests/api/hog_data.py
+++ b/tests/api/hog_data.py
@@ -1,1 +1,0 @@
-../../ee/tests/api/hog_data.py

--- a/tests/api/test_api_carbondb.py
+++ b/tests/api/test_api_carbondb.py
@@ -1,1 +1,0 @@
-../../ee/tests/api/test_api_carbondb.py

--- a/tests/api/test_api_hog.py
+++ b/tests/api/test_api_hog.py
@@ -1,1 +1,0 @@
-../../ee/tests/api/test_api_hog.py

--- a/tests/cron/test_carbondb_compress.py
+++ b/tests/cron/test_carbondb_compress.py
@@ -1,1 +1,0 @@
-../../ee/tests/cron/test_carbondb_compress.py

--- a/tests/frontend/test_frontend_ee.py
+++ b/tests/frontend/test_frontend_ee.py
@@ -1,1 +1,0 @@
-../../ee/tests/frontend/test_frontend_ee.py

--- a/tools/rebuild_carbondb.py
+++ b/tools/rebuild_carbondb.py
@@ -1,1 +1,0 @@
-../ee/tools/rebuild_carbondb.py


### PR DESCRIPTION
Removes the EE repository as linked content from the repo.

We decided to not have anything "invisible" in the repository on normal install.

This means also all symlinks to Enterprise only files have been removed

<!-- greptile_comment -->

## Greptile Summary

This PR removes all Enterprise Edition (EE) symlinks and visibility from the main repository, making the codebase cleaner by eliminating 'invisible' enterprise content from normal installations.

- Removed `ee` directory submodule and all associated symlinks to EE features (CarbonDB, PowerHOG)
- Modified `/lib/install_shared.sh` to handle EE repository cloning directly instead of using submodules
- Added explicit EE file patterns to `/.gitignore` to prevent tracking enterprise files
- Removed all EE-related frontend files including `frontend/carbondb.html`, `frontend/hog.html`, and associated JavaScript files
- Removed EE-specific test files and cron jobs from `/tests` and `/cron` directories



<!-- /greptile_comment -->