### PR TITLE
Fix error handling for clipboard API is unavailable

### DIFF
--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -199,14 +199,20 @@ const showNotification = (message_title, message_text, type='warning') => {
     return;
 }
 
-const copyToClipboard = (e) => {
+const copyToClipboard = async (e) => {
   e.preventDefault();
-  if (navigator && navigator.clipboard && navigator.clipboard.writeText)
-    navigator.clipboard.writeText(e.currentTarget.previousElementSibling.innerHTML)
-    return false
-
-  alert('Copying to clipboard on local is not working due to browser security models')
-  return Promise.reject('The Clipboard API is not available.');
+  
+  if (!navigator?.clipboard?.writeText) {
+    alert('Clipboard API not supported');
+    return;
+  }
+  
+  try {
+    const htmlContent = e.currentTarget.previousElementSibling.innerHTML;
+    await navigator.clipboard.writeText(htmlContent);
+  } catch (err) {
+    alert('Failed to copy HTML content to clipboard!');
+  }
 };
 
 const dateToYMD = (date, short=false, no_break=false) => {


### PR DESCRIPTION
The `copyToClipboard` method had several issues:
- the alert command was unreachable, because it came after the return statement (therefore the warning "unreachable code after return statement" was displayed in the dev console)
- return value is not required, because the event listeners don't use return values for event handling
- the error message was wrong: the clipboard API is actually available locally, `localhost:9142` works, but not `http://metrics.green-coding.internal:9142`
- the clipboard API is async