### PR TITLE
204 special handling

### DIFF
--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -33,7 +33,7 @@
     <gmt-menu></gmt-menu>
     <div class="main ui container" id="main">
         <h1 class="ui header float left"><a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon opened"></i></a> CI Run Info</h1>
-        <div class="ui full-width-card card">
+        <div class="ui full-width-card card container-no-data">
             <div class="content">
                 <div class="header"><a class="ui red ribbon label">
                     <h3>General Info</h3>
@@ -83,7 +83,19 @@
                 </div>
             </div>
         </div><!-- end ui full-width-card card -->
-        <div class="ui icon message blue">
+
+        <div id="message-no-data" class="ui icon message red container-no-data">
+            <i class="info circle icon"></i>
+            <div class="content">
+                <div class="header">
+                    No data for time frame
+                </div>
+                <p>In the selected time frame we have not seen any data :/</p>
+                <p>Try selecting a longer period reaching deeper into the past to see data for this repo.</p>
+            </div>
+        </div>
+
+        <div class="ui icon message blue container-no-data">
             <i class="info circle icon"></i>
             <div class="content">
                 <p> Here you can see the energy measurements of the associated CI/CD pipeline. </p>
@@ -119,10 +131,9 @@
             </div>
         </div>
 
-        <div class="ui segment" id="chart-container">
+        <div id="chart-container" class="ui segment container-no-data"></div>
 
-        </div>
-        <div class = "ui segment" id="stats-container">
+        <div id="stats-container" class="ui segment container-no-data">
             <div class="header"><a class="ui teal ribbon label">
                     <h3>Pipeline stats</h3>
                 </a></div>
@@ -163,7 +174,7 @@
             </div>
         </div>
 
-       <div id="loader-question" class="ui icon info message blue">
+       <div id="loader-question" class="ui icon info message blue container-no-data">
             <i class="info circle icon"></i>
 
             <div class="content">
@@ -177,7 +188,7 @@
             <ul></ul>
         </div>
 
-        <div class="ui one cards" id="api-loader" style="display:none;">
+        <div id="api-loader" class="ui one cards" style="display:none;">
             <div class="card" style="min-height: 300px">
                 <div class="ui active dimmer">
                     <div class="ui indeterminate text loader">Building table ...</div>
@@ -185,6 +196,7 @@
                 <p></p>
             </div>
         </div>
+
         <div id="chart-container"></div>
 
 

--- a/frontend/ci.html
+++ b/frontend/ci.html
@@ -197,9 +197,6 @@
             </div>
         </div>
 
-        <div id="chart-container"></div>
-
-
         <div class="ui segment" id="run-details-table" style="display: none">
             <div class="header"><a class="ui teal ribbon label">
                     <h3 data-tooltip="The runs table shows all measurements your pipeline has made in the selected timeframe" data-position="top left">Runs Table <i class="question circle icon "></i> </h3>

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -308,10 +308,18 @@ const refreshView = async (repo, branch, workflow_id, chart_instance) => {
     let stats = null;
     try {
         [measurements, stats] = await getMeasurementsAndStats(repo, branch, workflow_id, start_date, end_date); // iterates I
+        document.querySelectorAll('.container-no-data').forEach(el => el.style.display = '')
+        document.querySelector('#message-no-data').style.display = 'none';
 
     } catch (err) {
-        showNotification('Could not get data from API', err);
-        return; // abort
+        if (err instanceof APIEmptyResponse204) {
+            document.querySelectorAll('.container-no-data').forEach(el => el.style.display = 'none')
+            document.querySelector('#message-no-data').style.display = '';
+            return
+        } else {
+            showNotification('Could not get data from API', err);
+            return; // abort
+        }
     }
 
     history.pushState(null, '', `${window.location.origin}${window.location.pathname}?repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`); // replace URL to bookmark!

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -1,5 +1,7 @@
 const GMT_MACHINES = JSON.parse(localStorage.getItem('gmt_machines')) || {}; // global variable. dynamically resolved via resolveMachinesToGlobalVariable
 
+class APIEmptyResponse204 extends Error {}
+
 // tricky to make this async as some other functions will depend on the value of the variable
 // but if it is not set yet it will populate in a later call
 const resolveMachinesToGlobalVariable = async () => {
@@ -274,7 +276,7 @@ async function makeAPICall(path, values=null, force_authentication_token=null, f
     .then(response => {
         if (response.status == 204) {
             // 204 responses use no body, so json() call would fail
-            return {success: false, err: "No data to display. API returned empty response (HTTP 204)"}
+            throw new APIEmptyResponse204('No data to display. API returned empty response (HTTP 204)')
         }
         if (response.status == 202) {
             return

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -125,9 +125,21 @@ const loadCharts = async () => {
     let phase_stats_data = null;
     try {
         phase_stats_data = (await makeAPICall(`/v1/timeline?${buildQueryParams()}`)).data
+        console.log(phase_stats_data);
+
+        document.querySelectorAll('.container-no-data').forEach(el => el.style.display = '')
+        document.querySelector('#message-no-data').style.display = 'none';
+
     } catch (err) {
-        showNotification('Could not get compare in-repo data from API', err);
-        return
+        if (err instanceof APIEmptyResponse204) {
+            document.querySelectorAll('.container-no-data').forEach(el => el.style.display = 'none')
+            document.querySelector('#message-no-data').style.display = '';
+            document.querySelector('a.item[data-tab=two]').click()
+            return
+        } else {
+            showNotification('Could not get data from API', err);
+            return; // abort
+        }
     }
 
     history.pushState(null, '', `${window.location.origin}${window.location.pathname}?${buildQueryParams()}`); // replace URL to bookmark!

--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -78,7 +78,7 @@
                         </div>
                         <div class="ui one column stackable grid">
                             <div class="column">
-                                <div class="ui yellow icon message floated right">
+                                <div class="ui yellow icon message floated right container-no-data">
                                     <i class="info circle icon"></i>
                                     <div class="content">
                                         <div class="header">
@@ -95,7 +95,7 @@
                         </div>
                     </div>
                     <div class="ui tab" data-tab="two">
-                        <div class="ui blue icon message floated right">
+                        <div class="ui blue icon message floated right container-no-data">
                             <i class="info circle icon"></i>
                             <div class="content">
                                 <div class="header">
@@ -245,9 +245,20 @@
             </div>
         </div><!-- end ui full-width-card card -->
 
+        <div id="message-no-data" class="ui icon message red container-no-data">
+            <i class="info circle icon"></i>
+            <div class="content">
+                <div class="header">
+                    No data for time frame
+                </div>
+                <p>In the selected time frame we have not seen any data :/</p>
+                <p>Try selecting a longer period reaching deeper into the past to see data for this repo.</p>
+            </div>
+        </div>
+
         <div class="ui full-width-card"></div>
 
-        <div class="ui blue icon message">
+        <div class="ui blue icon message container-no-data">
             <i class="info circle icon"></i>
             <div class="content">
                 <div class="header">
@@ -257,7 +268,7 @@
                 <p>To show details click on the bars! A new menu will appear.</p>
             </div>
         </div>
-        <div class="ui two cards" id="api-loader">
+        <div id="api-loader" class="ui two cards container-no-data">
             <div class="card" style="min-height: 300px">
                 <div class="ui active dimmer">
                     <div class="ui indeterminate text loader">Waiting for API data</div>


### PR DESCRIPTION
This PR changes the behaviour when no data is present for:
- Old Eco CI repositories / Eco CI URLs with recent dates
- Old Watchlist Items / Timeline URLs with recent dates

Before this is what would show:

<img width="1483" height="765" alt="Screenshot 2025-07-14 at 1 43 41 PM" src="https://github.com/user-attachments/assets/42c57c99-f65d-40f8-b4d1-b64097007ced" />

Which was hard for the user to understand if a terminal error has happend or what not.

Effectively the API was just returning a HTTP 204 and there might be well data with a different time frame.

Behaviour has now been moved to this:
<img width="975" height="283" alt="Screenshot 2025-07-14 at 1 40 58 PM" src="https://github.com/user-attachments/assets/62e0fcff-74af-48d1-8cb1-450a88e5e19f" />


and
<img width="1320" height="746" alt="Screenshot 2025-07-14 at 1 40 06 PM" src="https://github.com/user-attachments/assets/cc5c67ca-ae9b-44e6-b680-4b82061058cc" />


## Alternative implementation explored

We also discussed the implementation of just "showing what we have". This would be for instance the "last 30 measurements"

While this is theoretically possible I faced multiple technical challenges as well as some UX challenges:
- Code for making queries internally is re-used in multiple functions. Date was so far a **mandatory** variable. Making this optional would have been quite an implementation
- Since APIs where expected to return data ascending for a certain time frame it would have made code way more complex and harder to read if there was also an option to sort-inverse => last 30 items => sort-inverse-again. 
- We also make statistics over a defined period of time - If we change that to the last 30 items the user must be aware of what period this is now shown as the aggregate data lacks time information. You could simply take the last 30 runs and then play the period back to the front end. However, this would require a great deal of effort and would always lead to a different result for the user. Typically the view is always 30 days. You then suddenly have MORE than 30 days and so on. Yes, you can again cap the view at 30 days. But the round trips are getting more and more. The question is what do we actually want

This is the solution chosen.

@ribalba : Do you think that solves the user confusion? What would you like to add?

<!-- greptile_comment -->

## Greptile Summary

This PR improves the user experience when no data is available for a given time period in the Green Metrics Tool. Previously, when querying old Eco CI repositories or watchlist items with recent dates, users would receive an unclear HTTP 204 response with no indication of why data was missing. The changes implement a more user-friendly approach across multiple frontend files.

Key changes:
1. Added a custom `APIEmptyResponse204` error class in `main.js`
2. Implemented consistent error handling across `timeline.js`, `ci.js`, and related files
3. Added clear UI feedback with red message banners explaining why no data is shown
4. Added consistent CSS classes (`container-no-data`) for better state management

The developer also explored an alternative approach of "showing what we have" (last 30 measurements) but rejected it due to technical complexity and potential UX inconsistencies with time-based aggregations.

## Confidence score: 5/5
1. This is a safe UI improvement that doesn't affect core functionality
2. The changes are well-structured, consistent across files, and improve user experience without introducing new risks
3. Key files to review:
   - frontend/js/helpers/main.js (error handling changes)
   - frontend/timeline.html and frontend/ci.html (UI message changes)
   - frontend/js/timeline.js and frontend/js/ci.js (implementation of new error handling)

<sub>5 files reviewed, 1 comment</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=green-metrics-tool_1247)</sub>

<!-- /greptile_comment -->