### PR TITLE
Jobs can now be cancelled via API and Dashboard

### DIFF
--- a/api/object_specifications.py
+++ b/api/object_specifications.py
@@ -1,7 +1,15 @@
 from pydantic import BaseModel, ConfigDict, Field, field_validator, constr
-from typing import Optional, Dict
+from typing import Optional, Dict, Literal
 
 from fastapi.exceptions import RequestValidationError
+
+### Jobs
+
+class JobChange(BaseModel):
+    job_id: int
+    action: Literal['cancel']
+
+    model_config = ConfigDict(extra='forbid')
 
 ### Software Add
 

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -55,6 +55,7 @@ VALUES (
                 "/v1/insights",
                 "/v1/ci/insights",
                 "/v1/machines",
+                "/v1/job",
                 "/v2/jobs",
                 "/v1/notes/{run_id}",
                 "/v1/network/{run_id}",

--- a/frontend/js/status.js
+++ b/frontend/js/status.js
@@ -123,10 +123,14 @@ $(document).ready(function () {
                 } },
             ],
             deferRender: true,
-            order: [[7, 'desc']] // API also orders, but we need to indicate order for the user
+            order: [[7, 'desc']], // API also orders, but we need to indicate order for the user
+            drawCallback: function(settings) {
+                document.querySelectorAll('.cancel-job').forEach(el => {
+                    el.removeEventListener('click', cancelJob)
+                    el.addEventListener('click', cancelJob)
+                })
+            },
         });
-
-        document.querySelectorAll('.cancel-job').forEach(el => el.addEventListener('click', cancelJob))
 
     })();
 });

--- a/lib/db.py
+++ b/lib/db.py
@@ -68,7 +68,7 @@ class DB:
             elif return_type == 'all':
                 ret = cur.fetchall()
             else:
-                ret = True
+                ret = cur.statusmessage
 
         return ret
 

--- a/migrations/2025_05_29_job_cancel.sql
+++ b/migrations/2025_05_29_job_cancel.sql
@@ -1,0 +1,11 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{api,routes}',
+    (
+        COALESCE(capabilities->'api'->'routes', '[]'::jsonb) ||
+        '["/v1/job"]'::jsonb
+    ),
+    true
+)
+WHERE id = 1;


### PR DESCRIPTION
<img width="580" alt="Screenshot 2025-05-29 at 8 10 16 AM" src="https://github.com/user-attachments/assets/1d5f743d-09fc-4327-8b4d-9874ece75d00" />


<!-- greptile_comment -->

## Greptile Summary

This PR adds job cancellation functionality to the Green Metrics Tool, allowing users to cancel jobs in WAITING state via both API and dashboard UI.

- Added new `JobChange` Pydantic model in `api/object_specifications.py` with strict validation for job cancellation requests
- Implemented PUT endpoint `/v1/job` in `api/scenario_runner.py` with proper state and permission checks
- Modified `lib/db.py` to return `statusmessage` instead of hardcoded `True` for better operation verification
- Added frontend cancellation UI in `frontend/js/status.js` with cancel buttons and status updates
- Updated default user capabilities in `docker/structure.sql` to include the new `/v1/job` route



<!-- /greptile_comment -->