### PR TITLE
Made network carbon data intensity dynamic

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -227,6 +227,10 @@ sci:
     # The number worldwide for 2024 is 473
     # The number 334 that comes as default is for Germany from 2024 and comes from https://app.electricitymaps.com/zone/DE/all/yearly
     I: 334
+    # N is not technically part of the SCI, but we keep the value here for better clustering.
+    # N is the network energy intensity per transferred data. It transforms values like GB to kWh
+    # See https://www.green-coding.io/co2-formulas/ for details
+    N: 0.001875
 
 #optimization:
 #  ignore:

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -265,7 +265,7 @@ def build_and_store_phase_stats(run_id, sci=None):
             # build the network energy
             # network via formula: https://www.green-coding.io/co2-formulas/
             # pylint: disable=invalid-name
-            network_io_in_kWh = Decimal(sum(network_bytes_total)) / 1_000_000_000 * Decimal(0.002651650429449553)
+            network_io_in_kWh = Decimal(sum(network_bytes_total)) / 1_000_000_000 * Decimal(config['sci']['N'])
             network_io_in_uJ = network_io_in_kWh * 3_600_000_000_000
             csv_buffer.write(generate_csv_line(run_id, 'network_energy_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_in_uJ, 'TOTAL', None, None, None, None, None, 'uJ'))
             # co2 calculations

--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -104,6 +104,7 @@ sci:
   RS: 1
   TE: 181000
   I: 436
+  N: 0.001875
 
 optimization:
   ignore:


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Made network energy intensity configurable by introducing a new parameter 'N' in the SCI configuration section, replacing a hardcoded value in phase_stats.py for network carbon data calculations.

- Added `N: 0.001875` parameter in `config.yml.example` for network energy intensity (kWh/GB)
- Replaced hardcoded value `0.002651650429449553` with configurable `config['sci']['N']` in `lib/phase_stats.py`
- Added documentation link to carbon formulas in configuration file
- Placed network intensity parameter in SCI section for better configuration clustering



<!-- /greptile_comment -->