### PR TITLE
Switching to CLOCK_BOOTTIME to account for suspend states

### DIFF
--- a/lib/c/gmt-lib.c
+++ b/lib/c/gmt-lib.c
@@ -39,8 +39,8 @@ void get_time_offset(struct timespec *offset) {
         perror("clock_gettime CLOCK_REALTIME");
         exit(EXIT_FAILURE);
     }
-    if (clock_gettime(CLOCK_MONOTONIC_RAW, &monotonic) != 0) {
-        perror("clock_gettime CLOCK_MONOTONIC_RAW");
+    if (clock_gettime(CLOCK_BOOTTIME, &monotonic) != 0) {
+        perror("clock_gettime CLOCK_BOOTTIME");
         exit(EXIT_FAILURE);
     }
     offset->tv_sec = realtime.tv_sec - monotonic.tv_sec;
@@ -53,8 +53,8 @@ void get_time_offset(struct timespec *offset) {
 
 void get_adjusted_time(struct timeval *adjusted, struct timespec *offset) {
     struct timespec now_monotonic;
-    if (clock_gettime(CLOCK_MONOTONIC_RAW, &now_monotonic) != 0) {
-        perror("clock_gettime CLOCK_MONOTONIC_RAW");
+    if (clock_gettime(CLOCK_BOOTTIME, &now_monotonic) != 0) {
+        perror("clock_gettime CLOCK_BOOTTIME");
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
This PR switches the used Clock in GMT metric providers to`CLOCK_BOOTTIME` to mitigate following issues:

- if the system goes to suspend the clock times returned by the metric providers currently using `CLOCK_MONOTONIC_RAW` with just an initial calculated offset will get skewed. Since the output is a *Unix Timestamp* this is considered unintended behaviour and we want a proper *Unix Timestamp* as the output.
- Metric Providers that use easier syscalls from for instance the CLI world typically access 'CLOCK_REALTIME' by default (for instance `date`). Providers like `PsuEnergyAcIpmiMachineProvider` will thus be off from the `CLOCK_MONOTONIC_RAW` and we need to standardize  this to be the actual time for both.

The current implementation changes the clock but leads to mal-accounting in providers that account for power instead of energy as seen in screenshot #1. The time gap is understood as the system being running on the same power for the pause that has occured.

We need to decide if that is what we want to allow or not. Do cases exists where this is valid power accounting?
In the case of suspend it is definitely wrong. Since no power values are know to us and the system is in very low power mode accounting for a gap here seems like the best option.
<img width="1176" alt="Screenshot 2025-06-18 at 7 55 39 AM" src="https://github.com/user-attachments/assets/b2b4a1ea-8f4e-4699-8533-201a4a8af127" />

To complete the analysis: All other metric reporter types account the gap correctly as plain missing data when it comes to raw data. However average calculations all flake, as the time window that is looked at has a huge gap.

Getting from energy to power becomes thus impossible without somehow removing the gap from the data.
Question is: Do we want to analyze the resulting measurement data and "classify" gaps ... which can be error prone.
Or just render the measurement as failed if a suspend occurs? And we just keep the behaviour of going into suspend as a non-breaking option for debug purposes?

Addon: Example screenshot of detected sampling rate which is heavily off and we could use it for detecting a suspend.
<img width="195" alt="Screenshot 2025-06-18 at 8 10 41 AM" src="https://github.com/user-attachments/assets/98bc7781-8fed-484a-9cdd-7de491c6b894" />


@ribalba ?


