### PR TITLE
Add direnv for automatic enabling of venv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+source venv/bin/activate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,37 @@ All contributions should be done via Pull Requests. We use the standard forking 
 
 Please see our: [Contribution Guidelines](https://docs.green-coding.org/docs/contributing/green-metrics-tool-contribution/)
 
+## Development Environment Setup
+
+### direnv (Optional)
+
+For automatic virtual environment activation, install [direnv](https://direnv.net/):
+
+```bash
+# Ubuntu/Debian
+sudo apt install direnv
+
+# macOS
+brew install direnv
+
+# Add to ~/.bashrc or ~/.zshrc
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+# or for zsh:
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+
+# Reload shell
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+After installing direnv, enable it for this project:
+
+```bash
+cd /path/to/green-metrics-tool
+direnv allow
+```
+
+Now the virtual environment will activate automatically when entering the project directory.
+
 ## Python conventions
 
 We adhere to standard ([PEP8][pep8]) python conventions for the most part.


### PR DESCRIPTION
I still sometimes forget to execute "source venv/bin/activate". This PR proposes an automatic way of executing it whenever you go into the directory using [direnv](https://direnv.net/).

<img width="891" height="181" alt="image" src="https://github.com/user-attachments/assets/b0f8fd33-3723-4a7e-b41a-9c36cd347d04" />
