### PR TITLE
Adding dev-no-sleeps and dev-no-optimization to the cluster

### DIFF
--- a/api/object_specifications.py
+++ b/api/object_specifications.py
@@ -22,7 +22,7 @@ class Software(BaseModel):
 
 class UserSetting(BaseModel):
     name: str
-    value: str | list
+    value: str | list | bool
 
     model_config = ConfigDict(extra='forbid')
 

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -40,7 +40,13 @@ VALUES (
         "user": {
             "visible_users": [0,1],
             "is_super_user": true,
-            "updateable_settings": ["measurement.disabled_metric_providers","measurement.flow_process_duration","measurement.total_duration"]
+            "updateable_settings": [
+                "measurement.dev_no_sleeps",
+                "measurement.dev_no_optimizations",
+                "measurement.disabled_metric_providers",
+                "measurement.flow_process_duration",
+                "measurement.total_duration"
+            ]
         },
         "api": {
             "quotas": {},
@@ -95,6 +101,8 @@ VALUES (
         "machines": [1],
         "measurement": {
             "quotas": {},
+            "dev_no_sleeps": false,
+            "dev_no_optimizations": false,
             "total_duration": 86400,
             "flow_process_duration": 86400,
             "orchestrators": {

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -2,10 +2,13 @@ const updateSetting = async (el) => {
     const left_el = el.parentElement.previousElementSibling.querySelector('input, select');
     const name = left_el.getAttribute('data-setting');
     try {
-        if (left_el.tagName.toLowerCase() === 'select') {
+        if (left_el.type == 'select-multiple') {
             const value = $(left_el).dropdown('get values');
             await makeAPICall('/v1/user/setting', {name: name, value: value}, null, true)
             showNotification('Save success!', `${name} = ${value}`)
+        } else if (left_el.type == 'checkbox') {
+            await makeAPICall('/v1/user/setting', {name: name, value: left_el.checked}, null, true)
+            showNotification('Save success!', `${name} = ${left_el.checked}`)
         } else {
             await makeAPICall('/v1/user/setting', {name: name, value: left_el.value}, null, true)
             showNotification('Save success!', `${name} = ${left_el.value}`)
@@ -20,8 +23,10 @@ const getSettings = async () => {
     try {
         const data = await makeAPICall('/v1/user/settings');
 
-        document.querySelector('#measurement-flow-process-duration').value = data?.data?._capabilities?.measurement?.flow_process_duration
-        document.querySelector('#measurement-total-duration').value = data?.data?._capabilities?.measurement?.total_duration
+        if (data?.data?._capabilities?.measurement?.dev_no_optimizations === true) document.querySelector('#measurement-dev-no-optimizations').checked = true;
+        if (data?.data?._capabilities?.measurement?.dev_no_sleeps === true) document.querySelector('#measurement-dev-no-sleeps').checked = true;
+        document.querySelector('#measurement-flow-process-duration').value = data?.data?._capabilities?.measurement?.flow_process_duration;
+        document.querySelector('#measurement-total-duration').value = data?.data?._capabilities?.measurement?.total_duration;
         $('#measurement-disabled-metric-providers').dropdown('set exactly', data?.data?._capabilities?.measurement?.disabled_metric_providers);
     } catch (err) {
         showNotification('Could not load settings', err);

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -116,6 +116,16 @@
                                     <td><input type="text" placeholder="Input a value" id="measurement-total-duration" name="measurement-total-duration" data-setting="measurement.total_duration" required="" ></td>
                                     <td><button id="save-measurement-total-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
+                                <tr>
+                                    <td>(DEV) No Sleeps during run<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster. However it will make the measurement invalid as important cooldown times are skipped.</small></span></td>
+                                    <td><input type="checkbox" id="measurement-dev-no-sleeps" name="measurement-dev-no-sleeps" data-setting="measurement.dev_no_sleeps" required=""></td>
+                                    <td><button id="save-measurement-dev-no-sleeps" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>(DEV) No optimizations after run<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster if you are not interested in the optimizations to run.</small></span></td>
+                                    <td><input type="checkbox"  id="measurement-dev-no-optimizations" name="measurement-dev-no-optimizations" data-setting="measurement.dev_no_optimizations" required=""></td>
+                                    <td><button id="save-measurement-dev-no-optimizations" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
                                 <!--
                                 <tr>
                                     <td>Kill running measurements</td>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -118,12 +118,12 @@
                                 </tr>
                                 <tr>
                                     <td>(DEV) No Sleeps during run<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster. However it will make the measurement invalid as important cooldown times are skipped.</small></span></td>
-                                    <td><input type="checkbox" id="measurement-dev-no-sleeps" name="measurement-dev-no-sleeps" data-setting="measurement.dev_no_sleeps" required=""></td>
+                                    <td><input type="checkbox" id="measurement-dev-no-sleeps" name="measurement-dev-no-sleeps" data-setting="measurement.dev_no_sleeps"></td>
                                     <td><button id="save-measurement-dev-no-sleeps" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
                                     <td>(DEV) No optimizations after run<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster if you are not interested in the optimizations to run.</small></span></td>
-                                    <td><input type="checkbox"  id="measurement-dev-no-optimizations" name="measurement-dev-no-optimizations" data-setting="measurement.dev_no_optimizations" required=""></td>
+                                    <td><input type="checkbox"  id="measurement-dev-no-optimizations" name="measurement-dev-no-optimizations" data-setting="measurement.dev_no_optimizations"></td>
                                     <td><button id="save-measurement-dev-no-optimizations" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <!--

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -51,6 +51,8 @@ class RunJob(Job):
             user_id=self._user_id,
             usage_scenario_variables=self._usage_scenario_variables,
             measurement_flow_process_duration=user._capabilities['measurement']['flow_process_duration'],
+            dev_no_sleeps=user._capabilities['measurement'].get('dev_no_sleeps', False),
+            dev_no_optimizations=user._capabilities['measurement'].get('dev_no_optimizations', False),
             measurement_total_duration=user._capabilities['measurement']['total_duration'],
             disabled_metric_providers=user._capabilities['measurement']['disabled_metric_providers'],
             allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'], # They are specific to the orchestrator. However currently we only have one. As soon as we support more orchestrators we will sub-class Runner with dedicated child classes (DockerRunner, PodmanRunner etc.)

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1663,7 +1663,8 @@ class ScenarioRunner:
                 )
 
         for argument in self._arguments:
-            if (argument.startswith('dev_') or argument == 'skip_system_checks')  and self._arguments[argument] not in (False, None):
+            # dev no optimizations does not make the run invalid ... all others do
+            if argument != 'dev_no_optimizations' and (argument.startswith('dev_') or argument == 'skip_system_checks')  and self._arguments[argument] not in (False, None):
                 invalid_message = 'Development switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n'
                 print(TerminalColors.WARNING, invalid_message, TerminalColors.ENDC)
 

--- a/lib/user.py
+++ b/lib/user.py
@@ -65,6 +65,9 @@ class User():
             raise ValueError(f"You cannot change this setting: {name}")
 
         match name:
+            case 'measurement.dev_no_optimizations' | 'measurement.dev_no_sleeps':
+                if not isinstance(value, bool):
+                    raise ValueError(f'The setting {name} must be boolean')
             case 'measurement.flow_process_duration' | 'measurement.total_duration':
                 if not (isinstance(value, int) or value.isdigit()) or int(value) <= 0 or int(value) > 86400:
                     raise ValueError(f'The setting {name} must be between 1 and 86400')

--- a/migrations/2025_05_13_user_settings_dashboard.sql
+++ b/migrations/2025_05_13_user_settings_dashboard.sql
@@ -1,0 +1,8 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{user,updateable_settings}',
+    '["measurement.dev_no_sleeps","measurement.dev_no_optimizations","measurement.total_duration"]'::jsonb,
+    true -- Create the key if it doesn't exist
+)
+WHERE user_id = 1;

--- a/migrations/2025_05_13_user_settings_dashboard.sql
+++ b/migrations/2025_05_13_user_settings_dashboard.sql
@@ -2,7 +2,29 @@ UPDATE users
 SET capabilities = jsonb_set(
     capabilities,
     '{user,updateable_settings}',
-    '["measurement.dev_no_sleeps","measurement.dev_no_optimizations","measurement.total_duration"]'::jsonb,
-    true -- Create the key if it doesn't exist
+    (
+        COALESCE(capabilities->'user'->'updateable_settings', '[]'::jsonb) ||
+        '["measurement.dev_no_sleeps","measurement.dev_no_optimizations"]'::jsonb
+    ),
+    true
 )
-WHERE user_id = 1;
+WHERE id = 1;
+
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,dev_no_sleeps}',
+    'false'::jsonb,
+    true
+)
+WHERE id = 1;
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,dev_no_optimizations}',
+    'false'::jsonb,
+    true
+)
+WHERE id = 1;


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added development settings for measurement control in the Green Metrics Tool, enabling skipping of sleep times and optimizations during development/testing phases.

- Migration file `/migrations/2025_05_13_user_settings_dashboard.sql` needs correction: wrong column name in WHERE clause and missing transaction wrapper
- Added boolean validation in `/api/object_specifications.py` for `UserSetting` model to support new dev settings
- New dev settings UI elements in `/frontend/settings.html` with clear warning messages about measurement validity impact
- Implemented checkbox handling in `/frontend/js/settings.js` for new boolean settings with proper error handling
- Modified `ScenarioRunner` in `/lib/scenario_runner.py` to support skipping sleeps/optimizations, but potential data integrity concerns with `dev_no_optimizations` not marking runs as invalid



<!-- /greptile_comment -->