### PR TITLE
Sampling rate rework

### DIFF
--- a/.devcontainer/codespace-setup.sh
+++ b/.devcontainer/codespace-setup.sh
@@ -13,7 +13,7 @@ sed -i 's/- 9142:9142/- 9142:9142\n      - 9143:9143/' /workspaces/green-metrics
 sed -i 's|- ./nginx/block.conf|#- ./nginx/block.conf|' /workspaces/green-metrics-tool/docker/compose.yml
 
 # activate XGBoost provider with sane values for GitHub Codespaces
-sed -i 's/common:/common:\n      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:\n        resolution: 99\n        CPUChips: 1\n        HW_CPUFreq: 2800\n        CPUCores: 32\n        CPUThreads: 64\n        TDP: 270\n        HW_MemAmountGB: 256\n        VHost_Ratio: 0.03125\n/' /workspaces/green-metrics-tool/config.yml
+sed -i 's/common:/common:\n      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:\n        sampling_rate: 99\n        CPUChips: 1\n        HW_CPUFreq: 2800\n        CPUCores: 32\n        CPUThreads: 64\n        TDP: 270\n        HW_MemAmountGB: 256\n        VHost_Ratio: 0.03125\n/' /workspaces/green-metrics-tool/config.yml
 
 
 git clone https://github.com/green-coding-solutions/example-applications.git --depth=1 --single-branch /workspaces/green-metrics-tool/example-applications || true

--- a/config.yml.example
+++ b/config.yml.example
@@ -167,7 +167,7 @@ measurement:
     macos:
     #--- MacOS: On Mac you only need this provider. Please remove all others!
       powermetrics.provider.PowermetricsProvider:
-        sampling_rate: 499 # If you set this value too low powermetrics will not be able to accomodate the timing. We recommend now lower than 199 ms
+        sampling_rate: 499 # If you set this value too low powermetrics will not be able to accommodate the timing. We recommend no lower than 199 ms
       cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
         sampling_rate: 99
     #--- Architecture - Common

--- a/config.yml.example
+++ b/config.yml.example
@@ -97,66 +97,66 @@ measurement:
     linux:
     #--- Always-On - We recommend these providers to be always enabled
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
     #--- CGroupV2 - Turn these on if you have CGroupsV2 working on your machine
       cpu.utilization.cgroup.container.provider.CpuUtilizationCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
       memory.used.cgroup.container.provider.MemoryUsedCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
       network.io.cgroup.container.provider.NetworkIoCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
       disk.io.cgroup.container.provider.DiskIoCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
     #--- RAPL - Only enable these if you have RAPL enabled on your machine
 #      cpu.energy.rapl.msr.component.provider.CpuEnergyRaplMsrComponentProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      memory.energy.rapl.msr.component.provider.MemoryEnergyRaplMsrComponentProvider:
-#        resolution: 99
+#        sampling_rate: 99
     #--- Machine Energy - These providers need special hardware / lab equipment to work
 #      psu.energy.ac.gude.machine.provider.PsuEnergyAcGudeMachineProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      psu.energy.ac.powerspy2.machine.provider.PsuEnergyAcPowerspy2MachineProvider:
-#        resolution: 250
+#        sampling_rate: 250
 #      psu.energy.ac.mcp.machine.provider.PsuEnergyAcMcpMachineProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      psu.energy.ac.ipmi.machine.provider.PsuEnergyAcIpmiMachineProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      psu.energy.dc.rapl.msr.machine.provider.PsuEnergyDcRaplMsrMachineProvider:
-#        resolution: 99
+#        sampling_rate: 99
     #--- GPU - Only enable these if you have GPUs with power measurement enabled in your machine
 #      gpu.energy.nvidia.smi.component.provider.GpuEnergyNvidiaSmiComponentProvider:
-#        resolution: 99
+#        sampling_rate: 99
     #--- Sensors - these providers need the lm-sensors package installed
 #      lmsensors.temperature.component.provider.LmsensorsTemperatureComponentProvider:
-#        resolution: 99
+#        sampling_rate: 99
       # Please change these values according to the names in '$ sensors'
 #        chips: ['thinkpad-isa-0000', 'coretemp-isa-0000']
 #        features: ['CPU', 'Package id 0', 'Core 0', 'Core 1', 'Core 2', 'Core 3']
 #      lmsensors.fan.component.provider.LmsensorsFanComponentProvider:
-#        resolution: 99
+#        sampling_rate: 99
       # Please change these values according to the names in '$ sensors'
 #        chips: ['thinkpad-isa-0000']
 #        features: ['fan1', 'fan2']
     #--- Debug - These providers should only be needed for debugging and introspection purposes
 #      cpu.frequency.sysfs.core.provider.CpuFrequencySysfsCoreProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      cpu.time.cgroup.container.provider.CpuTimeCgroupContainerProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      cpu.time.cgroup.system.provider.CpuTimeCgroupSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      cpu.time.procfs.system.provider.CpuTimeProcfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #        remove_virtual_interfaces: True
 #      disk.used.statvfs.system.provider.DiskUsedStatvfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #      cpu.utilization.cgroup.system.provider.CpuUtilizationCgroupSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
 #        cgroups:
 #            "org.gnome.Shell@wayland.service":
 #                name: "Window Manager incl. X11"
@@ -167,21 +167,21 @@ measurement:
     macos:
     #--- MacOS: On Mac you only need this provider. Please remove all others!
       powermetrics.provider.PowermetricsProvider:
-        resolution: 499 # If you set this value too low powermetrics will not be able to accomodate the timing. We recommend now lower than 199 ms
+        sampling_rate: 499 # If you set this value too low powermetrics will not be able to accomodate the timing. We recommend now lower than 199 ms
       cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
-        resolution: 99
+        sampling_rate: 99
     #--- Architecture - Common
     common:
 #      network.connections.proxy.container.provider.NetworkConnectionsProxyContainerProvider:
 ##        host_ip: 192.168.1.2 # This only needs to be enabled if automatic detection fails
     #--- Model based - These providers estimate rather than measure. Helpful where measuring is not possible, like in VMs
 #      psu.energy.ac.sdia.machine.provider.PsuEnergyAcSdiaMachineProvider:
-#        resolution: 99
+#        sampling_rate: 99
       #-- This is a default configuration. Please change this to your system!
 #        CPUChips: 1
 #        TDP: 65
 #      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
-#        resolution: 99
+#        sampling_rate: 99
       #-- This is a default configuration. Please change this to your system!
 #        CPUChips: 1
 #        HW_CPUFreq: 3200

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -222,7 +222,7 @@ CREATE TABLE measurement_metrics (
     metric text NOT NULL,
     detail_name text NOT NULL,
     unit text NOT NULL,
-    sampling_rate_configured int -- can be null for providers like NetworkProxy
+    sampling_rate_configured int  NOT NULL
 );
 
 CREATE UNIQUE INDEX measurement_metrics_get ON measurement_metrics(run_id,metric,detail_name); -- technically we could allow also different units, but we want to see the use case for that first

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -221,7 +221,8 @@ CREATE TABLE measurement_metrics (
     run_id uuid NOT NULL REFERENCES runs(id) ON DELETE CASCADE ON UPDATE CASCADE,
     metric text NOT NULL,
     detail_name text NOT NULL,
-    unit text NOT NULL
+    unit text NOT NULL,
+    sampling_rate_configured int -- can be null for providers like NetworkProxy
 );
 
 CREATE UNIQUE INDEX measurement_metrics_get ON measurement_metrics(run_id,metric,detail_name); -- technically we could allow also different units, but we want to see the use case for that first

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -256,7 +256,7 @@ CREATE TABLE measurement_metrics (
     metric text NOT NULL,
     detail_name text NOT NULL,
     unit text NOT NULL,
-    sampling_rate_configured int  NOT NULL
+    sampling_rate_configured int NOT NULL
 );
 
 CREATE UNIQUE INDEX measurement_metrics_get ON measurement_metrics(run_id,metric,detail_name); -- technically we could allow also different units, but we want to see the use case for that first

--- a/lib/metric_importer.py
+++ b/lib/metric_importer.py
@@ -24,14 +24,14 @@ def import_measurements(df, metric_name, run_id):
 
         df['run_id'] = run_id
 
-        metric_and_detail_names = df[['metric', 'detail_name', 'unit']].drop_duplicates()
+        metric_and_detail_names = df[['metric', 'detail_name', 'unit', 'sampling_rate_configured']].drop_duplicates()
 
         for _, row in metric_and_detail_names.iterrows():
             measurement_metric_id = DB().fetch_one('''
-                INSERT INTO measurement_metrics (run_id, metric, detail_name, unit)
-                VALUES (%s, %s, %s, %s)
+                INSERT INTO measurement_metrics (run_id, metric, detail_name, unit, sampling_rate_configured)
+                VALUES (%s, %s, %s, %s, %s)
                 RETURNING id
-            ''', params=(run_id, row['metric'], row['detail_name'], row['unit']))[0] # using row['metric'] here instead of metric_name, as some providers have multiple metrics inlined like powermetrics
+            ''', params=(run_id, row['metric'], row['detail_name'], row['unit'], row['sampling_rate_configured']))[0] # using row['metric'] here instead of metric_name, as some providers have multiple metrics inlined like powermetrics
             df.loc[(df['metric'] == row['metric']) & (df['detail_name'] == row['detail_name']) & (df['unit'] == row['unit']), 'measurement_metric_id'] = measurement_metric_id
 
         df['measurement_metric_id'] = df.measurement_metric_id.astype(int)

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -108,7 +108,7 @@ def build_and_store_phase_stats(run_id, sci=None):
 
     runtime_phase_idx = None
 
-    for idx, phase in enumerate(phases):
+    for idx, phase in enumerate(phases[0]):
         if phase['name'] == '[RUNTIME]': # do not process runtime like this, but rather reconstruct it later. Still advance the idx counter though as we want to use the number later
             runtime_phase_idx = idx
             continue

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -502,8 +502,8 @@ class ScenarioRunner:
         measurement_config['sci'] = self._sci
         self._sampling_interval_padding = measurement_config['sampling_interval_padding'] = max(
             measurement_config['providers'].values(),
-            key=lambda x: x.get('resolution', 0) if x else 0
-        ).get('resolution', 0)
+            key=lambda x: x.get('sampling_rate', 0) if x else 0
+        ).get('sampling_rate', 0)
 
         # We issue a fetch_one() instead of a query() here, cause we want to get the RUN_ID
         self._run_id = DB().fetch_one("""

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -54,8 +54,8 @@ def check_largest_sampling_rate():
 
     return max(
         metric_providers.values(),
-        key=lambda x: x.get('resolution', 0) if x else 0
-    ).get('resolution', 0) <= 1000
+        key=lambda x: x.get('sampling_rate', 0) if x else 0
+    ).get('sampling_rate', 0) <= 1000
 
 def check_cpu_utilization():
     return psutil.cpu_percent(0.1) < 5.0

--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -151,7 +151,7 @@ class BaseMetricProvider:
 
         return df
 
-    def _add_auxillary_fields(self, df): # can be overriden in child
+    def _add_auxiliary_fields(self, df): # can be overriden in child
         df['unit'] = self._unit
         df['metric'] = self._metric_name
         df['sampling_rate_configured'] = self._sampling_rate
@@ -168,7 +168,7 @@ class BaseMetricProvider:
         self._check_resolution_underflow(df)
 
         df = self._parse_metrics(df)
-        df = self._add_auxillary_fields(df)
+        df = self._add_auxiliary_fields(df)
 
         df = self._add_and_validate_sampling_rate_and_jitter(df)
 

--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -17,7 +17,7 @@ class BaseMetricProvider:
     def __init__(self, *,
         metric_name,
         metrics,
-        resolution,
+        sampling_rate,
         unit,
         current_dir,
         metric_provider_executable='metric-provider-binary',
@@ -27,7 +27,7 @@ class BaseMetricProvider:
     ):
         self._metric_name = metric_name
         self._metrics = metrics
-        self._resolution = resolution
+        self._sampling_rate = sampling_rate
         self._unit = unit
         self._current_dir = current_dir
         self._metric_provider_executable = metric_provider_executable
@@ -133,7 +133,7 @@ class BaseMetricProvider:
         df['detail_name'] = f"[{self._metric_name.split('_')[-1].upper()}]" # default, can be overridden in child
         return df
 
-    def _add_and_validate_resolution_and_jitter(self, df):
+    def _add_and_validate_sampling_rate_and_jitter(self, df):
         # DF can have many columns still. Since all of them might have induced a separate timing row
         # we group by everything apart from time and value itself
         # for most metric providers only detail_name and container_id should be present and differ though
@@ -143,17 +143,18 @@ class BaseMetricProvider:
         df['sampling_rate_95p'] = df.groupby(grouping_columms)['sampling_rate'].transform(lambda x: x.quantile(0.95))
         df = df.drop('sampling_rate', axis=1)
 
-        if (sampling_rate_95p := df['sampling_rate_95p'].max()) >= self._resolution*1000*1.2:
-            raise RuntimeError(f"Effective sampling rate (95p) was absurdly high: {sampling_rate_95p} compared to target rate of {self._resolution*1000}", df)
+        if (sampling_rate_95p := df['sampling_rate_95p'].max()) >= self._sampling_rate*1000*1.2:
+            raise RuntimeError(f"Effective sampling rate (95p) was absurdly high: {sampling_rate_95p} compared to configured rate of {self._sampling_rate*1000}", df)
 
-        if (sampling_rate_95p := df['sampling_rate_95p'].min()) <= self._resolution*1000*0.8:
-            raise RuntimeError(f"Effective sampling rate (95p) was absurdly low: {sampling_rate_95p} compared to target rate of {self._resolution*1000}", df)
+        if (sampling_rate_95p := df['sampling_rate_95p'].min()) <= self._sampling_rate*1000*0.8:
+            raise RuntimeError(f"Effective sampling rate (95p) was absurdly low: {sampling_rate_95p} compared to configured rate of {self._sampling_rate*1000}", df)
 
         return df
 
     def _add_unit_and_metric(self, df): # can be overriden in child
         df['unit'] = self._unit
         df['metric'] = self._metric_name
+        df['sampling_rate_configured'] = self._sampling_rate
         return df
 
     @final
@@ -169,7 +170,7 @@ class BaseMetricProvider:
         df = self._parse_metrics(df)
         df = self._add_unit_and_metric(df)
 
-        df = self._add_and_validate_resolution_and_jitter(df)
+        df = self._add_and_validate_sampling_rate_and_jitter(df)
 
         self._check_empty(df) # we do another check after transformations, as this could have resulted in zero rows
 
@@ -180,10 +181,10 @@ class BaseMetricProvider:
 
     def start_profiling(self):
 
-        if self._resolution is None:
+        if self._sampling_rate is None:
             call_string = self._metric_provider_executable
         else:
-            call_string = f"{self._metric_provider_executable} -i {self._resolution}"
+            call_string = f"{self._metric_provider_executable} -i {self._sampling_rate}"
 
 
         if self._metric_provider_executable[0] != '/':

--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -151,7 +151,7 @@ class BaseMetricProvider:
 
         return df
 
-    def _add_unit_and_metric(self, df): # can be overriden in child
+    def _add_auxillary_fields(self, df): # can be overriden in child
         df['unit'] = self._unit
         df['metric'] = self._metric_name
         df['sampling_rate_configured'] = self._sampling_rate
@@ -168,7 +168,7 @@ class BaseMetricProvider:
         self._check_resolution_underflow(df)
 
         df = self._parse_metrics(df)
-        df = self._add_unit_and_metric(df)
+        df = self._add_auxillary_fields(df)
 
         df = self._add_and_validate_sampling_rate_and_jitter(df)
 

--- a/metric_providers/cgroup.py
+++ b/metric_providers/cgroup.py
@@ -5,7 +5,7 @@ class CgroupMetricProvider(BaseMetricProvider):
     def __init__(self, *,
             metric_name,
             metrics,
-            resolution,
+            sampling_rate,
             unit,
             current_dir,
             skip_check,
@@ -14,7 +14,7 @@ class CgroupMetricProvider(BaseMetricProvider):
         super().__init__(
             metric_name=metric_name,
             metrics=metrics,
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit=unit,
             current_dir=current_dir,
             skip_check=skip_check

--- a/metric_providers/container.py
+++ b/metric_providers/container.py
@@ -4,7 +4,7 @@ class ContainerMetricProvider(BaseMetricProvider):
     def __init__(self, *,
             metric_name,
             metrics,
-            resolution,
+            sampling_rate,
             unit,
             current_dir,
             skip_check,
@@ -13,7 +13,7 @@ class ContainerMetricProvider(BaseMetricProvider):
         super().__init__(
             metric_name=metric_name,
             metrics=metrics,
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit=unit,
             current_dir=current_dir,
             skip_check=skip_check

--- a/metric_providers/cpu/energy/rapl/msr/component/provider.py
+++ b/metric_providers/cpu/energy/rapl/msr/component/provider.py
@@ -4,11 +4,11 @@ from metric_providers.base import BaseMetricProvider, MetricProviderConfiguratio
 from lib.utils import is_rapl_energy_filtering_deactivated
 
 class CpuEnergyRaplMsrComponentProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='cpu_energy_rapl_msr_component',
             metrics={'time': int, 'value': int, 'package_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/cpu/frequency/sysfs/core/provider.py
+++ b/metric_providers/cpu/frequency/sysfs/core/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class CpuFrequencySysfsCoreProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='cpu_frequency_sysfs_core',
             metrics={'time': int, 'value': int, 'core_id': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Hz',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='get-scaling-cur-freq.sh',

--- a/metric_providers/cpu/time/cgroup/container/provider.py
+++ b/metric_providers/cpu/time/cgroup/container/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.container import ContainerMetricProvider
 
 class CpuTimeCgroupContainerProvider(ContainerMetricProvider):
-    def __init__(self, resolution, skip_check=False, containers: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, containers: dict = None):
         super().__init__(
             metric_name='cpu_time_cgroup_container',
             metrics={'time': int, 'value': int, 'container_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='us',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/cpu/time/cgroup/system/provider.py
+++ b/metric_providers/cpu/time/cgroup/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.cgroup import CgroupMetricProvider
 
 class CpuTimeCgroupSystemProvider(CgroupMetricProvider):
-    def __init__(self, resolution, skip_check=False, cgroups: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, cgroups: dict = None):
         super().__init__(
             metric_name='cpu_time_cgroup_system',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='us',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/cpu/time/procfs/system/provider.py
+++ b/metric_providers/cpu/time/procfs/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class CpuTimeProcfsSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='cpu_time_procfs_system',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='us',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check = skip_check

--- a/metric_providers/cpu/utilization/cgroup/container/provider.py
+++ b/metric_providers/cpu/utilization/cgroup/container/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.container import ContainerMetricProvider
 
 class CpuUtilizationCgroupContainerProvider(ContainerMetricProvider):
-    def __init__(self, resolution, skip_check=False, containers: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, containers: dict = None):
         super().__init__(
             metric_name='cpu_utilization_cgroup_container',
             metrics={'time': int, 'value': int, 'container_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Ratio',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/cpu/utilization/cgroup/system/provider.py
+++ b/metric_providers/cpu/utilization/cgroup/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.cgroup import CgroupMetricProvider
 
 class CpuUtilizationCgroupSystemProvider(CgroupMetricProvider):
-    def __init__(self, resolution, skip_check=False, cgroups: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, cgroups: dict = None):
         super().__init__(
             metric_name='cpu_utilization_cgroup_system',
             metrics={'time': int, 'value': int, 'cgroup_str': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Ratio',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/cpu/utilization/mach/system/provider.py
+++ b/metric_providers/cpu/utilization/mach/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class CpuUtilizationMachSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='cpu_utilization_mach_system',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Ratio',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check = skip_check,

--- a/metric_providers/cpu/utilization/procfs/system/provider.py
+++ b/metric_providers/cpu/utilization/procfs/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class CpuUtilizationProcfsSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='cpu_utilization_procfs_system',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Ratio',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check = skip_check,

--- a/metric_providers/disk/io/cgroup/container/provider.py
+++ b/metric_providers/disk/io/cgroup/container/provider.py
@@ -4,11 +4,11 @@ from lib import utils
 from metric_providers.container import ContainerMetricProvider
 
 class DiskIoCgroupContainerProvider(ContainerMetricProvider):
-    def __init__(self, resolution, skip_check=False, containers: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, containers: dict = None):
         super().__init__(
             metric_name='disk_io_cgroup_container',
             metrics={'time': int, 'read_bytes': int, 'written_bytes': int, 'container_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/disk/io/cgroup/system/provider.py
+++ b/metric_providers/disk/io/cgroup/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.cgroup import CgroupMetricProvider
 
 class DiskIoCgroupSystemProvider(CgroupMetricProvider):
-    def __init__(self, resolution, skip_check=False, cgroups: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, cgroups: dict = None):
         super().__init__(
             metric_name='disk_io_cgroup_system',
             metrics={'time': int, 'read_bytes': int, 'written_bytes': int, 'cgroup_str': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/disk/io/procfs/system/provider.py
+++ b/metric_providers/disk/io/procfs/system/provider.py
@@ -5,11 +5,11 @@ from lib import utils
 from metric_providers.base import BaseMetricProvider
 
 class DiskIoProcfsSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='disk_io_procfs_system',
             metrics={'time': int, 'read_sectors': int, 'written_sectors': int, 'device': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/disk/used/statvfs/system/provider.py
+++ b/metric_providers/disk/used/statvfs/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class DiskUsedStatvfsSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='disk_used_statvfs_system',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/gpu/energy/nvidia/smi/component/provider.py
+++ b/metric_providers/gpu/energy/nvidia/smi/component/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class GpuEnergyNvidiaSmiComponentProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='gpu_energy_nvidia_smi_component',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='metric-provider-nvidia-smi-wrapper.sh',

--- a/metric_providers/lmsensors/abstract_provider.py
+++ b/metric_providers/lmsensors/abstract_provider.py
@@ -23,7 +23,7 @@ class LmsensorsProvider(BaseMetricProvider):
         return ['-c'] + [f"'{i}'" for i in provider_config['chips']] \
             + ['-f'] + [f"'{i}'" for i in provider_config['features']]
 
-    def __init__(self, metric_name, resolution, unit, skip_check=False):
+    def __init__(self, metric_name, sampling_rate, unit, skip_check=False):
         if __name__ == '__main__':
             # If you run this on the command line you will need to set this in the config
             # This is separate so it is always clear what config is used.
@@ -33,7 +33,7 @@ class LmsensorsProvider(BaseMetricProvider):
         super().__init__(
             metric_name=metric_name,
             metrics={'time': int, 'value': int, 'sensor_name': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit=unit,
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/lmsensors/fan/component/provider.py
+++ b/metric_providers/lmsensors/fan/component/provider.py
@@ -1,11 +1,11 @@
 from metric_providers.lmsensors.abstract_provider import LmsensorsProvider
 
 class LmsensorsFanComponentProvider(LmsensorsProvider):
-    def __init__(self, resolution, *, skip_check=False, **_):
+    def __init__(self, sampling_rate, *, skip_check=False, **_):
         self._provider_config_path = 'lmsensors.fan.component.provider.LmsensorsFanComponentProvider'
         super().__init__(
             metric_name='lmsensors_fan_component',
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='RPM',
             skip_check=skip_check,
         )

--- a/metric_providers/lmsensors/temperature/component/provider.py
+++ b/metric_providers/lmsensors/temperature/component/provider.py
@@ -1,11 +1,11 @@
 from metric_providers.lmsensors.abstract_provider import LmsensorsProvider
 
 class LmsensorsTemperatureComponentProvider(LmsensorsProvider):
-    def __init__(self, resolution, *, skip_check=False, **_):
+    def __init__(self, sampling_rate, *, skip_check=False, **_):
         self._provider_config_path = 'lmsensors.temperature.component.provider.LmsensorsTemperatureComponentProvider'
         super().__init__(
             metric_name='lmsensors_temperature_component',
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='centi°C',
             skip_check=skip_check,
         )

--- a/metric_providers/memory/energy/rapl/msr/component/provider.py
+++ b/metric_providers/memory/energy/rapl/msr/component/provider.py
@@ -4,11 +4,11 @@ from metric_providers.base import BaseMetricProvider, MetricProviderConfiguratio
 from lib.utils import is_rapl_energy_filtering_deactivated
 
 class MemoryEnergyRaplMsrComponentProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='memory_energy_rapl_msr_component',
             metrics={'time': int, 'value': int, 'dram_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/memory/used/cgroup/container/provider.py
+++ b/metric_providers/memory/used/cgroup/container/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.container import ContainerMetricProvider
 
 class MemoryUsedCgroupContainerProvider(ContainerMetricProvider):
-    def __init__(self, resolution, skip_check=False, containers: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, containers: dict = None):
         super().__init__(
             metric_name='memory_used_cgroup_container',
             metrics={'time': int, 'value': int, 'container_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/memory/used/cgroup/system/provider.py
+++ b/metric_providers/memory/used/cgroup/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.cgroup import CgroupMetricProvider
 
 class MemoryUsedCgroupSystemProvider(CgroupMetricProvider):
-    def __init__(self, resolution, skip_check=False, cgroups: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, cgroups: dict = None):
         super().__init__(
             metric_name='memory_used_cgroup_system',
             metrics={'time': int, 'value': int, 'cgroup_str': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/memory/used/procfs/system/provider.py
+++ b/metric_providers/memory/used/procfs/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class MemoryUsedProcfsSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='memory_used_procfs_system',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/network/connections/proxy/container/provider.py
+++ b/metric_providers/network/connections/proxy/container/provider.py
@@ -20,7 +20,7 @@ class NetworkConnectionsProxyContainerProvider(BaseMetricProvider):
         super().__init__(
             metric_name='network_connections_proxy_container_dockerproxy',
             metrics={},
-            resolution=None,
+            sampling_rate=None,
             unit=None,
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,
@@ -104,8 +104,8 @@ class NetworkConnectionsProxyContainerProvider(BaseMetricProvider):
     def _add_unit_and_metric(self, df):
         return df # noop. Just for overwriting
 
-    def _check_resolution_underflow(self, df):
+    def _check_sampling_rate_underflow(self, df):
         pass  # noop. Just for overwriting
 
-    def _add_and_validate_resolution_and_jitter(self, df):
+    def _add_and_validate_sampling_rate_and_jitter(self, df):
         return df # noop. Just for overwriting

--- a/metric_providers/network/connections/proxy/container/provider.py
+++ b/metric_providers/network/connections/proxy/container/provider.py
@@ -101,7 +101,7 @@ class NetworkConnectionsProxyContainerProvider(BaseMetricProvider):
     def _check_monotonic(self, df):
         pass  # noop. Just for overwriting
 
-    def _add_auxillary_fields(self, df):
+    def _add_auxiliary_fields(self, df):
         return df # noop. Just for overwriting
 
     def _check_sampling_rate_underflow(self, df):

--- a/metric_providers/network/connections/proxy/container/provider.py
+++ b/metric_providers/network/connections/proxy/container/provider.py
@@ -101,7 +101,7 @@ class NetworkConnectionsProxyContainerProvider(BaseMetricProvider):
     def _check_monotonic(self, df):
         pass  # noop. Just for overwriting
 
-    def _add_unit_and_metric(self, df):
+    def _add_auxillary_fields(self, df):
         return df # noop. Just for overwriting
 
     def _check_sampling_rate_underflow(self, df):

--- a/metric_providers/network/connections/tcpdump/system/provider.py
+++ b/metric_providers/network/connections/tcpdump/system/provider.py
@@ -11,7 +11,7 @@ class NetworkConnectionsTcpdumpSystemProvider(BaseMetricProvider):
         super().__init__(
             metric_name='network_connections_tcpdump_system',
             metrics={},
-            resolution=None,
+            sampling_rate=None,
             unit=None,
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='tcpdump.sh',
@@ -39,10 +39,10 @@ class NetworkConnectionsTcpdumpSystemProvider(BaseMetricProvider):
     def _check_monotonic(self, df):
         pass  # noop. Just for overwriting
 
-    def _check_resolution_underflow(self, df):
+    def _check_sampling_rate_underflow(self, df):
         pass  # noop. Just for overwriting
 
-    def _add_and_validate_resolution_and_jitter(self, df):
+    def _add_and_validate_sampling_rate_and_jitter(self, df):
         return df  # noop. Just for overwriting
 
     def get_stderr(self):

--- a/metric_providers/network/connections/tcpdump/system/provider.py
+++ b/metric_providers/network/connections/tcpdump/system/provider.py
@@ -33,7 +33,7 @@ class NetworkConnectionsTcpdumpSystemProvider(BaseMetricProvider):
     def _check_empty(self, df):
         pass # noop. Just for overwriting. Empty data is ok for this reporter
 
-    def _add_auxillary_fields(self, df):
+    def _add_auxiliary_fields(self, df):
         return df # noop. Just for overwriting
 
     def _check_monotonic(self, df):

--- a/metric_providers/network/connections/tcpdump/system/provider.py
+++ b/metric_providers/network/connections/tcpdump/system/provider.py
@@ -33,7 +33,7 @@ class NetworkConnectionsTcpdumpSystemProvider(BaseMetricProvider):
     def _check_empty(self, df):
         pass # noop. Just for overwriting. Empty data is ok for this reporter
 
-    def _add_unit_and_metric(self, df):
+    def _add_auxillary_fields(self, df):
         return df # noop. Just for overwriting
 
     def _check_monotonic(self, df):

--- a/metric_providers/network/io/cgroup/container/provider.py
+++ b/metric_providers/network/io/cgroup/container/provider.py
@@ -4,11 +4,11 @@ from lib import utils
 from metric_providers.container import ContainerMetricProvider
 
 class NetworkIoCgroupContainerProvider(ContainerMetricProvider):
-    def __init__(self, resolution, skip_check=False, containers: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, containers: dict = None):
         super().__init__(
             metric_name='network_io_cgroup_container',
             metrics={'time': int, 'received_bytes': int, 'transmitted_bytes': int, 'container_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/network/io/cgroup/system/provider.py
+++ b/metric_providers/network/io/cgroup/system/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.cgroup import CgroupMetricProvider
 
 class NetworkIoCgroupSystemProvider(CgroupMetricProvider):
-    def __init__(self, resolution, skip_check=False, cgroups: dict = None):
+    def __init__(self, sampling_rate, skip_check=False, cgroups: dict = None):
         super().__init__(
             metric_name='network_io_cgroup_system',
             metrics={'time': int, 'received_bytes': int, 'transmitted_bytes': int, 'cgroup_str': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/network/io/procfs/system/provider.py
+++ b/metric_providers/network/io/procfs/system/provider.py
@@ -4,11 +4,11 @@ from lib import utils
 from metric_providers.base import BaseMetricProvider
 
 class NetworkIoProcfsSystemProvider(BaseMetricProvider):
-    def __init__(self, resolution, remove_virtual_interfaces=True, skip_check=False):
+    def __init__(self, sampling_rate, remove_virtual_interfaces=True, skip_check=False):
         super().__init__(
             metric_name='network_io_procfs_system',
             metrics={'time': int, 'received_bytes': int, 'transmitted_bytes': int, 'interface': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='Bytes',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/powermetrics/provider.py
+++ b/metric_providers/powermetrics/provider.py
@@ -100,7 +100,7 @@ class PowermetricsProvider(BaseMetricProvider):
     def _parse_metrics(self, df):
         return df # noop, as we have already set detail_name individually in _read_metrics
 
-    def _add_unit_and_metric(self, df):
+    def _add_auxillary_fields(self, df):
         return df # noop, as we have already set detail_name individually in _read_metrics
 
     def _check_resolution_underflow(self, df):

--- a/metric_providers/powermetrics/provider.py
+++ b/metric_providers/powermetrics/provider.py
@@ -100,7 +100,7 @@ class PowermetricsProvider(BaseMetricProvider):
     def _parse_metrics(self, df):
         return df # noop, as we have already set detail_name individually in _read_metrics
 
-    def _add_auxillary_fields(self, df):
+    def _add_auxiliary_fields(self, df):
         return df # noop, as we have already set detail_name individually in _read_metrics
 
     def _check_resolution_underflow(self, df):

--- a/metric_providers/powermetrics/provider.py
+++ b/metric_providers/powermetrics/provider.py
@@ -10,14 +10,14 @@ import signal
 from metric_providers.base import MetricProviderConfigurationError, BaseMetricProvider
 
 class PowermetricsProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         # We get this value on init as we want to have to for check_system to work in the normal case
         self._pm_process_count = self.powermetrics_total_count()
 
         super().__init__(
             metric_name='powermetrics',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='/usr/bin/powermetrics',

--- a/metric_providers/psu/energy/ac/gude/machine/check_gude_modified.py
+++ b/metric_providers/psu/energy/ac/gude/machine/check_gude_modified.py
@@ -6,15 +6,15 @@ import sys
 import requests
 
 
-def main(resolution):
+def main(sampling_rate):
     url = 'http://192.168.178.32/status.json'
 
     only_values = 0x4000
     cgi = {'components': only_values}  # simple-sensors + and only values
 
-    resolution = float(resolution)
+    sampling_rate = float(sampling_rate)
 
-    target_sleep_time = resolution / 1000.0
+    target_sleep_time = sampling_rate / 1000.0
 
     while True:  # loop until CTRL+C
         timestamp_before = time.time_ns()
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
     if args.i is None:
         parser.print_help()
-        print('Please supply -i to set resolution in milliseconds')
+        print('Please supply -i to set sampling_rate in milliseconds')
         sys.exit(1)
 
     main(args.i)

--- a/metric_providers/psu/energy/ac/gude/machine/provider.py
+++ b/metric_providers/psu/energy/ac/gude/machine/provider.py
@@ -5,18 +5,18 @@ from metric_providers.base import BaseMetricProvider
 
 
 class PsuEnergyAcGudeMachineProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='psu_energy_ac_gude_machine',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,
         )
 
     def start_profiling(self, containers=None):
-        call_string = f"{self._current_dir}/check_gude_modified.py -i {self._resolution}"
+        call_string = f"{self._current_dir}/check_gude_modified.py -i {self._sampling_rate}"
 
         call_string += f" > {self._filename}"
 

--- a/metric_providers/psu/energy/ac/ipmi/machine/provider.py
+++ b/metric_providers/psu/energy/ac/ipmi/machine/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class PsuEnergyAcIpmiMachineProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='psu_energy_ac_ipmi_machine',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable='ipmi-get-machine-energy-stat.sh',

--- a/metric_providers/psu/energy/ac/mcp/machine/provider.py
+++ b/metric_providers/psu/energy/ac/mcp/machine/provider.py
@@ -3,11 +3,11 @@ import os
 from metric_providers.base import BaseMetricProvider
 
 class PsuEnergyAcMcpMachineProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='psu_energy_ac_mcp_machine',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit="uJ",
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/psu/energy/ac/powerspy2/machine/provider.py
+++ b/metric_providers/psu/energy/ac/powerspy2/machine/provider.py
@@ -2,11 +2,11 @@ import os
 from metric_providers.base import BaseMetricProvider, MetricProviderConfigurationError
 
 class PsuEnergyAcPowerspy2MachineProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name="psu_energy_ac_powerspy2_machine",
             metrics={"time": int, "value": int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit="uJ",
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             metric_provider_executable="metric-provider.py",

--- a/metric_providers/psu/energy/ac/sdia/machine/provider.py
+++ b/metric_providers/psu/energy/ac/sdia/machine/provider.py
@@ -4,11 +4,11 @@ from metric_providers.base import BaseMetricProvider, MetricProviderConfiguratio
 from lib.global_config import GlobalConfig
 
 class PsuEnergyAcSdiaMachineProvider(BaseMetricProvider):
-    def __init__(self, *, resolution, CPUChips, TDP, skip_check=False, filename=None):
+    def __init__(self, *, sampling_rate, CPUChips, TDP, skip_check=False, filename=None):
         super().__init__(
             metric_name='psu_energy_ac_sdia_machine',
             metrics={'time': int, 'value': int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/psu/energy/ac/xgboost/machine/provider.py
+++ b/metric_providers/psu/energy/ac/xgboost/machine/provider.py
@@ -10,12 +10,12 @@ from metric_providers.base import BaseMetricProvider, MetricProviderConfiguratio
 from lib.global_config import GlobalConfig
 
 class PsuEnergyAcXgboostMachineProvider(BaseMetricProvider):
-    def __init__(self, resolution, *, HW_CPUFreq, CPUChips, CPUThreads, TDP,
+    def __init__(self, sampling_rate, *, HW_CPUFreq, CPUChips, CPUThreads, TDP,
                  HW_MemAmountGB, CPUCores=None, Hardware_Availability_Year=None, VHost_Ratio=1, skip_check=False, filename=None):
         super().__init__(
             metric_name="psu_energy_ac_xgboost_machine",
             metrics={"time": int, "value": int},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit="uJ",
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/metric_providers/psu/energy/dc/rapl/msr/machine/provider.py
+++ b/metric_providers/psu/energy/dc/rapl/msr/machine/provider.py
@@ -4,11 +4,11 @@ from metric_providers.base import BaseMetricProvider, MetricProviderConfiguratio
 from lib.utils import is_rapl_energy_filtering_deactivated
 
 class PsuEnergyDcRaplMsrMachineProvider(BaseMetricProvider):
-    def __init__(self, resolution, skip_check=False):
+    def __init__(self, sampling_rate, skip_check=False):
         super().__init__(
             metric_name='psu_energy_dc_rapl_msr_machine',
             metrics={'time': int, 'value': int, 'psys_id': str},
-            resolution=resolution,
+            sampling_rate=sampling_rate,
             unit='uJ',
             current_dir=os.path.dirname(os.path.abspath(__file__)),
             skip_check=skip_check,

--- a/tests/data/usage_scenarios/noop.yml
+++ b/tests/data/usage_scenarios/noop.yml
@@ -1,0 +1,16 @@
+---
+name: Testing Noop
+author: Arne Tarara
+description: Testing Noop
+
+services:
+  test-container:
+    type: container
+    image: alpine
+
+flow:
+  - name: Testing Noop
+    container: test-container
+    commands:
+      - type: console
+        command: echo 1

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -208,7 +208,7 @@ def test_phase_stats_network_io_two_measurements():
     assert data[3]['sampling_rate_95p'] == 1000486
 
 def test_phase_stats_network_io_two_measurements_at_phase_border():
-    run_id = Tests.insert_run(measurement_config='{"providers": {"network.io.procfs.system.provider.NetworkIoProcfsSystemProvider": {"resolution": 99}}}')
+    run_id = Tests.insert_run(measurement_config='{"providers": {"network.io.procfs.system.provider.NetworkIoProcfsSystemProvider": {"sampling_rate": 99}}}')
     Tests.import_two_network_io_procfs_measurements_at_phase_border(run_id)
 
     build_and_store_phase_stats(run_id)

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -208,7 +208,7 @@ def test_phase_stats_network_io_two_measurements():
     assert data[3]['sampling_rate_95p'] == 1000486
 
 def test_phase_stats_network_io_two_measurements_at_phase_border():
-    run_id = Tests.insert_run(measurement_config='{"providers": {"network.io.procfs.system.provider.NetworkIoProcfsSystemProvider": {"sampling_rate": 99}}}')
+    run_id = Tests.insert_run()
     Tests.import_two_network_io_procfs_measurements_at_phase_border(run_id)
 
     build_and_store_phase_stats(run_id)
@@ -223,24 +223,24 @@ def test_phase_stats_network_io_two_measurements_at_phase_border():
 
     assert data[3]['metric'] == 'network_io_procfs_system'
     assert data[3]['detail_name'] == 'CURRENT_ACTUAL_NETWORK_INTERFACE'
-    assert data[3]['value'] == 138242
-    assert data[3]['sampling_rate_95p'] == 99000
-    assert data[3]['sampling_rate_avg'] == 99000
-    assert data[3]['sampling_rate_max'] == 99000
+    assert data[3]['value'] == 13686
+    assert data[3]['sampling_rate_95p'] == 1000000
+    assert data[3]['sampling_rate_avg'] == 1000000
+    assert data[3]['sampling_rate_max'] == 1000000
 
     assert data[0]['metric'] == 'network_total_procfs_system'
     assert data[0]['detail_name'] == 'CURRENT_ACTUAL_NETWORK_INTERFACE'
     assert data[0]['value'] == 13686
-    assert data[0]['sampling_rate_95p'] == 99000
-    assert data[0]['sampling_rate_avg'] == 99000
-    assert data[0]['sampling_rate_max'] == 99000
+    assert data[0]['sampling_rate_95p'] == 1000000
+    assert data[0]['sampling_rate_avg'] == 1000000
+    assert data[0]['sampling_rate_max'] == 1000000
 
     assert data[4]['metric'] == 'network_io_procfs_system'
     assert data[4]['detail_name'] == 'lo'
     assert data[4]['value'] == 0
-    assert data[4]['sampling_rate_95p'] == 99000
-    assert data[4]['sampling_rate_avg'] == 99000
-    assert data[4]['sampling_rate_max'] == 99000
+    assert data[4]['sampling_rate_95p'] == 1000000
+    assert data[4]['sampling_rate_avg'] == 1000000
+    assert data[4]['sampling_rate_max'] == 1000000
 
 
 def test_phase_stats_single_network_procfs():

--- a/tests/test-config-extra-network-and-duplicate-psu-providers.yml
+++ b/tests/test-config-extra-network-and-duplicate-psu-providers.yml
@@ -67,28 +67,28 @@ measurement:
   metric_providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
 #      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
       network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
         remove_virtual_interfaces: True
       disk.used.statvfs.system.provider.DiskUsedStatvfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
       memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
     macos:
       cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
-        resolution: 99
+        sampling_rate: 99
     common:
       network.connections.proxy.container.provider.NetworkConnectionsProxyContainerProvider:
 
       psu.energy.ac.sdia.machine.provider.PsuEnergyAcSdiaMachineProvider:
-        resolution: 99
+        sampling_rate: 99
         CPUChips: 1
         TDP: 60
       psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
-        resolution: 99
+        sampling_rate: 99
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -69,28 +69,28 @@ measurement:
   metric_providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
 #      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
-#        resolution: 99
+#        sampling_rate: 99
       network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
         remove_virtual_interfaces: True
       disk.used.statvfs.system.provider.DiskUsedStatvfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
       memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
-        resolution: 99
+        sampling_rate: 99
       cpu.utilization.cgroup.container.provider.CpuUtilizationCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
       memory.used.cgroup.container.provider.MemoryUsedCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
       network.io.cgroup.container.provider.NetworkIoCgroupContainerProvider:
-        resolution: 99
+        sampling_rate: 99
     macos:
       cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
-        resolution: 99
+        sampling_rate: 99
     common:
       psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
-        resolution: 99
+        sampling_rate: 99
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -21,7 +21,7 @@ TEST_MEASUREMENT_DURATION = TEST_MEASUREMENT_END_TIME - TEST_MEASUREMENT_START_T
 TEST_MEASUREMENT_DURATION_S = TEST_MEASUREMENT_DURATION / 1_000_000
 TEST_MEASUREMENT_DURATION_H = TEST_MEASUREMENT_DURATION_S/60/60
 
-def insert_run(*, uri='test-uri', branch='test-branch', filename='test-filename', user_id=1, machine_id=1, measurement_config='{}'):
+def insert_run(*, uri='test-uri', branch='test-branch', filename='test-filename', user_id=1, machine_id=1):
     # spoof time from the beginning of UNIX time until now.
     phases = [
         {"start": TEST_MEASUREMENT_START_TIME-8, "name": "[BASELINE]", "end": TEST_MEASUREMENT_START_TIME-7},
@@ -34,10 +34,10 @@ def insert_run(*, uri='test-uri', branch='test-branch', filename='test-filename'
     ]
 
     return DB().fetch_one('''
-        INSERT INTO runs (uri, branch, filename, phases, user_id, machine_id, measurement_config)
+        INSERT INTO runs (uri, branch, filename, phases, user_id, machine_id)
         VALUES
-        (%s, %s, %s, %s, %s, %s, %s) RETURNING id;
-    ''', params=(uri, branch, filename, json.dumps(phases), user_id, machine_id, measurement_config))[0]
+        (%s, %s, %s, %s, %s, %s) RETURNING id;
+    ''', params=(uri, branch, filename, json.dumps(phases), user_id, machine_id))[0]
 
 def import_single_cpu_energy_measurement(run_id):
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -164,7 +164,7 @@ def import_demo_data():
     config = GlobalConfig().config
     pg_port = config['postgresql']['port']
     pg_dbname = config['postgresql']['dbname']
-    subprocess.run(
+    ps = subprocess.run(
         f"docker exec -i --user postgres test-green-coding-postgres-container psql -d{pg_dbname} -p{pg_port} < {CURRENT_DIR}/../data/demo_data.sql",
         check=True,
         shell=True,
@@ -173,11 +173,15 @@ def import_demo_data():
         encoding='UTF-8'
     )
 
+    if ps.stderr != '':
+        reset_db()
+        raise RuntimeError('Import of Demo data into DB failed', ps.stderr)
+
 def import_demo_data_ee():
     config = GlobalConfig().config
     pg_port = config['postgresql']['port']
     pg_dbname = config['postgresql']['dbname']
-    subprocess.run(
+    ps = subprocess.run(
         f"docker exec -i --user postgres test-green-coding-postgres-container psql -d{pg_dbname} -p{pg_port} < {CURRENT_DIR}/../ee/data/demo_data_ee.sql",
         check=True,
         shell=True,
@@ -186,6 +190,9 @@ def import_demo_data_ee():
         encoding='UTF-8'
     )
 
+    if ps.stderr != '':
+        reset_db()
+        raise RuntimeError('Import of Demo data into DB failed', ps.stderr)
 
 def assertion_info(expected, actual):
     return f"Expected: {expected}, Actual: {actual}"

--- a/tools/calibrate.py
+++ b/tools/calibrate.py
@@ -91,7 +91,7 @@ def load_metric_providers(mp, pt_providers, provider_interval_override=None):
         logging.info(f"Importing {class_name} from {module_path}")
 
         if provider_interval_override:
-            conf['resolution'] = provider_interval_override
+            conf['sampling_rate'] = provider_interval_override
 
 
         module = importlib.import_module(module_path)

--- a/tools/import_measurements.py
+++ b/tools/import_measurements.py
@@ -23,7 +23,7 @@ def import_metric_provider(metric_provider):
 
     module = importlib.import_module(module_path)
 
-    stub_config = { 'resolution' : 99, 'skip_check': True}
+    stub_config = { 'sampling_rate' : 99, 'skip_check': True}
     obj = getattr(module, class_name)(**stub_config)
 
     return obj


### PR DESCRIPTION
- renames resolution to sampling_rate to be more specific
  + we use resolution now only for resolution underflows when talking about the value. not the timing
- stores configured sampling_rate in DB
- removes the hack from phase_stats so that we can more easily get to the configured sampling rate
  + needed for https://github.com/green-coding-solutions/green-metrics-tool/pull/1189 

<!-- greptile_comment -->

## Greptile Summary

This PR renames 'resolution' to 'sampling_rate' across the codebase and adds storage of configured sampling rates in the database for better clarity and maintainability.

- Added `sampling_rate_configured` column to `measurement_metrics` table in `docker/structure.sql` with proper indexing
- Updated `lib/metric_importer.py` to store configured sampling rates but needs fix for DataFrame filter conditions
- Renamed `resolution` parameter to `sampling_rate` consistently across all metric providers and configuration files
- Removed resolution lookup hack from `lib/phase_stats.py` by using stored sampling rates directly
- Added new test cases in `test_config_opts.py` to validate phase padding functionality



<!-- /greptile_comment -->