### PR TITLE
Notes sent by Eco Ci now shown in frontend

### DIFF
--- a/api/eco_ci.py
+++ b/api/eco_ci.py
@@ -168,7 +168,7 @@ async def get_ci_measurements(repo: str, branch: str, workflow: str, start_date:
                 AND latest_workflow.workflow_id = ci_measurements.workflow_id
                 ORDER BY latest_workflow.created_at DESC
                 LIMIT 1) AS workflow_name,
-               lat, lon, city, carbon_intensity_g, carbon_ug
+               lat, lon, city, carbon_intensity_g, carbon_ug, note
         FROM ci_measurements
         WHERE
             (TRUE = %s OR user_id = ANY(%s::int[]))

--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -206,6 +206,7 @@
                     <th>Location</th>
                     <th>Grid Intensity</th>
                     <th>gCO2eq of run</th>
+                    <th>Note</th>
                 </tr>
             </thead>
             <tbody id="ci-table"></tbody>

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -185,7 +185,7 @@ const displayRunDetailsTable = (measurements, repo) => {
     measurements.forEach(measurement => {
         const li_node = document.createElement("tr");
 
-        let [energy_uj, run_id, created_at, label, cpu, commit_hash, duration_us, source, cpu_util, workflow_name, lat, lon, city, carbon_intensity_g, carbon_ug] = measurement;
+        let [energy_uj, run_id, created_at, label, cpu, commit_hash, duration_us, source, cpu_util, workflow_name, lat, lon, city, carbon_intensity_g, carbon_ug, note] = measurement;
 
         const short_hash = commit_hash.substring(0, 7);
         const tooltip = `title="${commit_hash}"`;
@@ -220,6 +220,8 @@ const displayRunDetailsTable = (measurements, repo) => {
                             <td class="td-index">${city_string}</td>
                             <td class="td-index">${escapeString(carbon_intensity_g)} gCO2/kWh</td>
                             <td class="td-index" title="${carbon_ug/1000000}">${escapeString(numberFormatterLong.format(carbon_ug/1000000))} gCO2e</td>
+                            <td class="td-index">${ (note == null) ? '' : `<span class="ui icon" data-position="top right" data-inverted="" data-tooltip="${escapeString(note)}"><i class="ui question circle icon fluid"></i></span>` }</td>
+
                             `;
         document.querySelector("#ci-table").appendChild(li_node);
     });

--- a/frontend/request.html
+++ b/frontend/request.html
@@ -55,7 +55,7 @@
                     <li>Only public repositories are supported</li>
                     <li>Soft-Limit of 5 runs month, 30 Minutes per measurement, measurement minutes, data retention ...</li>
                     <li>For a premium account with no restrictions please see <a style="text-decoration: underline; font-weight: bold;" href="https://www.green-coding.io/products/green-metrics-tool">our comparison table</a></li>
-                    <li>If you already have a premium plan please enter your authentication token on the <a style="text-decoration: underline; font-weight: bold;" href="/settings">settings page</a></li>
+                    <li>If you already have a premium plan please enter your token on the <a style="text-decoration: underline; font-weight: bold;" href="/authentication.html">Authentication page</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
<img width="970" alt="Screenshot 2025-06-06 at 9 32 47 AM" src="https://github.com/user-attachments/assets/0e71128b-7472-4bfa-ab8d-d58f31e8d3ba" />


<!-- greptile_comment -->

## Greptile Summary

Enhances the Eco CI interface by adding support for displaying measurement notes in the frontend, completing the full cycle of note handling from API to UI.

- Added note field exposure in `/api/eco_ci.py` GET endpoint to return measurement notes
- Implemented note display in `/frontend/js/ci.js` using tooltips for better UX
- Added 'Note' column to CI run details table in `/frontend/ci.html`
- Updated authentication flow in `/frontend/request.html` to use dedicated authentication page



<!-- /greptile_comment -->