### PR TITLE
Added statistical significance schedule mode [skip ci]

### DIFF
--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -95,7 +95,8 @@ VALUES (
                 "variance",
                 "tag",
                 "commit-variance",
-                "tag-variance"
+                "tag-variance",
+                "statistical-significance"
             ]
         },
         "machines": [1],

--- a/frontend/request.html
+++ b/frontend/request.html
@@ -105,6 +105,7 @@
                                 <option value='commit-variance'>Test variance on every new commit (3 measurements in a row) [Premium]</option>
                                 <option value='tag'>On every new tag [Premium]</option>
                                 <option value='tag-variance'>Test variance on every new tag (3 measurements in a row) [Premium]</option>
+                                <option value='statistical-significance'>Do 30 runs to evaluate statistical significance [Premium]</option>
                             </select>
                         </div>
                         <button class="positive ui button">Submit software</button>

--- a/migrations/2025_05_14_jobs_schedule_modes.sql
+++ b/migrations/2025_05_14_jobs_schedule_modes.sql
@@ -1,0 +1,11 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{jobs,schedule_modes}',
+    (
+        COALESCE(capabilities->'jobs'->'schedule_modes', '[]'::jsonb) ||
+        '["statistical-significance"]'::jsonb
+    ),
+    true
+)
+WHERE id = 1;


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added a new 'statistical-significance' schedule mode that enables running 30 measurements for statistical analysis, expanding the measurement capabilities of the Green Metrics Tool.

- Added 'statistical-significance' option in `/frontend/request.html` dropdown menu as a premium feature
- Modified `/api/scenario_runner.py` to create 30 jobs when statistical-significance mode is selected
- Added migration `/migrations/2025_05_14_jobs_schedule_modes.sql` to update DEFAULT user capabilities
- Missing DOWN migration script for reversibility in case of rollback
- No validation logic added to ensure all 30 measurements complete successfully



<!-- /greptile_comment -->