### PR TITLE
More user measurement configurations

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -77,12 +77,6 @@ machine:
   base_temperature_feature: False
 
 measurement:
-  system_check_threshold: 3 # Can be 1=INFO, 2=WARN or 3=ERROR
-  pre_test_sleep: 5
-  idle_duration: 10
-  baseline_duration: 5
-  post_test_sleep: 5
-  phase_transition_time: 1
   boot:
     wait_time_dependencies: 60
   metric_providers:

--- a/config.yml.example
+++ b/config.yml.example
@@ -77,10 +77,7 @@ machine:
   base_temperature_feature: False
 
 measurement:
-  boot:
-    wait_time_dependencies: 60
   metric_providers:
-
   # Please select the needed providers according to the working ones on your system
   # More info https://docs.green-coding.io/docs/measuring/metric-providers
   # Please activate and deactivate any provider in this list by uncommenting it.

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -53,7 +53,8 @@ VALUES (
                 "measurement.baseline_duration",
                 "measurement.post_test_sleep",
                 "measurement.phase_transition_time",
-                "measurement.wait_time_dependencies"
+                "measurement.wait_time_dependencies",
+                "measurement.skip_volume_inspect"
             ]
         },
         "api": {
@@ -115,12 +116,16 @@ VALUES (
             "quotas": {},
             "dev_no_sleeps": false,
             "dev_no_optimizations": false,
+            "allow_unsafe": false,
+            "skip_unsafe": true,
+            "skip_system_checks": false,
+            "skip_volume_inspect": false,
             "total_duration": 86400,
             "flow_process_duration": 86400,
             "system_check_threshold": 3,
             "pre_test_sleep": 5,
-            "baseline_duration": 5,
-            "idle_duration": 10,
+            "baseline_duration": 60,
+            "idle_duration": 60,
             "post_test_sleep": 5,
             "phase_transition_time": 1,
             "wait_time_dependencies": 60,

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -46,7 +46,14 @@ VALUES (
                 "measurement.disabled_metric_providers",
                 "measurement.flow_process_duration",
                 "measurement.total_duration",
-                "measurement.phase_padding"
+                "measurement.phase_padding",
+                "measurement.system_check_threshold",
+                "measurement.pre_test_sleep",
+                "measurement.idle_duration",
+                "measurement.baseline_duration",
+                "measurement.post_test_sleep",
+                "measurement.phase_transition_time",
+                "measurement.wait_time_dependencies"
             ]
         },
         "api": {
@@ -110,6 +117,13 @@ VALUES (
             "dev_no_optimizations": false,
             "total_duration": 86400,
             "flow_process_duration": 86400,
+            "system_check_threshold": 3,
+            "pre_test_sleep": 5,
+            "baseline_duration": 5,
+            "idle_duration": 10,
+            "post_test_sleep": 5,
+            "phase_transition_time": 1,
+            "wait_time_dependencies": 60,
             "orchestrators": {
                 "docker": {
                     "allowed_run_args": []

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -26,6 +26,7 @@ const getSettings = async () => {
         if (data?.data?._capabilities?.measurement?.dev_no_optimizations === true) document.querySelector('#measurement-dev-no-optimizations').checked = true;
         if (data?.data?._capabilities?.measurement?.dev_no_sleeps === true) document.querySelector('#measurement-dev-no-sleeps').checked = true;
         if (data?.data?._capabilities?.measurement?.phase_padding === true) document.querySelector('#measurement-phase-padding').checked = true;
+        if (data?.data?._capabilities?.measurement?.skip_volume_inspect === true) document.querySelector('#measurement-skip-volume-inspect').checked = true;
         document.querySelector('#measurement-flow-process-duration').value = data?.data?._capabilities?.measurement?.flow_process_duration;
         document.querySelector('#measurement-total-duration').value = data?.data?._capabilities?.measurement?.total_duration;
         $('#measurement-disabled-metric-providers').dropdown('set exactly', data?.data?._capabilities?.measurement?.disabled_metric_providers);

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -29,6 +29,13 @@ const getSettings = async () => {
         document.querySelector('#measurement-flow-process-duration').value = data?.data?._capabilities?.measurement?.flow_process_duration;
         document.querySelector('#measurement-total-duration').value = data?.data?._capabilities?.measurement?.total_duration;
         $('#measurement-disabled-metric-providers').dropdown('set exactly', data?.data?._capabilities?.measurement?.disabled_metric_providers);
+        document.querySelector('#measurement-system-check-threshold').value = data?.data?._capabilities?.measurement?.system_check_threshold;
+        document.querySelector('#measurement-pre-test-sleep').value = data?.data?._capabilities?.measurement?.pre_test_sleep;
+        document.querySelector('#measurement-idle-duration').value = data?.data?._capabilities?.measurement?.idle_duration;
+        document.querySelector('#measurement-baseline-duration').value = data?.data?._capabilities?.measurement?.baseline_duration;
+        document.querySelector('#measurement-post-test-sleep').value = data?.data?._capabilities?.measurement?.post_test_sleep;
+        document.querySelector('#measurement-phase-transition-time').value = data?.data?._capabilities?.measurement?.phase_transition_time;
+        document.querySelector('#measurement-wait-time-dependencies').value = data?.data?._capabilities?.measurement?.wait_time_dependencies;
     } catch (err) {
         showNotification('Could not load settings', err);
     }

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -96,7 +96,15 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>Disable providers</td>
+                                    <td>System check threshold<br>
+                                        <span><small><i class="question circle icon"></i>Can be 1=INFO, 2=WARN or 3=ERROR. When set on 3 runs will fail only on erros, when 2 then also on warnings and 1 also on pure info statements.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-system-check-threshold" name="measurement-system-check-threshold" data-setting="measurement.system_check_threshold" required=""></td>
+                                    <td><button id="save-measurement-system-check-threshold" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Disable providers<br>
+                                        <span><small><i class="question circle icon"></i>Deactivates a provider even if configured on the machine. Use only if you experience errors with a provider.</small></span>
                                     <td>
                                         <select id="measurement-disabled-metric-providers" multiple="" class="ui multiple search selection dropdown" data-setting="measurement.disabled_metric_providers">
                                             <option value="">Select Metrics Provider</option>
@@ -107,19 +115,67 @@
                                     <td><button id="save-measurement-disabled-metric-providers" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
-                                    <td>Maximum flow process duration</td>
+                                    <td>Maximum flow process duration<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds.</small></span>
+                                    </td>
                                     <td><input type="text" placeholder="Input a value" id="measurement-flow-process-duration" name="measurement-flow-process-duration" data-setting="measurement.flow_process_duration" required=""></td>
                                     <td><button id="save-measurement-flow-process-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
-                                    <td>Maximum total duration</td>
+                                    <td>Maximum total duration<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds.</small></span>
+                                    </td>
                                     <td><input type="text" placeholder="Input a value" id="measurement-total-duration" name="measurement-total-duration" data-setting="measurement.total_duration" required="" ></td>
                                     <td><button id="save-measurement-total-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
-                                    <td>Phase padding</td>
+                                    <td>Phase padding<br>
+                                        <span><small><i class="question circle icon"></i>Determines if phases shall be padded to account for possible undersampling. Only turn off when you need nanosecond exact cut-offs from measurements and favor undersampling instead of capturing partial samples.</small></span>
+                                    </td>
                                     <td><input type="checkbox" id="measurement-phase-padding" name="measurement-phase-padding" data-setting="measurement.phase_padding"></td>
                                     <td><button id="save-measurement-phase-padding" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Pre-test sleep<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-pre-test-sleep" name="measurement-pre-test-sleep" data-setting="measurement.pre_test_sleep" required=""></td>
+                                    <td><button id="save-measurement-pre-test-sleep" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Baseline duration<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds. We recommend 60 seconds at least to get stable baseline for runtime overhead calculations.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-baseline-duration" name="measurement-baseline-duration" data-setting="measurement.baseline_duration" required=""></td>
+                                    <td><button id="save-measurement-baseline-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Idle duration<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds. We recommend 60 seconds at least to get stable baseline for runtime overhead calculations.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-idle-duration" name="measurement-idle-duration" data-setting="measurement.idle_duration" required=""></td>
+                                    <td><button id="save-measurement-idle-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Post-test sleep<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds. Should be 10 seconds minimum when doing Blue Angel measurements.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-post-test-sleep" name="measurement-post-test-sleep" data-setting="measurement.post_test_sleep" required=""></td>
+                                    <td><button id="save-measurement-post-test-sleep" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Phase transition time<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-phase-transition-time" name="measurement-phase-transition-time" data-setting="measurement.phase_transition_time" required=""></td>
+                                    <td><button id="save-measurement-phase-transition-time" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
+                                <tr>
+                                    <td>Wait time for dependencies<br>
+                                        <span><small><i class="question circle icon"></i>Value is in seconds.</small></span>
+                                    </td>
+                                    <td><input type="text" placeholder="Input a value" id="measurement-wait-time-dependencies" name="measurement-wait-time-dependencies" data-setting="measurement.wait_time_dependencies" required=""></td>
+                                    <td><button id="save-measurement-wait-time-dependencies" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
                                     <td>(DEV) No Sleeps during run<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster. However it will make the measurement invalid as important cooldown times are skipped.</small></span></td>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -187,6 +187,11 @@
                                     <td><input type="checkbox"  id="measurement-dev-no-optimizations" name="measurement-dev-no-optimizations" data-setting="measurement.dev_no_optimizations"></td>
                                     <td><button id="save-measurement-dev-no-optimizations" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
+                                <tr>
+                                    <td>(DEV) Skip volume inspect<br><span><small><i class="question circle icon"></i>You can use this while developing to speed up runs on the cluster if you are not interested in the volume sizes or experience errors with shared non-readable volumes.</small></span></td>
+                                    <td><input type="checkbox"  id="measurement-skip-volume-inspect" name="easurement-skip-volume-inspect" data-setting="measurement.skip_volume_inspect"></td>
+                                    <td><button id="save-measurement-skip-volume-inspect" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
+                                </tr>
                                 <!--
                                 <tr>
                                     <td>Kill running measurements</td>

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -42,21 +42,30 @@ class RunJob(Job):
             uri_type='URL',
             filename=self._filename,
             branch=self._branch,
-            skip_unsafe=user._capabilities['measurement'].get('skip_unsafe', True),
-            allow_unsafe=user._capabilities['measurement'].get('allow_unsafe', False),
-            skip_system_checks=skip_system_checks,
-            skip_volume_inspect=user._capabilities['measurement'].get('skip_volume_inspect', False),
-            full_docker_prune=full_docker_prune,
-            docker_prune=docker_prune,
+            skip_unsafe=user._capabilities['measurement']['skip_unsafe'],
+            allow_unsafe=user._capabilities['measurement']['allow_unsafe'],
+            skip_system_checks=user._capabilities['measurement']['skip_system_checks'],
+            skip_volume_inspect=user._capabilities['measurement']['skip_volume_inspect'],
+            full_docker_prune=full_docker_prune, # is no user setting as it can change behaviour of subsequent runs. Thus set by machine / cluster
+            docker_prune=docker_prune, # is no user setting as it can change behaviour of subsequent runs. Thus set by machine / cluster
             job_id=self._id,
             user_id=self._user_id,
             usage_scenario_variables=self._usage_scenario_variables,
             measurement_flow_process_duration=user._capabilities['measurement']['flow_process_duration'],
-            dev_no_sleeps=user._capabilities['measurement'].get('dev_no_sleeps', False),
-            dev_no_optimizations=user._capabilities['measurement'].get('dev_no_optimizations', False),
             measurement_total_duration=user._capabilities['measurement']['total_duration'],
+            measurement_system_check_threshold=user._capabilities['measurement']['system_check_threshold'],
+            measurement_pre_test_sleep=user._capabilities['measurement']['pre_test_sleep'],
+            measurement_idle_duration=user._capabilities['measurement']['idle_duration'],
+            measurement_baseline_duration=user._capabilities['measurement']['baseline_duration'],
+            measurement_post_test_sleep=user._capabilities['measurement']['post_test_sleep'],
+            measurement_phase_transition_time=user._capabilities['measurement']['phase_transition_time'],
+            measurement_wait_time_dependencies=user._capabilities['measurement']['wait_time_dependencies'],
+            dev_no_sleeps=user._capabilities['measurement']['dev_no_sleeps'],
+            dev_no_optimizations=user._capabilities['measurement']['dev_no_optimizations'],
             disabled_metric_providers=user._capabilities['measurement']['disabled_metric_providers'],
             allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'], # They are specific to the orchestrator. However currently we only have one. As soon as we support more orchestrators we will sub-class Runner with dedicated child classes (DockerRunner, PodmanRunner etc.)
+
+
         )
         try:
             # Start main code. Only URL is allowed for cron jobs

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -69,7 +69,10 @@ class ScenarioRunner:
         dev_no_sleeps=False, dev_cache_build=False, dev_no_metrics=False,
         dev_flow_timetravel=False, dev_no_optimizations=False, docker_prune=False, job_id=None,
         user_id=1, measurement_flow_process_duration=None, measurement_total_duration=None, disabled_metric_providers=None, allowed_run_args=None, dev_no_phase_stats=False, dev_no_save=False,
-        skip_volume_inspect=False, commit_hash_folder=None, usage_scenario_variables=None, phase_padding=True):
+        skip_volume_inspect=False, commit_hash_folder=None, usage_scenario_variables=None, phase_padding=True,
+        measurement_system_check_threshold=3, measurement_pre_test_sleep=5, measurement_idle_duration=60,
+        measurement_baseline_duration=60, measurement_post_test_sleep=5, measurement_phase_transition_time=1,
+        measurement_wait_time_dependencies=60):
 
         if skip_unsafe is True and allow_unsafe is True:
             raise RuntimeError('Cannot specify both --skip-unsafe and --allow-unsafe')
@@ -120,6 +123,13 @@ class ScenarioRunner:
         self._measurement_total_duration = measurement_total_duration
         self._disabled_metric_providers = [] if disabled_metric_providers is None else disabled_metric_providers
         self._allowed_run_args = [] if allowed_run_args is None else allowed_run_args # They are specific to the orchestrator. However currently we only have one. As soon as we support more orchestrators we will sub-class Runner with dedicated child classes (DockerRunner, PodmanRunner etc.)
+        self._measurement_system_check_threshold = measurement_system_check_threshold
+        self._measurement_pre_test_sleep = measurement_pre_test_sleep
+        self._measurement_idle_duration = measurement_idle_duration
+        self._measurement_baseline_duration = measurement_baseline_duration
+        self._measurement_post_test_sleep = measurement_post_test_sleep
+        self._measurement_phase_transition_time = measurement_phase_transition_time
+        self._measurement_wait_time_dependencies = measurement_wait_time_dependencies
         self._last_measurement_duration = 0
         self._phase_padding = phase_padding
         self._phase_padding_ms = max(
@@ -227,7 +237,7 @@ class ScenarioRunner:
             return
 
         if mode =='start':
-            warnings = system_checks.check_start()
+            warnings = system_checks.check_start(self._measurement_system_check_threshold)
             for warn in warnings:
                 self.__warnings.append(warn)
         else:
@@ -833,7 +843,6 @@ class ScenarioRunner:
         return OrderedDict((key, services[key]) for key in names_ordered)
 
     def setup_services(self):
-        config = GlobalConfig().config
         print(TerminalColors.HEADER, '\nSetting up services', TerminalColors.ENDC)
         # technically the usage_scenario needs no services and can also operate on an empty list
         # This use case is when you have running containers on your host and want to benchmark some code running in them
@@ -1138,7 +1147,7 @@ class ScenarioRunner:
                     time_waited = 0
                     state = ''
                     health = 'healthy' # default because some containers have no health
-                    max_waiting_time = config['measurement']['boot']['wait_time_dependencies']
+                    max_waiting_time = self._measurement_wait_time_dependencies
                     while time_waited < max_waiting_time:
                         status_output = subprocess.check_output(
                             ["docker", "container", "inspect", "-f", "{{.State.Status}}", dependent_container_name],
@@ -1346,15 +1355,14 @@ class ScenarioRunner:
             raise TimeoutError(f"Timeout of {self._measurement_total_duration} s was exceeded. This can be configured in the user authentication for 'total_duration'.")
 
     def start_phase(self, phase, transition = True):
-        config = GlobalConfig().config
         print(TerminalColors.HEADER, f"\nStarting phase {phase}.", TerminalColors.ENDC)
 
         self.check_total_runtime_exceeded()
 
         if transition:
             # The force-sleep must go and we must actually check for the temperature baseline
-            print(f"\nForce-sleeping for {config['measurement']['phase_transition_time']}s")
-            self.custom_sleep(config['measurement']['phase_transition_time'])
+            print(f"\nForce-sleeping for {self._measurement_phase_transition_time}s")
+            self.custom_sleep(self._measurement_phase_transition_time)
             #print(TerminalColors.HEADER, '\nChecking if temperature is back to baseline ...', TerminalColors.ENDC)
 
         phase_time = int(time.time_ns() / 1_000)
@@ -1858,7 +1866,6 @@ class ScenarioRunner:
 
         '''
         try:
-            config = GlobalConfig().config
             self.start_measurement() # we start as early as possible to include initialization overhead
             self.clear_caches()
             self.check_system('start')
@@ -1881,10 +1888,10 @@ class ScenarioRunner:
             if self._debugger.active:
                 self._debugger.pause('metric-providers (non-container) start complete. Waiting to start measurement')
 
-            self.custom_sleep(config['measurement']['pre_test_sleep'])
+            self.custom_sleep(self._measurement_pre_test_sleep)
 
             self.start_phase('[BASELINE]')
-            self.custom_sleep(config['measurement']['baseline_duration'])
+            self.custom_sleep(self._measurement_baseline_duration)
             self.end_phase('[BASELINE]')
 
             if self._debugger.active:
@@ -1916,7 +1923,7 @@ class ScenarioRunner:
                 self._debugger.pause('metric-providers (container) start complete. Waiting to start idle phase')
 
             self.start_phase('[IDLE]')
-            self.custom_sleep(config['measurement']['idle_duration'])
+            self.custom_sleep(self._measurement_idle_duration)
             self.end_phase('[IDLE]')
 
             if self._debugger.active:
@@ -1938,7 +1945,7 @@ class ScenarioRunner:
 
             self.end_measurement()
             self.check_process_returncodes()
-            self.custom_sleep(config['measurement']['post_test_sleep'])
+            self.custom_sleep(self._measurement_post_test_sleep)
             self.identify_invalid_run()
 
         except BaseException as exc:

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -129,7 +129,7 @@ start_checks = [
 
 ]
 
-def check_start():
+def check_start(system_check_threshold=3):
     print(TerminalColors.HEADER, '\nRunning System Checks', TerminalColors.ENDC)
     warnings = []
     max_key_length = max(len(key[2]) for key in start_checks)
@@ -159,7 +159,7 @@ def check_start():
 
             print(f"Checking {formatted_key} : {output}")
 
-            if retval is False and check[1].value >= GlobalConfig().config['measurement']['system_check_threshold']:
+            if retval is False and check[1].value >= system_check_threshold:
                 # Error needs to raise
                 raise ConfigurationCheckError(check[3], check[1])
 

--- a/lib/user.py
+++ b/lib/user.py
@@ -65,7 +65,7 @@ class User():
             raise ValueError(f"You cannot change this setting: {name}")
 
         match name:
-            case 'measurement.dev_no_optimizations' | 'measurement.dev_no_sleeps' | 'measurement.phase_padding':
+            case 'measurement.dev_no_optimizations' | 'measurement.dev_no_sleeps' | 'measurement.phase_padding' | 'measurement.skip_volume_inspect':
                 if not isinstance(value, bool):
                     raise ValueError(f'The setting {name} must be boolean')
             case 'measurement.flow_process_duration' | 'measurement.total_duration':

--- a/lib/user.py
+++ b/lib/user.py
@@ -78,6 +78,14 @@ class User():
                 if not value.issubset(allowed_values):
                     raise ValueError(f'The setting {name} must be in {allowed_values} but is {value}')
                 value = list(value) # transform back, as it is not json serializable. But we need the unique transform of set beforehand
+            case 'measurement.system_check_threshold':
+                if not (isinstance(value, int) or value.isdigit()) or int(value) not in [1, 2, 3]:
+                    raise ValueError(f'The setting {name} must be 1, 2 or 3')
+                value = int(value)
+            case 'measurement.pre_test_sleep' | 'measurement.idle_duration' | 'measurement.baseline_duration' | 'measurement.post_test_sleep' | 'measurement.phase_transition_time' | 'measurement.wait_time_dependencies':
+                if not (isinstance(value, int) or value.isdigit()) or int(value) <= 0 or int(value) > 86400:
+                    raise ValueError(f'The setting {name} must be between 1 and 86400')
+                value = int(value)
             case _:
                 raise ValueError(f'The setting {name} is unknown')
 

--- a/migrations/2025_08_01_more_measurement_user_settings.sql
+++ b/migrations/2025_08_01_more_measurement_user_settings.sql
@@ -1,0 +1,67 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{user,updateable_settings}',
+    (
+        COALESCE(capabilities->'user'->'updateable_settings', '[]'::jsonb) ||
+        '["measurement.system_check_threshold", "measurement.pre_test_sleep", "measurement.idle_duration", "measurement.baseline_duration", "measurement.post_test_sleep", "measurement.phase_transition_time", "measurement.wait_time_dependencies"]'::jsonb
+    ),
+    true
+) WHERE id != 0;
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,system_check_threshold}',
+   '3',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,pre_test_sleep}',
+   '5',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,idle_duration}',
+    '60',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,baseline_duration}',
+    '60',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,post_test_sleep}',
+   '5',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,phase_transition_time}',
+   '1',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,wait_time_dependencies}',
+    '60',
+    true
+);
+

--- a/migrations/2025_08_01_more_measurement_user_settings.sql
+++ b/migrations/2025_08_01_more_measurement_user_settings.sql
@@ -4,7 +4,7 @@ SET capabilities = jsonb_set(
     '{user,updateable_settings}',
     (
         COALESCE(capabilities->'user'->'updateable_settings', '[]'::jsonb) ||
-        '["measurement.system_check_threshold", "measurement.pre_test_sleep", "measurement.idle_duration", "measurement.baseline_duration", "measurement.post_test_sleep", "measurement.phase_transition_time", "measurement.wait_time_dependencies"]'::jsonb
+        '["measurement.system_check_threshold", "measurement.pre_test_sleep", "measurement.idle_duration", "measurement.baseline_duration", "measurement.post_test_sleep", "measurement.phase_transition_time", "measurement.wait_time_dependencies", "measurement.skip_volume_inspect"]'::jsonb
     ),
     true
 ) WHERE id != 0;
@@ -65,3 +65,34 @@ SET capabilities = jsonb_set(
     true
 );
 
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,allow_unsafe}',
+    'false',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,skip_unsafe}',
+    'true',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,skip_system_checks}',
+    'false',
+    true
+);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,skip_volume_inspect}',
+    'false',
+    true
+);

--- a/runner.py
+++ b/runner.py
@@ -58,6 +58,21 @@ if __name__ == '__main__':
     parser.add_argument('--print-phase-stats', type=str, help='Prints the stats for the given phase to the CLI for quick verification without the Dashboard. Try "[RUNTIME]" as argument.')
     parser.add_argument('--print-logs', action='store_true', help='Prints the container and process logs to stdout')
 
+    # Measurement settings
+    parser.add_argument('--measurement-system-check-threshold', type=int, default=3, help='System check threshold when to issue warning and when to fail. When set on 3 runs will fail only on erros, when 2 then also on warnings and 1 also on pure info statements. Can be 1=INFO, 2=WARN or 3=ERROR')
+    parser.add_argument('--measurement-pre-test-sleep', type=int, default=5, help='Override measurement pre-test sleep')
+    parser.add_argument('--measurement-idle-duration', type=int, default=60, help='Override measurement idle duration')
+    parser.add_argument('--measurement-baseline-duration', type=int, default=60, help='Override measurement baseline duration')
+    parser.add_argument('--measurement-post-test-sleep', type=int, default=5, help='Override measurement post-test sleep')
+    parser.add_argument('--measurement-phase-transition-time', type=int, default=1, help='Override measurement phase transition time')
+    parser.add_argument('--measurement-wait-time-dependencies', type=int, default=60, help='Override measurement wait time for dependencies')
+    parser.add_argument('--measurement-flow-process-duration', type=int, default=86400, help='Override measurement flow process duration')
+    parser.add_argument('--measurement-total-duration', type=int, default=86400, help='Override measurement total duration')
+
+    # intentionally not supported
+    # parser.add_argument('--disabled-metric-providers', nargs='+', help='Override disabled metric providers') # user can just edit the config in CLI mode and using another args="+" for parsing CLI is flaky
+    # parser.add_argument('--allowed-run-args', nargs='+', help='Override allowed run arguments to be passed to the docker container') # user can just go into --allow-unsafe and using another args="+" for parsing CLI is flaky
+
     args = parser.parse_args()
 
     if args.uri is None:
@@ -119,7 +134,19 @@ if __name__ == '__main__':
                     dev_flow_timetravel=args.dev_flow_timetravel, dev_no_optimizations=args.dev_no_optimizations,
                     docker_prune=args.docker_prune, dev_no_phase_stats=args.dev_no_phase_stats, user_id=args.user_id,
                     skip_volume_inspect=args.skip_volume_inspect, commit_hash_folder=args.commit_hash_folder,
-                    usage_scenario_variables=variables_dict, phase_padding=not args.no_phase_padding)
+                    usage_scenario_variables=variables_dict, phase_padding=not args.no_phase_padding,
+                    measurement_system_check_threshold=args.measurement_system_check_threshold,
+                    measurement_pre_test_sleep=args.measurement_pre_test_sleep,
+                    measurement_idle_duration=args.measurement_idle_duration,
+                    measurement_baseline_duration=args.measurement_baseline_duration,
+                    measurement_post_test_sleep=args.measurement_post_test_sleep,
+                    measurement_phase_transition_time=args.measurement_phase_transition_time,
+                    measurement_wait_time_dependencies=args.measurement_wait_time_dependencies,
+                    measurement_flow_process_duration=args.measurement_flow_process_duration,
+                    measurement_total_duration=args.measurement_total_duration,
+                    #disabled_metric_providers # this is intentionally not supported as the user can just edit the config in CLI mode and using another args="+" for parsing CLI is flaky
+                    #allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'] # this is intentionally not supported as the user can just enter --allow-unsafe in CLI mode and using another args="+" for parsing CLI is flaky
+                    )
 
     # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
     #pylint: disable=broad-except

--- a/tests/cron/test_client.py
+++ b/tests/cron/test_client.py
@@ -14,6 +14,8 @@ def test_simple_cluster_run():
     branch = 'main'
     machine_id = 1
 
+    Tests.shorten_sleep_times(1)
+
     Job.insert('run', user_id=1, name=name, url=url, email=None, branch=branch, filename=filename, machine_id=machine_id)
 
     ps = subprocess.run(

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -68,6 +68,8 @@ def test_insert_job():
     assert job._state == 'WAITING'
 
 def test_simple_run_job_no_quota():
+    Tests.shorten_sleep_times(1)
+
     name = utils.randomword(12)
     url = 'https://github.com/green-coding-solutions/pytest-dummy-repo'
     filename = 'usage_scenario.yml'
@@ -91,6 +93,8 @@ def test_simple_run_job_no_quota():
         Tests.assertion_info('MEASUREMENT SUCCESSFULLY COMPLETED', ps.stdout)
 
 def test_simple_run_job_quota_gets_deducted():
+    Tests.shorten_sleep_times(1)
+
     name = utils.randomword(12)
     url = 'https://github.com/green-coding-solutions/pytest-dummy-repo'
     filename = 'usage_scenario.yml'
@@ -119,6 +123,8 @@ def test_simple_run_job_quota_gets_deducted():
     assert User(1)._capabilities['measurement']['quotas']['1'] < 10_000 * 60
 
 def test_simple_run_job_with_variables():
+    Tests.shorten_sleep_times(1)
+
     name = utils.randomword(12)
     url = 'https://github.com/green-coding-solutions/pytest-dummy-repo'
     filename = 'usage_scenario.yml'

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -618,6 +618,7 @@ def test_settings_measurement():
     assert user._capabilities['measurement']['post_test_sleep'] == 5
     assert user._capabilities['measurement']['phase_transition_time'] == 1
     assert user._capabilities['measurement']['wait_time_dependencies'] == 60
+    assert user._capabilities['measurement']['skip_volume_inspect'] is False
 
 
     value = page.locator('#measurement-disabled-metric-providers').input_value()
@@ -660,33 +661,39 @@ def test_settings_measurement():
     value = page.locator('#measurement-wait-time-dependencies').input_value()
     assert int(value.strip()) == user._capabilities['measurement']['wait_time_dependencies']
 
+    value = page.locator('#measurement-skip-volume-inspect').is_checked()
+    assert value is user._capabilities['measurement']['skip_volume_inspect']
+
+
+    page.locator('#measurement-system-check-threshold').fill('2')
     page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "NetworkConnectionsProxyContainerProvider");')
     page.locator('#measurement-flow-process-duration').fill('456')
     page.locator('#measurement-total-duration').fill('123')
     page.locator('#measurement-phase-padding').click()
-    page.locator('#measurement-dev-no-sleeps').click()
-    page.locator('#measurement-dev-no-optimizations').click()
-    page.locator('#measurement-system-check-threshold').fill('2')
     page.locator('#measurement-pre-test-sleep').fill('100')
     page.locator('#measurement-idle-duration').fill('200')
     page.locator('#measurement-baseline-duration').fill('100')
     page.locator('#measurement-post-test-sleep').fill('100')
     page.locator('#measurement-phase-transition-time').fill('2')
     page.locator('#measurement-wait-time-dependencies').fill('120')
+    page.locator('#measurement-dev-no-sleeps').click()
+    page.locator('#measurement-dev-no-optimizations').click()
+    page.locator('#measurement-skip-volume-inspect').click()
 
+    page.locator('#save-measurement-system-check-threshold').click()
     page.locator('#save-measurement-disabled-metric-providers').click()
     page.locator('#save-measurement-flow-process-duration').click()
     page.locator('#save-measurement-total-duration').click()
     page.locator('#save-measurement-phase-padding').click()
-    page.locator('#save-measurement-dev-no-sleeps').click()
-    page.locator('#save-measurement-dev-no-optimizations').click()
-    page.locator('#save-measurement-system-check-threshold').click()
     page.locator('#save-measurement-pre-test-sleep').click()
     page.locator('#save-measurement-idle-duration').click()
     page.locator('#save-measurement-baseline-duration').click()
     page.locator('#save-measurement-post-test-sleep').click()
     page.locator('#save-measurement-phase-transition-time').click()
     page.locator('#save-measurement-wait-time-dependencies').click()
+    page.locator('#save-measurement-dev-no-sleeps').click()
+    page.locator('#save-measurement-dev-no-optimizations').click()
+    page.locator('#save-measurement-skip-volume-inspect').click()
 
     #page.wait_for_load_state("networkidle") # Network Idle sadly not enough here. The DB seems to take 1-2 seconds
     time.sleep(1)
@@ -705,50 +712,4 @@ def test_settings_measurement():
     assert user._capabilities['measurement']['post_test_sleep'] == 100
     assert user._capabilities['measurement']['phase_transition_time'] == 2
     assert user._capabilities['measurement']['wait_time_dependencies'] == 120
-
-
-    page.locator('#measurement-disabled-metric-providers').click()
-    page.locator('#measurement-flow-process-duration').fill('86400')
-    page.locator('#measurement-total-duration').fill('86400')
-    page.locator('#measurement-phase-padding').click()
-    page.locator('#measurement-dev-no-sleeps').click()
-    page.locator('#measurement-dev-no-optimizations').click()
-    page.locator('#measurement-system-check-threshold').fill('3')
-    page.locator('#measurement-pre-test-sleep').fill('5')
-    page.locator('#measurement-idle-duration').fill('10')
-    page.locator('#measurement-baseline-duration').fill('5')
-    page.locator('#measurement-post-test-sleep').fill('5')
-    page.locator('#measurement-phase-transition-time').fill('1')
-    page.locator('#measurement-wait-time-dependencies').fill('60')
-
-    page.locator('#save-measurement-disabled-metric-providers').click()
-    page.locator('#save-measurement-flow-process-duration').click()
-    page.locator('#save-measurement-total-duration').click()
-    page.locator('#save-measurement-phase-padding').click()
-    page.locator('#save-measurement-dev-no-sleeps').click()
-    page.locator('#save-measurement-dev-no-optimizations').click()
-    page.locator('#save-measurement-system-check-threshold').click()
-    page.locator('#save-measurement-pre-test-sleep').click()
-    page.locator('#save-measurement-idle-duration').click()
-    page.locator('#save-measurement-baseline-duration').click()
-    page.locator('#save-measurement-post-test-sleep').click()
-    page.locator('#save-measurement-phase-transition-time').click()
-    page.locator('#save-measurement-wait-time-dependencies').click()
-
-    #page.wait_for_load_state("networkidle") # Network Idle sadly not enough here. The DB seems to take 1-2 seconds
-    time.sleep(1)
-
-    user = User(1)
-    assert user._capabilities['measurement']['disabled_metric_providers'] == []
-    assert user._capabilities['measurement']['flow_process_duration'] == 86400
-    assert user._capabilities['measurement']['total_duration'] == 86400
-    assert user._capabilities['measurement']['phase_padding'] is True
-    assert user._capabilities['measurement']['dev_no_sleeps'] is False
-    assert user._capabilities['measurement']['dev_no_optimizations'] is False
-    assert user._capabilities['measurement']['system_check_threshold'] == 3
-    assert user._capabilities['measurement']['pre_test_sleep'] == 5
-    assert user._capabilities['measurement']['idle_duration'] == 10
-    assert user._capabilities['measurement']['baseline_duration'] == 5
-    assert user._capabilities['measurement']['post_test_sleep'] == 5
-    assert user._capabilities['measurement']['phase_transition_time'] == 1
-    assert user._capabilities['measurement']['wait_time_dependencies'] == 60
+    assert user._capabilities['measurement']['skip_volume_inspect'] is True

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -611,6 +611,13 @@ def test_settings_measurement():
     assert user._capabilities['measurement']['phase_padding'] is True
     assert user._capabilities['measurement']['dev_no_sleeps'] is False
     assert user._capabilities['measurement']['dev_no_optimizations'] is False
+    assert user._capabilities['measurement']['system_check_threshold'] == 3
+    assert user._capabilities['measurement']['pre_test_sleep'] == 5
+    assert user._capabilities['measurement']['idle_duration'] == 60
+    assert user._capabilities['measurement']['baseline_duration'] == 60
+    assert user._capabilities['measurement']['post_test_sleep'] == 5
+    assert user._capabilities['measurement']['phase_transition_time'] == 1
+    assert user._capabilities['measurement']['wait_time_dependencies'] == 60
 
 
     value = page.locator('#measurement-disabled-metric-providers').input_value()
@@ -632,12 +639,40 @@ def test_settings_measurement():
     value = page.locator('#measurement-dev-no-optimizations').is_checked()
     assert value is user._capabilities['measurement']['dev_no_optimizations']
 
+    value = page.locator('#measurement-system-check-threshold').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['system_check_threshold']
+
+    value = page.locator('#measurement-pre-test-sleep').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['pre_test_sleep']
+
+    value = page.locator('#measurement-idle-duration').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['idle_duration']
+
+    value = page.locator('#measurement-baseline-duration').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['baseline_duration']
+
+    value = page.locator('#measurement-post-test-sleep').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['post_test_sleep']
+
+    value = page.locator('#measurement-phase-transition-time').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['phase_transition_time']
+
+    value = page.locator('#measurement-wait-time-dependencies').input_value()
+    assert int(value.strip()) == user._capabilities['measurement']['wait_time_dependencies']
+
     page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "NetworkConnectionsProxyContainerProvider");')
     page.locator('#measurement-flow-process-duration').fill('456')
     page.locator('#measurement-total-duration').fill('123')
     page.locator('#measurement-phase-padding').click()
     page.locator('#measurement-dev-no-sleeps').click()
     page.locator('#measurement-dev-no-optimizations').click()
+    page.locator('#measurement-system-check-threshold').fill('2')
+    page.locator('#measurement-pre-test-sleep').fill('100')
+    page.locator('#measurement-idle-duration').fill('200')
+    page.locator('#measurement-baseline-duration').fill('100')
+    page.locator('#measurement-post-test-sleep').fill('100')
+    page.locator('#measurement-phase-transition-time').fill('2')
+    page.locator('#measurement-wait-time-dependencies').fill('120')
 
     page.locator('#save-measurement-disabled-metric-providers').click()
     page.locator('#save-measurement-flow-process-duration').click()
@@ -645,6 +680,13 @@ def test_settings_measurement():
     page.locator('#save-measurement-phase-padding').click()
     page.locator('#save-measurement-dev-no-sleeps').click()
     page.locator('#save-measurement-dev-no-optimizations').click()
+    page.locator('#save-measurement-system-check-threshold').click()
+    page.locator('#save-measurement-pre-test-sleep').click()
+    page.locator('#save-measurement-idle-duration').click()
+    page.locator('#save-measurement-baseline-duration').click()
+    page.locator('#save-measurement-post-test-sleep').click()
+    page.locator('#save-measurement-phase-transition-time').click()
+    page.locator('#save-measurement-wait-time-dependencies').click()
 
     #page.wait_for_load_state("networkidle") # Network Idle sadly not enough here. The DB seems to take 1-2 seconds
     time.sleep(1)
@@ -656,3 +698,57 @@ def test_settings_measurement():
     assert user._capabilities['measurement']['phase_padding'] is False
     assert user._capabilities['measurement']['dev_no_sleeps'] is True
     assert user._capabilities['measurement']['dev_no_optimizations'] is True
+    assert user._capabilities['measurement']['system_check_threshold'] == 2
+    assert user._capabilities['measurement']['pre_test_sleep'] == 100
+    assert user._capabilities['measurement']['idle_duration'] == 200
+    assert user._capabilities['measurement']['baseline_duration'] == 100
+    assert user._capabilities['measurement']['post_test_sleep'] == 100
+    assert user._capabilities['measurement']['phase_transition_time'] == 2
+    assert user._capabilities['measurement']['wait_time_dependencies'] == 120
+
+
+    page.locator('#measurement-disabled-metric-providers').click()
+    page.locator('#measurement-flow-process-duration').fill('86400')
+    page.locator('#measurement-total-duration').fill('86400')
+    page.locator('#measurement-phase-padding').click()
+    page.locator('#measurement-dev-no-sleeps').click()
+    page.locator('#measurement-dev-no-optimizations').click()
+    page.locator('#measurement-system-check-threshold').fill('3')
+    page.locator('#measurement-pre-test-sleep').fill('5')
+    page.locator('#measurement-idle-duration').fill('10')
+    page.locator('#measurement-baseline-duration').fill('5')
+    page.locator('#measurement-post-test-sleep').fill('5')
+    page.locator('#measurement-phase-transition-time').fill('1')
+    page.locator('#measurement-wait-time-dependencies').fill('60')
+
+    page.locator('#save-measurement-disabled-metric-providers').click()
+    page.locator('#save-measurement-flow-process-duration').click()
+    page.locator('#save-measurement-total-duration').click()
+    page.locator('#save-measurement-phase-padding').click()
+    page.locator('#save-measurement-dev-no-sleeps').click()
+    page.locator('#save-measurement-dev-no-optimizations').click()
+    page.locator('#save-measurement-system-check-threshold').click()
+    page.locator('#save-measurement-pre-test-sleep').click()
+    page.locator('#save-measurement-idle-duration').click()
+    page.locator('#save-measurement-baseline-duration').click()
+    page.locator('#save-measurement-post-test-sleep').click()
+    page.locator('#save-measurement-phase-transition-time').click()
+    page.locator('#save-measurement-wait-time-dependencies').click()
+
+    #page.wait_for_load_state("networkidle") # Network Idle sadly not enough here. The DB seems to take 1-2 seconds
+    time.sleep(1)
+
+    user = User(1)
+    assert user._capabilities['measurement']['disabled_metric_providers'] == []
+    assert user._capabilities['measurement']['flow_process_duration'] == 86400
+    assert user._capabilities['measurement']['total_duration'] == 86400
+    assert user._capabilities['measurement']['phase_padding'] is True
+    assert user._capabilities['measurement']['dev_no_sleeps'] is False
+    assert user._capabilities['measurement']['dev_no_optimizations'] is False
+    assert user._capabilities['measurement']['system_check_threshold'] == 3
+    assert user._capabilities['measurement']['pre_test_sleep'] == 5
+    assert user._capabilities['measurement']['idle_duration'] == 10
+    assert user._capabilities['measurement']['baseline_duration'] == 5
+    assert user._capabilities['measurement']['post_test_sleep'] == 5
+    assert user._capabilities['measurement']['phase_transition_time'] == 1
+    assert user._capabilities['measurement']['wait_time_dependencies'] == 60

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -37,7 +37,7 @@ def setup_module(module):
         subprocess.run(['docker', 'compose', '-f', GMT_DIR+folder+'compose.yml', 'build'], check=True)
 
         # Run the application
-        runner = ScenarioRunner(name=RUN_NAME, uri=GMT_DIR, filename=folder+filename, uri_type='folder', dev_cache_build=False, dev_no_sleeps=False, dev_no_metrics=False, skip_system_checks=False)
+        runner = ScenarioRunner(name=RUN_NAME, uri=GMT_DIR, filename=folder+filename, uri_type='folder', dev_cache_build=False, dev_no_sleeps=False, dev_no_metrics=False, skip_system_checks=False, measurement_pre_test_sleep=1, measurement_baseline_duration=1, measurement_idle_duration=1, measurement_post_test_sleep=1, measurement_phase_transition_time=1, measurement_wait_time_dependencies=5)
         runner.run()
 
     #pylint: disable=global-statement

--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -56,16 +56,6 @@ machine:
   base_temperature_feature: "asd"
 
 measurement:
-  system_check_threshold: 3
-  pre_test_sleep: 0
-  idle_duration: 0
-  baseline_duration: 0
-  flow_process_duration: 1800 # half hour
-  total_duration: 3600 # one hour
-  post_test_sleep: 0
-  phase_transition_time: 0
-  boot:
-    wait_time_dependencies: 10
   metric_providers:
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -176,12 +176,12 @@ def insert_user(user_id, token):
     DB().query("""
         INSERT INTO "public"."users"("id", "name","token","capabilities","created_at")
         VALUES
-        (%s, %s, %s, (SELECT capabilities FROM users WHERE user.id = 1), E'2024-08-22 11:28:24.937262+00')
+        (%s, %s, %s, (SELECT capabilities FROM users WHERE id = 1), E'2024-08-22 11:28:24.937262+00')
     """, params=(user_id, token, sha256_hash.hexdigest()))
     DB().query("""
         UPDATE users SET capabilities = jsonb_set(capabilities, '{user,visible_users}', %s ,false)
-            WHERE user.id = %s
-    """, params=(user_id, user_id))
+            WHERE id = %s
+    """, params=(str(user_id), user_id))
 
 
 def import_demo_data():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -23,13 +23,11 @@ TEST_MEASUREMENT_DURATION_S = TEST_MEASUREMENT_DURATION / 1_000_000
 TEST_MEASUREMENT_DURATION_H = TEST_MEASUREMENT_DURATION_S/60/60
 
 def shorten_sleep_times(duration_in_s):
-    DB().query('''
-        UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,pre_test_sleep}',%s,false);
-        UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,baseline_duration}',%s,false);
-        UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,idle_duration}',%s,false);
-        UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,post_test_sleep}',%s,false);
-        UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,phase_transition_time}',%s,false);
-    ''', params=(duration_in_s, duration_in_s, duration_in_s, duration_in_s, duration_in_s))
+    DB().query("UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,pre_test_sleep}',%s,false)", params=(str(duration_in_s), ))
+    DB().query("UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,baseline_duration}',%s,false)", params=(str(duration_in_s), ))
+    DB().query("UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,idle_duration}',%s,false)", params=(str(duration_in_s), ))
+    DB().query("UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,post_test_sleep}',%s,false)", params=(str(duration_in_s), ))
+    DB().query("UPDATE users SET capabilities = jsonb_set(capabilities,'{measurement,phase_transition_time}',%s,false)", params=(str(duration_in_s), ))
 
 
 def insert_run(*, uri='test-uri', branch='test-branch', filename='test-filename', user_id=1, machine_id=1):
@@ -175,12 +173,16 @@ def insert_user(user_id, token):
     sha256_hash = hashlib.sha256()
     sha256_hash.update(token.encode('UTF-8'))
 
-    # Reminder: because of f-string all {} braces are doubled to be escaped
-    DB().query(f"""
+    DB().query("""
         INSERT INTO "public"."users"("id", "name","token","capabilities","created_at")
         VALUES
-        (%s, %s, %s,E'{{"user":{{"visible_users":[{user_id}],"is_super_user": false}},"api":{{"quotas":{{}},"routes":["/v1/user/setting","/v1/user/settings","/v2/carbondb/add","/v2/carbondb/filters","/v2/carbondb","/v1/carbondb/add","/v1/ci/measurement/add","/v2/ci/measurement/add","/v1/software/add","/v1/hog/add"]}},"data":{{"runs":{{"retention":2678400}},"hog_tasks":{{"retention":2678400}},"measurements":{{"retention":2678400}},"hog_coalitions":{{"retention":2678400}},"ci_measurements":{{"retention":2678400}},"hog_measurements":{{"retention":2678400}}}},"jobs":{{"schedule_modes":["one-off","daily","weekly","commit","variance"]}},"machines":[1],"measurement":{{"quotas":{{}},"total_duration":86400,"flow_process_duration":86400}},"optimizations":["container_memory_utilization","container_cpu_utilization","message_optimization","container_build_time","container_boot_time","container_image_size"]}}',E'2024-08-22 11:28:24.937262+00');
+        (%s, %s, %s, (SELECT capabilities FROM users WHERE user.id = 1), E'2024-08-22 11:28:24.937262+00')
     """, params=(user_id, token, sha256_hash.hexdigest()))
+    DB().query("""
+        UPDATE users SET capabilities = jsonb_set(capabilities, '{user,visible_users}', %s ,false)
+            WHERE user.id = %s
+    """, params=(user_id, user_id))
+
 
 def import_demo_data():
     config = GlobalConfig().config

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -491,14 +491,14 @@ Container health of dependent service 'test-container-2': healthy
 
 def test_depends_on_healthcheck_missing_start_period():
     # Test setup: Container would be healthy after 3 seconds, however, no start_period is set (default 0s), therefore start_interval is not used.
-    # Because max waiting time is configured to be 5s (test_config.yml), exception is raised after 5s.
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/healthcheck_missing_start_period.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    # Because max waiting time is configured to be 5s, exception is raised after 5s.
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/healthcheck_missing_start_period.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True, measurement_wait_time_dependencies=5)
 
     with pytest.raises(RuntimeError) as e:
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
 
-    expected_exception = "Health check of dependent services of 'test-container-1' failed! Container 'test-container-2' is not healthy but 'starting' after waiting for 10 sec"
+    expected_exception = "Health check of dependent services of 'test-container-1' failed! Container 'test-container-2' is not healthy but 'starting' after waiting for 5 sec"
     assert str(e.value).startswith(expected_exception),\
         Tests.assertion_info(f"Exception: {expected_exception}", str(e.value))
 
@@ -529,7 +529,7 @@ def test_depends_on_healthcheck_error_container_unhealthy():
 def test_depends_on_healthcheck_error_max_waiting_time():
     # Test setup: Container would be healthy after 7 seconds, however, interval is set to 100s and there is no start interval.
     # Because max waiting time is configured to be 10s (test_config.yml), the healthcheck at 10s will never be executed.
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/healthcheck_error_max_waiting_time.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/healthcheck_error_max_waiting_time.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True, measurement_wait_time_dependencies=10)
 
     with pytest.raises(RuntimeError) as e:
         with Tests.RunUntilManager(runner) as context:

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -399,7 +399,7 @@ def test_depends_on_huge():
     assert_order(out.getvalue(), 'test-container-1', 'test-container-2')
 
 def test_depends_on_error_not_running():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/depends_on_error_not_running.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/depends_on_error_not_running.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True, measurement_wait_time_dependencies=10)
 
     with pytest.raises(RuntimeError) as e:
         with Tests.RunUntilManager(runner) as context:


### PR DESCRIPTION
This PR introduces more user configurations for the measurement.

For instance it is very helpful in developing to turn `system_check_threshhold` off on the cluster.

Also setting different baseline times and idle times is very helpful when wanting to have longer reference times.