### PR TITLE
Trying to test disk.io providers under github actions

### DIFF
--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -70,8 +70,8 @@ measurement:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
         resolution: 99
-#      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
-#        resolution: 99
+      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
+        resolution: 99
       network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
         resolution: 99
         remove_virtual_interfaces: True
@@ -84,6 +84,8 @@ measurement:
       memory.used.cgroup.container.provider.MemoryUsedCgroupContainerProvider:
         resolution: 99
       network.io.cgroup.container.provider.NetworkIoCgroupContainerProvider:
+        resolution: 99
+      disk.io.cgroup.container.provider.DiskIoCgroupContainerProvider:
         resolution: 99
     macos:
       cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR enables disk I/O metric providers in the test configuration for GitHub Actions testing, adding both system-level procfs and container-level cgroup providers.

- Added `disk.io.procfs.system.provider.DiskIoProcfsSystemProvider` in `/tests/test-config.yml.example` for system-wide disk I/O monitoring
- Added `disk.io.cgroup.container.provider.DiskIoCgroupContainerProvider` in `/tests/test-config.yml.example` for container-specific disk I/O metrics
- Both providers configured with resolution: 99 to match existing metric provider settings



<!-- /greptile_comment -->