### PR TITLE
Phase padding can now be turned on and off

### DIFF
--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -45,7 +45,8 @@ VALUES (
                 "measurement.dev_no_optimizations",
                 "measurement.disabled_metric_providers",
                 "measurement.flow_process_duration",
-                "measurement.total_duration"
+                "measurement.total_duration",
+                "measurement.phase_padding"
             ]
         },
         "api": {

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -101,6 +101,7 @@ VALUES (
         },
         "machines": [1],
         "measurement": {
+            "phase_padding": true,
             "quotas": {},
             "dev_no_sleeps": false,
             "dev_no_optimizations": false,

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -25,6 +25,7 @@ const getSettings = async () => {
 
         if (data?.data?._capabilities?.measurement?.dev_no_optimizations === true) document.querySelector('#measurement-dev-no-optimizations').checked = true;
         if (data?.data?._capabilities?.measurement?.dev_no_sleeps === true) document.querySelector('#measurement-dev-no-sleeps').checked = true;
+        if (data?.data?._capabilities?.measurement?.phase_padding === true) document.querySelector('#measurement-phase-padding').checked = true;
         document.querySelector('#measurement-flow-process-duration').value = data?.data?._capabilities?.measurement?.flow_process_duration;
         document.querySelector('#measurement-total-duration').value = data?.data?._capabilities?.measurement?.total_duration;
         $('#measurement-disabled-metric-providers').dropdown('set exactly', data?.data?._capabilities?.measurement?.disabled_metric_providers);

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -117,6 +117,11 @@
                                     <td><button id="save-measurement-total-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
+                                    <td>Phase padding</td>
+                                    <td><input type="checkbox" id="measurement-phase-padding" name="measurement-phase-padding" data-setting="measurement.phase_padding"></td>
+                                    <td><button id="save-measurement-phase-padding" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
                                     <td>(DEV) No Sleeps during run<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster. However it will make the measurement invalid as important cooldown times are skipped.</small></span></td>
                                     <td><input type="checkbox" id="measurement-dev-no-sleeps" name="measurement-dev-no-sleeps" data-setting="measurement.dev_no_sleeps"></td>
                                     <td><button id="save-measurement-dev-no-sleeps" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -69,11 +69,12 @@ class ScenarioRunner:
         dev_no_sleeps=False, dev_cache_build=False, dev_no_metrics=False,
         dev_flow_timetravel=False, dev_no_optimizations=False, docker_prune=False, job_id=None,
         user_id=1, measurement_flow_process_duration=None, measurement_total_duration=None, disabled_metric_providers=None, allowed_run_args=None, dev_no_phase_stats=False, dev_no_save=False,
-        skip_volume_inspect=False, commit_hash_folder=None, usage_scenario_variables=None):
+        skip_volume_inspect=False, commit_hash_folder=None, usage_scenario_variables=None, phase_padding=True):
 
         if skip_unsafe is True and allow_unsafe is True:
             raise RuntimeError('Cannot specify both --skip-unsafe and --allow-unsafe')
 
+        config = GlobalConfig().config
         # variables that should not change if you call run multiple times
         if name:
             self._name = name
@@ -104,7 +105,7 @@ class ScenarioRunner:
         self._architecture = utils.get_architecture()
 
         self._sci = {'R_d': None, 'R': 0}
-        self._sci |= GlobalConfig().config.get('sci', None)  # merge in data from machine config like I, TE etc.
+        self._sci |= config.get('sci', None)  # merge in data from machine config like I, TE etc.
 
         self._job_id = job_id
         self._arguments = locals()
@@ -112,7 +113,7 @@ class ScenarioRunner:
         self._run_id = None
         self._commit_hash = None
         self._commit_timestamp = None
-        self._sampling_interval_padding = 0
+
         self._commit_hash_folder = commit_hash_folder if commit_hash_folder else ''
         self._user_id = user_id
         self._measurement_flow_process_duration = measurement_flow_process_duration
@@ -120,6 +121,11 @@ class ScenarioRunner:
         self._disabled_metric_providers = [] if disabled_metric_providers is None else disabled_metric_providers
         self._allowed_run_args = [] if allowed_run_args is None else allowed_run_args # They are specific to the orchestrator. However currently we only have one. As soon as we support more orchestrators we will sub-class Runner with dedicated child classes (DockerRunner, PodmanRunner etc.)
         self._last_measurement_duration = 0
+        self._phase_padding = phase_padding
+        self._phase_padding_ms = max(
+            utils.get_metric_providers(config, self._disabled_metric_providers).values(),
+            key=lambda x: x.get('resolution', 0) if x else 0
+        ).get('resolution', 0)
 
         del self._arguments['self'] # self is not needed and also cannot be serialzed. We remove it
 
@@ -500,10 +506,8 @@ class ScenarioRunner:
         measurement_config['allowed_run_args'] = self._allowed_run_args
         measurement_config['disabled_metric_providers'] = self._disabled_metric_providers
         measurement_config['sci'] = self._sci
-        self._sampling_interval_padding = measurement_config['sampling_interval_padding'] = max(
-            measurement_config['providers'].values(),
-            key=lambda x: x.get('resolution', 0) if x else 0
-        ).get('resolution', 0)
+        measurement_config['phase_padding'] = self._phase_padding_ms
+
 
         # We issue a fetch_one() instead of a query() here, cause we want to get the RUN_ID
         self._run_id = DB().fetch_one("""
@@ -1271,9 +1275,10 @@ class ScenarioRunner:
 
         phase_time = int(time.time_ns() / 1_000)
 
-        self.__notes_helper.add_note({'note': f"Ending phase {phase} [UNPADDED]", 'detail_name': '[NOTES]', 'timestamp': phase_time})
-        phase_time += self._sampling_interval_padding*1000 # value is in ms and we need to get to us
-        time.sleep(self._sampling_interval_padding/1000) # no custom sleep here as even with dev_no_sleeps we must ensure phases don't overlap
+        if self._phase_padding:
+            self.__notes_helper.add_note({'note': f"Ending phase {phase} [UNPADDED]", 'detail_name': '[NOTES]', 'timestamp': phase_time})
+            phase_time += self._phase_padding_ms*1000 # value is in ms and we need to get to us
+            time.sleep(self._phase_padding_ms/1000) # no custom sleep here as even with dev_no_sleeps we must ensure phases don't overlap
 
         if phase not in self.__phases:
             raise RuntimeError('Calling end_phase before start_phase. This is a developer error!')
@@ -1286,9 +1291,12 @@ class ScenarioRunner:
 
                 subprocess.run(['docker', 'pause', container_to_pause], check=True, stdout=subprocess.DEVNULL)
 
-
         self.__phases[phase]['end'] = phase_time
-        self.__notes_helper.add_note({'note': f"Ending phase {phase} [PADDED]", 'detail_name': '[NOTES]', 'timestamp': phase_time})
+
+        if self._phase_padding:
+            self.__notes_helper.add_note({'note': f"Ending phase {phase} [PADDED]", 'detail_name': '[NOTES]', 'timestamp': phase_time})
+        else:
+            self.__notes_helper.add_note({'note': f"Ending phase {phase} [UNPADDED]", 'detail_name': '[NOTES]', 'timestamp': phase_time})
 
     def run_flows(self):
         ps_to_kill_tmp = []

--- a/lib/user.py
+++ b/lib/user.py
@@ -65,7 +65,7 @@ class User():
             raise ValueError(f"You cannot change this setting: {name}")
 
         match name:
-            case 'measurement.dev_no_optimizations' | 'measurement.dev_no_sleeps':
+            case 'measurement.dev_no_optimizations' | 'measurement.dev_no_sleeps' | 'measurement.phase_padding':
                 if not isinstance(value, bool):
                     raise ValueError(f'The setting {name} must be boolean')
             case 'measurement.flow_process_duration' | 'measurement.total_duration':

--- a/migrations/2025_05_18_phase_padding.sql
+++ b/migrations/2025_05_18_phase_padding.sql
@@ -1,0 +1,18 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,phase_padding}',
+    'true'::jsonb,
+    true
+); -- for all users
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{user,updateable_settings}',
+    (
+        COALESCE(capabilities->'user'->'updateable_settings', '[]'::jsonb) ||
+        '["measurement.phase_padding"]'::jsonb
+    ),
+    true
+); -- for all users

--- a/runner.py
+++ b/runner.py
@@ -47,6 +47,7 @@ if __name__ == '__main__':
     parser.add_argument('--full-docker-prune', action='store_true', help='Stop and remove all containers, build caches, volumes and images on the system')
     parser.add_argument('--docker-prune', action='store_true', help='Prune all unassociated build caches, networks volumes and stopped containers on the system')
     parser.add_argument('--skip-volume-inspect', action='store_true', help='Disable docker volume inspection. Can help if you encounter permission issues.')
+    parser.add_argument('--no-phase-padding', action='store_true', help='Do not add paddings to phase end to capture incomplete last sampling interval.')
     parser.add_argument('--dev-flow-timetravel', action='store_true', help='Allows to repeat a failed flow or timetravel to beginning of flows or restart services.')
     parser.add_argument('--dev-no-metrics', action='store_true', help='Skips loading the metric providers. Runs will be faster, but you will have no metric')
     parser.add_argument('--dev-no-sleeps', action='store_true', help='Removes all sleeps. Resulting measurement data will be skewed.')
@@ -118,7 +119,7 @@ if __name__ == '__main__':
                     dev_flow_timetravel=args.dev_flow_timetravel, dev_no_optimizations=args.dev_no_optimizations,
                     docker_prune=args.docker_prune, dev_no_phase_stats=args.dev_no_phase_stats, user_id=args.user_id,
                     skip_volume_inspect=args.skip_volume_inspect, commit_hash_folder=args.commit_hash_folder,
-                    usage_scenario_variables=variables_dict)
+                    usage_scenario_variables=variables_dict, phase_padding=not args.no_phase_padding)
 
     # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
     #pylint: disable=broad-except

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -530,29 +530,54 @@ def test_settings_measurement():
     page.wait_for_load_state("load") # ALL JS should be done
 
     user = User(1)
+    # check default values
+    assert user._capabilities['measurement']['disabled_metric_providers'] == []
+    assert user._capabilities['measurement']['flow_process_duration'] == 86400
+    assert user._capabilities['measurement']['total_duration'] == 86400
+    assert user._capabilities['measurement']['phase_padding'] is True
+    assert user._capabilities['measurement']['dev_no_sleeps'] is False
+    assert user._capabilities['measurement']['dev_no_optimizations'] is False
 
-    value = page.locator('#measurement-total-duration').input_value()
-    assert int(value.strip()) == user._capabilities['measurement']['total_duration']
-
-
-    value = page.locator('#measurement-flow-process-duration').input_value()
-    assert int(value.strip()) == user._capabilities['measurement']['flow_process_duration']
 
     value = page.locator('#measurement-disabled-metric-providers').input_value()
     providers = [] if value.strip() == '' else [value.strip()]
     assert providers == user._capabilities['measurement']['disabled_metric_providers']
 
-    page.locator('#measurement-total-duration').fill('123')
-    page.locator('#measurement-flow-process-duration').fill('456')
-    page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "NetworkConnectionsProxyContainerProvider");')
+    value = page.locator('#measurement-flow-process-duration').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['flow_process_duration']
 
-    page.locator('#save-measurement-total-duration').click()
-    page.locator('#save-measurement-flow-process-duration').click()
+    value = page.locator('#measurement-total-duration').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['total_duration']
+
+    value = page.locator('#measurement-phase-padding').is_checked()
+    assert value is user._capabilities['measurement']['phase_padding']
+
+    value = page.locator('#measurement-dev-no-sleeps').is_checked()
+    assert value is user._capabilities['measurement']['dev_no_sleeps']
+
+    value = page.locator('#measurement-dev-no-optimizations').is_checked()
+    assert value is user._capabilities['measurement']['dev_no_optimizations']
+
+    page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "NetworkConnectionsProxyContainerProvider");')
+    page.locator('#measurement-flow-process-duration').fill('456')
+    page.locator('#measurement-total-duration').fill('123')
+    page.locator('#measurement-phase-padding').click()
+    page.locator('#measurement-dev-no-sleeps').click()
+    page.locator('#measurement-dev-no-optimizations').click()
+
     page.locator('#save-measurement-disabled-metric-providers').click()
+    page.locator('#save-measurement-flow-process-duration').click()
+    page.locator('#save-measurement-total-duration').click()
+    page.locator('#save-measurement-phase-padding').click()
+    page.locator('#save-measurement-dev-no-sleeps').click()
+    page.locator('#save-measurement-dev-no-optimizations').click()
 
     page.wait_for_load_state("networkidle") # ALL AJAX should be done
 
     user = User(1)
-    assert user._capabilities['measurement']['total_duration'] == 123
-    assert user._capabilities['measurement']['flow_process_duration'] == 456
     assert user._capabilities['measurement']['disabled_metric_providers'] == ['NetworkConnectionsProxyContainerProvider']
+    assert user._capabilities['measurement']['flow_process_duration'] == 456
+    assert user._capabilities['measurement']['total_duration'] == 123
+    assert user._capabilities['measurement']['phase_padding'] is False
+    assert user._capabilities['measurement']['dev_no_sleeps'] is True
+    assert user._capabilities['measurement']['dev_no_optimizations'] is True


### PR DESCRIPTION
TODO: Needs still setting option in the admin and a migration and default entry in structure.sql for user_id = 1

<!-- greptile_comment -->

## Greptile Summary

Adds configurable phase padding functionality to the Green Metrics Tool, allowing users to control padding at phase ends through both UI settings and CLI flags.

- Added phase padding toggle in settings UI with proper database migrations and default configuration in `structure.sql`
- Added `--no-phase-padding` CLI flag in `runner.py` for command-line control
- Modified `ScenarioRunner` to calculate `_phase_padding_ms` based on metric provider resolution
- Added phase padding capability to user permissions system in `lib/user.py`
- Added comprehensive test coverage in `test_frontend.py` for UI interactions and state persistence



<!-- /greptile_comment -->