### PR TITLE
Fix test execution of runner.py

### DIFF
--- a/tests/test-config-extra-network-and-duplicate-psu-providers.yml
+++ b/tests/test-config-extra-network-and-duplicate-psu-providers.yml
@@ -88,7 +88,6 @@ measurement:
         CPUChips: 1
         TDP: 60
       psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
-        sampling_rate: 99
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -90,7 +90,6 @@ measurement:
         sampling_rate: 99
     common:
       psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
-        sampling_rate: 99
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -232,7 +232,7 @@ def reset_db():
     pg_dbname = config['postgresql']['dbname']
     redis_port = config['redis']['port']
     subprocess.run(
-        ['docker', 'exec', '--user', 'postgres', 'test-green-coding-postgres-container', 'bash', '-c', f'psql -d {pg_dbname} --port {pg_port} -c \'DROP schema "public" CASCADE\' '],
+        ['docker', 'exec', '--user', 'postgres', 'test-green-coding-postgres-container', 'bash', '-c', f'psql -d {pg_dbname} --port {pg_port} -c \'DROP SCHEMA IF EXISTS "public" CASCADE\' '],
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -85,7 +85,7 @@ def test_reporters_still_running():
 
 def test_template_website():
     ps = subprocess.run(
-        ['bash', '../run-template.sh', 'website', 'https://www.google.de', '--quick', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/test-config.yml"],
+        ['bash', os.path.normpath(f"{GMT_DIR}/run-template.sh"), 'website', 'https://www.google.de', '--quick', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/test-config.yml"],
         check=True,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
I had issues running `tests/test_runner.py::test_template_website`. This PR fixes some issues related the test configuration.

Sometimes the test still fails because the squid container does not become healthy. Potential cause: the healthcheck makes requests to the external website http://example.com
