### PR TITLE
Skips the git commands when dev-no-save is specified

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -283,6 +283,9 @@ class ScenarioRunner:
             path = os.path.realpath(self._uri)
             self.__working_folder = self._repo_folder = path
 
+        if self._dev_no_save:
+            return
+
         self._branch = subprocess.check_output(['git', 'branch', '--show-current'], cwd=self._repo_folder, encoding='UTF-8').strip()
 
         git_repo_root = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], cwd=self._repo_folder, encoding='UTF-8').strip()


### PR DESCRIPTION
I often create a `usage_scenario` in /tmp or somewhere to test something. Currently it is quite annoying that I need a git repo to run the tool. When I use `--dev-no-save` I don't technically need this data as we are not saving anything so we can skip it and we can enable "test" runs without git