### PR TITLE
Schema checker refactor

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1012,7 +1012,7 @@ class ScenarioRunner:
                 for network in service['networks']:
                     docker_run_string.append('--net')
                     docker_run_string.append(network)
-                    if service['networks'][network]:
+                    if isinstance(service['networks'], dict) and service['networks'][network]:
                         if service['networks'][network].get('aliases', None):
                             for alias in service['networks'][network]['aliases']:
                                 docker_run_string.append('--network-alias')

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -955,12 +955,12 @@ class ScenarioRunner:
                         raise RuntimeError('Environment variable needs to be a string with = or dict and non-empty. We do not allow the feature of forwarding variables from the host OS!')
 
                     # Check the key of the environment var
-                    if not self._allow_unsafe and re.fullmatch(r'[A-Z_]+[A-Z0-9_]*', env_key) is None:
+                    if not self._allow_unsafe and re.fullmatch(r'[A-Za-z_]+[A-Za-z0-9_]*', env_key) is None:
                         if self._skip_unsafe:
-                            warn_message= arrows(f"Found environment var key with wrong format. Only ^[A-Z_]+[A-Z0-9_]*$ allowed: {env_key} - Skipping")
+                            warn_message= arrows(f"Found environment var key with wrong format. Only ^[A-Za-z_]+[A-Za-z0-9_]*$ allowed: {env_key} - Skipping")
                             print(TerminalColors.WARNING, warn_message, TerminalColors.ENDC)
                             continue
-                        env_var_check_errors.append(f"- key '{env_key}' has wrong format. Only ^[A-Z_]+[A-Z0-9_]*$ is allowed - Maybe consider using --allow-unsafe or --skip-unsafe")
+                        env_var_check_errors.append(f"- key '{env_key}' has wrong format. Only ^[A-Za-z_]+[A-Za-z0-9_]*$ is allowed - Maybe consider using --allow-unsafe or --skip-unsafe")
 
                     # Check the value of the environment var
                     # We only forbid long values (>1024), every character is allowed.

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -92,11 +92,15 @@ class SchemaChecker():
                 'R_d': And(str, Use(self.not_empty)),
             },
 
-            Optional("networks"): Or(list, dict),
-            Optional("volumes"): Or(list, dict), # volumes in the root level are fine. They have no implication alone and will be checked in the service then if listed
-
+            Optional("networks"): Or(
+                dict,
+                [And(str, Use(self.contains_no_invalid_chars))],
+            ),
+            Optional("volumes"): Or(
+                dict,
+                And(str, Use(self.contains_no_invalid_chars))
+            ),
             Optional("services"): {
-
                 Use(self.contains_no_invalid_chars): {
                     Optional("restart"): str, # is part of compose. we ignore it as GMT has own orchestration
                     Optional("expose"): [str, int], # is part of compose. we ignore it as it is non functionaly anyway

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -10,9 +10,6 @@ class SchemaChecker():
     def __init__(self, validate_compose_flag):
         self._validate_compose_flag = validate_compose_flag
 
-    def single_or_list(self, value):
-        return Or(value, [value])
-
     def is_valid_string(self, value):
         valid_chars = set(string.ascii_letters + string.digits + '_' + '-')
         if not set(value).issubset(valid_chars):
@@ -108,7 +105,7 @@ class SchemaChecker():
                     Optional("image"): And(str, Use(self.not_empty)),
                     Optional("build"): Or(Or({And(str, Use(self.not_empty)):And(str, Use(self.not_empty))},list),And(str, Use(self.not_empty))),
                     Optional("networks"): Or(
-                        self.single_or_list(Use(self.contains_no_invalid_chars)),
+                        [And(str, Use(self.contains_no_invalid_chars))],
                         {
                             Use(self.contains_no_invalid_chars):
                                 Or(
@@ -117,10 +114,22 @@ class SchemaChecker():
                                 )
                         }
                     ),
-                    Optional("environment"): self.single_or_list(Or(dict,And(str, Use(self.not_empty)))),
-                    Optional("labels"): self.single_or_list(Or(dict,And(str, Use(self.not_empty)))),
-                    Optional("ports"): self.single_or_list(Or(And(str, Use(self.not_empty)), int)),
-                    Optional('depends_on'): Or([And(str, Use(self.not_empty))],dict),
+                    Optional("environment"): Or(
+                        dict,
+                        [And(str, Use(self.not_empty))]
+                    ),
+                    Optional("labels"): Or(
+                        dict,
+                        [And(str, Use(self.not_empty))]
+                    ),
+                    Optional("ports"): [Or( # we do not support the long form as mappings
+                        int,
+                        And(str, Use(self.not_empty))
+                    )],
+                    Optional('depends_on'): Or(
+                        dict,
+                        [And(str, Use(self.not_empty))]
+                    ),
                     Optional('deploy'):Or({
                         Optional('resources'): {
                             Optional('limits'): {
@@ -147,10 +156,10 @@ class SchemaChecker():
                         Optional("detach"): bool,
                         Optional("shell"): And(str, Use(self.not_empty)),
                     }],
-                    Optional("volumes"): self.single_or_list(str),
+                    Optional("volumes"): [And(str, Use(self.not_empty))],
                     Optional("folder-destination"):And(str, Use(self.not_empty)),
-                    Optional("entrypoint"): Or(str, [str]),
-                    Optional("command"): Or(And(str, Use(self.not_empty)), [str]),
+                    Optional("entrypoint"): Or(str, [str]), # can be empty!
+                    Optional("command"): Or(And(str, Use(self.not_empty)), [And(str, Use(self.not_empty))]),
                     Optional("log-stdout"): bool,
                     Optional("log-stderr"): bool,
                     Optional("read-notes-stdout"): bool,


### PR DESCRIPTION
- The access to networks was always assuming a dict. This is not correct
- ENV vars can now be also small letters
- Some refactor and removing "str" type for some keys where we used the legacy "single_or_list" function