### PR TITLE
Proper detached feature log parsing and process handling for setup-commands

### DIFF
--- a/templates/website/usage_scenario.yml
+++ b/templates/website/usage_scenario.yml
@@ -55,5 +55,7 @@ flow:
         log-stderr: true
       - type: console
         command: grep 'TCP_MEM_HIT/' /apps/squid/var/logs/access.log #validate that TCP_MEM_HITs present
-      - type: console
-        command: awk '/TCP_MISS\// { found=1 } END { exit found }' /apps/squid/var/logs/access.log # ensure no TCP_MISSes present
+        # This is sadly too strict. Pages fingerprint you all the time and a new request might get a new fingerprint that will not be cached
+        # But if you have a page that does not fingerprint we recommend having this uncommented, as it will warn you if resources bypass the cache pre-loading
+#      - type: console
+#        command: awk '/TCP_MISS\// { found=1 } END { exit found }' /apps/squid/var/logs/access.log # ensure no TCP_MISSes present

--- a/tests/data/usage_scenarios/setup_commands_multiple_noop.yml
+++ b/tests/data/usage_scenarios/setup_commands_multiple_noop.yml
@@ -1,6 +1,7 @@
 ---
-name: Test Stress
+name: Test noop
 author: Dan Mateas
+description: test
 description: test
 
 services:
@@ -10,13 +11,14 @@ services:
     build:
       context: ../stress-application
     setup-commands:
+      - command: echo hello world
       - command: ps -a
-        shell: sh
+      - command: echo goodbye world
 
 flow:
-  - name: Stress
+  - name: noop
     container: test-container
     commands:
       - type: console
-        command: stress-ng -c 1 -t 1 -q
-        note: Starting Stress
+        command: echo 1
+        note: Starting noop

--- a/tests/data/usage_scenarios/setup_commands_noop.yml
+++ b/tests/data/usage_scenarios/setup_commands_noop.yml
@@ -1,7 +1,6 @@
 ---
-name: Test Stress
+name: Test Noop
 author: Dan Mateas
-description: test
 description: test
 
 services:
@@ -11,14 +10,13 @@ services:
     build:
       context: ../stress-application
     setup-commands:
-      - command: echo hello world
       - command: ps -a
-      - command: echo goodbye world
+        shell: sh
 
 flow:
-  - name: Stress
+  - name: Noop
     container: test-container
     commands:
       - type: console
-        command: stress-ng -c 1 -t 1 -q
-        note: Starting Stress
+        command: echo 1
+        note: Starting Noop

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -203,11 +203,10 @@ def test_skip_unsupported_compose():
 def test_setup_commands_one_command():
     out = io.StringIO()
     err = io.StringIO()
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/setup_commands_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/setup_commands_noop.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
 
     with redirect_stdout(out), redirect_stderr(err):
-        with Tests.RunUntilManager(runner) as context:
-            context.run_until('setup_services')
+        runner.run()
     assert 'Running command:  docker exec test-container sh -c ps -a' in out.getvalue(), \
         Tests.assertion_info('stdout message: Running command: docker exec  ps -a', out.getvalue())
     assert '1 root      0:00 /bin/sh' in out.getvalue(), \
@@ -216,27 +215,14 @@ def test_setup_commands_one_command():
 def test_setup_commands_multiple_commands():
     out = io.StringIO()
     err = io.StringIO()
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/setup_commands_multiple_stress.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/setup_commands_multiple_noop.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
 
     with redirect_stdout(out), redirect_stderr(err):
-        with Tests.RunUntilManager(runner) as context:
-            context.run_until('setup_services')
+        runner.run()
 
-    expected_pattern = re.compile(r'Running command:  docker exec test-container echo hello world.*\
-\s*Stdout: hello world.*\
-\s*Stderr:.*\
-\s*Running command:  docker exec test-container ps -a.*\
-\s*Stdout:\s+PID\s+USER\s+TIME\s+COMMAND.*\
-\s*1\s+root\s+\d:\d\d\s+/bin/sh.*\
-\s*1\d+\s+root\s+\d:\d\d\s+ps -a.*\
-\s*Stderr:.*\
-\s*Running command:  docker exec test-container echo goodbye world.*\
-\s*Stdout: goodbye world.*\
-', re.MULTILINE)
-
-    assert re.search(expected_pattern, out.getvalue()), \
-        Tests.assertion_info('container stdout showing 3 commands run in sequence',\
-         'different messages in container stdout')
+    assert 'Running command:  docker exec test-container ps -a' in out.getvalue()
+    assert 'hello world' in out.getvalue()
+    assert 'goodbye world' in out.getvalue()
 
 def assert_order(text, first, second):
     index1 = text.find(first)


### PR DESCRIPTION
`setup-commands` had not detach feature before.

it was recently introduced and this new PR handles process return code checking and log parsing properly

<!-- greptile_comment -->

## Greptile Summary

Enhanced setup command handling in the Green Metrics Tool by adding proper detached process support, log parsing, and return code validation for `setup-commands` in containers.

- Added process tracking for detached setup commands in `lib/scenario_runner.py` via `__ps_to_kill` list for cleanup
- Implemented process output handling through `__ps_to_read` list for better logging
- Added validation of command execution with `check_process_returncodes` after `setup_services`
- Added support for command options: `read-notes-stdout`, `ignore-errors`, and `read-sci-stdout`



<!-- /greptile_comment -->