### PR TITLE
Checking outside symlinks when cloning from URL

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -655,6 +655,7 @@ class ScenarioRunner:
 
                 docker_build_command = ['docker', 'run', '--rm',
                     '-v', '/workspace',
+                    # if we ever decide here to copy and not link in read-only we must NOT copy resolved symlinks, as they can be malicious
                     '-v', f"{self._repo_folder}:/tmp/repo:ro", # this is the folder where the usage_scenario is!
                     '-v', f"{temp_dir}:/output",
                     'gcr.io/kaniko-project/executor:latest',
@@ -854,8 +855,10 @@ class ScenarioRunner:
 
             docker_run_string.append('-v')
             if 'folder-destination' in service:
+                 # if we ever decide here to copy and not link in read-only we must NOT copy resolved symlinks, as they can be malicious
                 docker_run_string.append(f"{self._repo_folder}:{service['folder-destination']}:ro")
             else:
+                 # if we ever decide here to copy and not link in read-only we must NOT copy resolved symlinks, as they can be malicious
                 docker_run_string.append(f"{self._repo_folder}:/tmp/repo:ro")
 
             if self.__docker_params:

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -273,6 +273,8 @@ class ScenarioRunner:
                     encoding='UTF-8'
                 )  # always name target-dir repo according to spec
 
+            if problematic_symlink := utils.find_outside_symlinks(self._repo_folder):
+                raise RuntimeError(f"Repository contained outside symlink: {problematic_symlink}\nGMT cannot handle this in URL or Cluster mode due to security concerns. Please change or remove the symlink or run GMT locally.")
         else:
             if self._branch:
                 # we never want to checkout a local directory to a different branch as this might also be the GMT directory itself and might confuse the tool

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -12,6 +12,23 @@ from lib.db import DB
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
+def is_outside_symlink(base_dir, symlink_path):
+    try:
+        target = os.readlink(symlink_path)
+        abs_target = os.path.abspath(os.path.join(os.path.dirname(symlink_path), target))
+        return not abs_target.startswith(os.path.abspath(base_dir)), abs_target
+    except OSError:
+        return False, None  # Not a symlink
+
+def find_outside_symlinks(base_dir):
+    for root, dirs, files in os.walk(base_dir):
+        for name in dirs + files:
+            full_path = os.path.join(root, name)
+            is_outside, target = is_outside_symlink(base_dir, full_path)
+            if is_outside:
+                return f"{full_path} → {target}"
+    return None
+
 def remove_git_suffix(url):
     if url.endswith('.git'):
         return url[:-4]

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -14,7 +14,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def is_outside_symlink(base_dir, symlink_path):
     try:
-        abs_target = os.path.realpath(os.path.join(os.path.dirname(symlink_path), symlink_path))
+        abs_target = os.path.realpath(symlink_path)
         return not abs_target.startswith(os.path.realpath(base_dir)), abs_target
     except OSError:
         return False, None  # Not a symlink

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -14,9 +14,8 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def is_outside_symlink(base_dir, symlink_path):
     try:
-        target = os.readlink(symlink_path)
-        abs_target = os.path.abspath(os.path.join(os.path.dirname(symlink_path), target))
-        return not abs_target.startswith(os.path.abspath(base_dir)), abs_target
+        abs_target = os.path.realpath(os.path.join(os.path.dirname(symlink_path), symlink_path))
+        return not abs_target.startswith(os.path.realpath(base_dir)), abs_target
     except OSError:
         return False, None  # Not a symlink
 

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -1053,3 +1053,14 @@ def test_restart_no_error():
 
     with Tests.RunUntilManager(runner) as context:
         context.run_until('setup_services')
+
+def test_outside_symlink_not_allowed():
+    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', filename='usage_scenario,yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+
+    with pytest.raises(RuntimeError) as exc:
+
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+
+    assert 'Repository contained outside symlink' in str(exc)
+    assert '/etc/passwd' in str(exc)

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -1054,13 +1054,44 @@ def test_restart_no_error():
     with Tests.RunUntilManager(runner) as context:
         context.run_until('setup_services')
 
+
 def test_outside_symlink_not_allowed():
     runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', filename='usage_scenario.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
 
     with pytest.raises(RuntimeError) as exc:
 
         with Tests.RunUntilManager(runner) as context:
-            context.run_until('setup_services')
+            context.run_until('import_metric_providers')
 
     assert 'Repository contained outside symlink' in str(exc)
-    assert '/etc/passwd' in str(exc)
+    assert '/passwd' in str(exc)
+
+
+def test_outside_symlink_not_allowed_deep():
+    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', branch="deep", filename='usage_scenario.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+
+    with pytest.raises(RuntimeError) as exc:
+
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('import_metric_providers')
+
+    assert 'Repository contained outside symlink' in str(exc)
+    assert '/passwd' in str(exc)
+
+def test_outside_symlink_not_allowed_missing_outside():
+    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', branch="missing-outside", filename='usage_scenario.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+
+    with pytest.raises(RuntimeError) as exc:
+
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('import_metric_providers')
+
+    assert 'Repository contained outside symlink' in str(exc)
+    assert '/h4huhguihui3ghguirue' in str(exc)
+
+# plain symlinks, even if missing, as long as they are inside the repository we want to allow at the moment
+def test_outside_symlink_not_allowed_missing_inside():
+    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', branch="missing-inside", filename='usage_scenario.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+
+    with Tests.RunUntilManager(runner) as context:
+        context.run_until('import_metric_providers')

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -1055,7 +1055,7 @@ def test_restart_no_error():
         context.run_until('setup_services')
 
 def test_outside_symlink_not_allowed():
-    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', filename='usage_scenario,yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', filename='usage_scenario.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
 
     with pytest.raises(RuntimeError) as exc:
 

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -1068,7 +1068,7 @@ def test_outside_symlink_not_allowed():
 
 
 def test_outside_symlink_not_allowed_deep():
-    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', branch="deep", filename='usage_scenario.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
+    runner = ScenarioRunner(uri='https://github.com/green-coding-solutions/symlink-repo', uri_type='URL', branch="deep", filename='usage_scenario_deep.yml', skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True)
 
     with pytest.raises(RuntimeError) as exc:
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added security measures to prevent directory traversal attacks by checking for symlinks that point outside repository directories when cloning from URLs in the Green Metrics Tool.

- Added `is_outside_symlink()` and `find_outside_symlinks()` in `lib/utils.py` to detect potentially malicious symlinks using `os.path.realpath()`
- Integrated symlink security checks in `lib/scenario_runner.py` to prevent unauthorized file access when cloning repositories
- Added test cases in `tests/test_usage_scenario.py` to validate symlink security features
- Consider improving error handling for permission issues and access errors in symlink detection



<!-- /greptile_comment -->