### PR TITLE
Shm size

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -892,6 +892,10 @@ class ScenarioRunner:
             if service.get('init', False):
                 docker_run_string.append('--init')
 
+            if shm_size := service.get('shm_size', False):
+                docker_run_string.append('--shm-size')
+                docker_run_string.append(str(shm_size))
+
             if 'ports' in service:
                 if self._allow_unsafe:
                     if not isinstance(service['ports'], list):

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -114,11 +114,11 @@ class SchemaChecker():
                         Optional('resources'): {
                             Optional('limits'): {
                                 Optional('cpus'): Or(And(str, Use(self.not_empty)), float, int),
-                                Optional('memory') : And(str, Use(self.not_empty)),
+                                Optional('memory') : Or(And(str, Use(self.not_empty)), float, int),
                             }
                         }
                     }, None),
-                    Optional('mem_limit'): And(str, Use(self.not_empty)),
+                    Optional('mem_limit'): Or(And(str, Use(self.not_empty)), float, int),
                     Optional('cpus') : Or(And(str, Use(self.not_empty)), float, int),
                     Optional('container_name'): And(str, Use(self.not_empty)),
 

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -121,7 +121,7 @@ class SchemaChecker():
                     Optional('mem_limit'): Or(And(str, Use(self.not_empty)), float, int),
                     Optional('cpus') : Or(And(str, Use(self.not_empty)), float, int),
                     Optional('container_name'): And(str, Use(self.not_empty)),
-
+                    Optional('shm_size'): Or(And(str, Use(self.not_empty)), float, int),
                     Optional("healthcheck"): {
                         Optional('test'): Or(list, And(str, Use(self.not_empty))),
                         Optional('interval'): And(str, Use(self.not_empty)),

--- a/tests/data/usage_scenarios/resource_limits_cpu_none.yml
+++ b/tests/data/usage_scenarios/resource_limits_cpu_none.yml
@@ -1,0 +1,20 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+
+  test-container-memory-int:
+    type: container
+    image: alpine
+    cpus: null
+
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/data/usage_scenarios/resource_limits_good.yml
+++ b/tests/data/usage_scenarios/resource_limits_good.yml
@@ -47,6 +47,25 @@ services:
           cpus: 1
           memory: "10M"
 
+  test-container-memory-int:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1
+          memory: 11000000
+
+
+  test-container-memory-float:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1
+          memory: 10000001.23
+
   test-container-limits-partial:
     type: container
     image: alpine
@@ -68,6 +87,20 @@ services:
     image: alpine
     cpus: 1
     mem_limit: "10M"
+
+
+  test-container-limit-only-service-level-memory-int:
+    type: container
+    image: alpine
+    cpus: 1
+    mem_limit: 11000000
+
+  test-container-limit-only-service-level-memory-float:
+    type: container
+    image: alpine
+    cpus: 1
+    mem_limit: 10000001.23
+
 
 
 flow:

--- a/tests/data/usage_scenarios/resource_limits_memory_none.yml
+++ b/tests/data/usage_scenarios/resource_limits_memory_none.yml
@@ -11,7 +11,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1
+          memory: null
 
 
 flow:

--- a/tests/data/usage_scenarios/resource_limits_shm_good.yml
+++ b/tests/data/usage_scenarios/resource_limits_shm_good.yml
@@ -1,0 +1,46 @@
+---
+name: Testing SHM
+author: Arne Tarara
+description: Testing SHM
+
+services:
+  test-container:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: "1.2"
+          memory: "10MB"
+
+    shm_size: "30MB"
+
+  test-container-2:
+    type: container
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: "1.2"
+          memory: "10MB"
+
+    shm_size: 15728640
+
+flow:
+  - name: Testing SHM
+    container: test-container
+    commands:
+      - type: console
+        command: 'echo "SHM size is: $(df -h /dev/shm)"'
+        shell: sh
+        log-stdout: True
+        log-stderr: True
+
+  - name: Testing SHM 2
+    container: test-container-2
+    commands:
+      - type: console
+        command: 'echo "SHM size is: $(df -h /dev/shm)"'
+        shell: sh
+        log-stdout: True
+        log-stderr: True

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -56,21 +56,21 @@ def test_resource_limits_good():
     assert 'Applying Memory Limit from deploy' in out.getvalue()
     assert 'Applying Memory Limit from services' in out.getvalue()
 
-def test_resource_limits_memory_int():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_memory_int.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+def test_resource_limits_memory_none():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_memory_none.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
     with pytest.raises(SchemaError) as e:
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
 
-    assert "1 should be instance of 'str'" in str(e.value)
+    assert "None should be instance of 'str'" in str(e.value)
 
-def test_resource_limits_memory_float():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_memory_float.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+def test_resource_limits_cpu_none():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_cpu_none.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
     with pytest.raises(SchemaError) as e:
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
 
-    assert "1.2 should be instance of 'str'" in str(e.value)
+    assert "None should be instance of 'str'" in str(e.value)
 
 
 def test_resource_limits_disalign_cpu():

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -88,3 +88,17 @@ def test_resource_limits_disalign_memory():
             context.run_until('setup_services')
 
     assert "mem_limit service top level key and deploy.resources.limits.memory must be identical" in str(e.value)
+
+
+def test_resource_limits_shm_good():
+    out = io.StringIO()
+    err = io.StringIO()
+
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/resource_limits_shm_good.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+
+    with redirect_stdout(out), redirect_stderr(err):
+        runner.run()
+
+    assert 'SHM size is: Filesystem' in out.getvalue()
+    assert "30.0M   0% /dev/shm" in out.getvalue()
+    assert "15.0M   0% /dev/shm" in out.getvalue()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds support for Docker shared memory (SHM) size configuration and improves resource limit validation, including handling of null values for CPU and memory limits in container configurations.

- Added support for `shm_size` in both string ('30MB') and byte (15728640) formats in `/lib/scenario_runner.py`
- Added validation for numeric types (float, int) in memory limits in `/lib/schema_checker.py`
- Fixed container name mismatch in `/tests/data/usage_scenarios/resource_limits_cpu_none.yml` between service definition and flow section
- Added comprehensive test cases in `/tests/data/usage_scenarios/resource_limits_shm_good.yml` for SHM configurations
- Needs to address invalid `cpus: null` configuration in `resource_limits_cpu_none.yml` which violates schema requirements



<!-- /greptile_comment -->