### PR TITLE
Detect systemd cgroup path using cgroup name (instead of container id)

### DIFF
--- a/lib/c/Makefile
+++ b/lib/c/Makefile
@@ -2,8 +2,8 @@ CFLAGS = -O3 -Wall
 
 all: gmt-lib.o detect_cgroup_path.o
 
-gmt-lib.o: gmt-lib.c
+gmt-lib.o: gmt-lib.c gmt-lib.h
 	gcc -c $< $(CFLAGS) -o $@
 
-detect_cgroup_path.o: detect_cgroup_path.c
+detect_cgroup_path.o: detect_cgroup_path.c detect_cgroup_path.h
 	gcc -c $< $(CFLAGS) -o $@

--- a/lib/c/detect_cgroup_path.c
+++ b/lib/c/detect_cgroup_path.c
@@ -85,6 +85,15 @@ char* detect_cgroup_path(const char* controller, int user_id, const char* id) {
         return path;
     }
 
+    // Try cgroups v2 with systemd but non-slice mountpoints and with cgroup name instead of container id (used for debug purposes)
+    snprintf(path, PATH_MAX,
+             "/sys/fs/cgroup/system.slice/%s/%s",
+             id, controller);
+    fd = fopen(path, "r");
+    if (fd != NULL) {
+        fclose(fd);
+        return path;
+    }
 
     // If no valid path is found, free the allocated memory and error
     free(path);

--- a/lib/c/detect_cgroup_path.c
+++ b/lib/c/detect_cgroup_path.c
@@ -85,9 +85,9 @@ char* detect_cgroup_path(const char* controller, int user_id, const char* id) {
         return path;
     }
 
-    // Try cgroups v2 with systemd but non-slice mountpoints and with cgroup name instead of container id (used for debug purposes)
+    // Try cgroups v2 with full cgroup name (typically used for debug purposes)
     snprintf(path, PATH_MAX,
-             "/sys/fs/cgroup/system.slice/%s/%s",
+             "/sys/fs/cgroup/%s/%s",
              id, controller);
     fd = fopen(path, "r");
     if (fd != NULL) {

--- a/metric_providers/cpu/energy/rapl/msr/component/Makefile
+++ b/metric_providers/cpu/energy/rapl/msr/component/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/energy/rapl/msr/component/Makefile
+++ b/metric_providers/cpu/energy/rapl/msr/component/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
+LIB_C = ../../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lm -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/energy/rapl/msr/component/Makefile
+++ b/metric_providers/cpu/energy/rapl/msr/component/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/throttling/msr/component/Makefile
+++ b/metric_providers/cpu/throttling/msr/component/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/throttling/msr/component/Makefile
+++ b/metric_providers/cpu/throttling/msr/component/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lm -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lm -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/throttling/msr/component/Makefile
+++ b/metric_providers/cpu/throttling/msr/component/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/time/cgroup/container/Makefile
+++ b/metric_providers/cpu/time/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/cgroup/container/Makefile
+++ b/metric_providers/cpu/time/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/cgroup/container/Makefile
+++ b/metric_providers/cpu/time/cgroup/container/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/cgroup/system/Makefile
+++ b/metric_providers/cpu/time/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/cgroup/system/Makefile
+++ b/metric_providers/cpu/time/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/cgroup/system/Makefile
+++ b/metric_providers/cpu/time/cgroup/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/procfs/system/Makefile
+++ b/metric_providers/cpu/time/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/procfs/system/Makefile
+++ b/metric_providers/cpu/time/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/time/procfs/system/Makefile
+++ b/metric_providers/cpu/time/procfs/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/cgroup/container/Makefile
+++ b/metric_providers/cpu/utilization/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/cgroup/container/Makefile
+++ b/metric_providers/cpu/utilization/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/cgroup/container/Makefile
+++ b/metric_providers/cpu/utilization/cgroup/container/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/cgroup/system/Makefile
+++ b/metric_providers/cpu/utilization/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/cgroup/system/Makefile
+++ b/metric_providers/cpu/utilization/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/cgroup/system/Makefile
+++ b/metric_providers/cpu/utilization/cgroup/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/mach/system/Makefile
+++ b/metric_providers/cpu/utilization/mach/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/mach/system/Makefile
+++ b/metric_providers/cpu/utilization/mach/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/mach/system/Makefile
+++ b/metric_providers/cpu/utilization/mach/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/procfs/system/Makefile
+++ b/metric_providers/cpu/utilization/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/procfs/system/Makefile
+++ b/metric_providers/cpu/utilization/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/procfs/system/Makefile
+++ b/metric_providers/cpu/utilization/procfs/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/container/Makefile
+++ b/metric_providers/disk/io/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/container/Makefile
+++ b/metric_providers/disk/io/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/container/Makefile
+++ b/metric_providers/disk/io/cgroup/container/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/system/Makefile
+++ b/metric_providers/disk/io/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/system/Makefile
+++ b/metric_providers/disk/io/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/cgroup/system/Makefile
+++ b/metric_providers/disk/io/cgroup/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/procfs/system/Makefile
+++ b/metric_providers/disk/io/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/procfs/system/Makefile
+++ b/metric_providers/disk/io/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/io/procfs/system/Makefile
+++ b/metric_providers/disk/io/procfs/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/used/statvfs/system/Makefile
+++ b/metric_providers/disk/used/statvfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/used/statvfs/system/Makefile
+++ b/metric_providers/disk/used/statvfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/disk/used/statvfs/system/Makefile
+++ b/metric_providers/disk/used/statvfs/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/gpu/energy/nvidia/nvml/component/Makefile
+++ b/metric_providers/gpu/energy/nvidia/nvml/component/Makefile
@@ -1,5 +1,5 @@
 CFLAGS  = -O3 -Wall -Werror -I../../../../../../lib/c -I/usr/local/cuda-12.9/targets/x86_64-linux/include
 LDFLAGS = -L../../../../../../lib/c -lnvidia-ml -lc
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
 	gcc $(CFLAGS) ../../../../../../lib/c/gmt-lib.o $< $(LDFLAGS) -o $@

--- a/metric_providers/gpu/energy/nvidia/nvml/component/Makefile
+++ b/metric_providers/gpu/energy/nvidia/nvml/component/Makefile
@@ -1,5 +1,5 @@
 CFLAGS  = -O3 -Wall -Werror -I../../../../../../lib/c -I/usr/local/cuda-12.9/targets/x86_64-linux/include
 LDFLAGS = -L../../../../../../lib/c -lnvidia-ml -lc
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
 	gcc $(CFLAGS) ../../../../../../lib/c/gmt-lib.o $< $(LDFLAGS) -o $@

--- a/metric_providers/gpu/energy/nvidia/nvml/component/Makefile
+++ b/metric_providers/gpu/energy/nvidia/nvml/component/Makefile
@@ -1,5 +1,6 @@
-CFLAGS  = -O3 -Wall -Werror -I../../../../../../lib/c -I/usr/local/cuda-12.9/targets/x86_64-linux/include
-LDFLAGS = -L../../../../../../lib/c -lnvidia-ml -lc
+LIB_C = ../../../../../../lib/c
+CFLAGS  = -O3 -Wall -Werror -I$(LIB_C) -I/usr/local/cuda-12.9/targets/x86_64-linux/include
+LDFLAGS = -L$(LIB_C) -lnvidia-ml -lc
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
-	gcc $(CFLAGS) ../../../../../../lib/c/gmt-lib.o $< $(LDFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(CFLAGS) $(LIB_C)/gmt-lib.o $< $(LDFLAGS) -o $@

--- a/metric_providers/lmsensors/Makefile
+++ b/metric_providers/lmsensors/Makefile
@@ -4,11 +4,13 @@ GLIBLIB = $(shell pkg-config --libs glib-2.0)
 GLIBGLAGS = $(shell pkg-config --cflags glib-2.0)
 CFLAGS = -O3 -Wall -Werror -Llib -lsensors $(GLIBLIB) $(GLIBGLAGS) -I../../lib/c
 
-binary:
+$(PROGRAM): $(SOURCES) ../../lib/c/gmt-lib.o ../../lib/c/gmt-lib.h
 	gcc ../../lib/c/gmt-lib.o $(SOURCES) $(CFLAGS) -o $(PROGRAM)
+
+binary: $(PROGRAM)
 
 lint:
 	cpplint *.c *.h
 
-debug:
+debug: $(SOURCES) ../../lib/c/gmt-lib.o ../../lib/c/gmt-lib.h
 	gcc ../../lib/c/gmt-lib.o $(SOURCES) $(CFLAGS) -g -o $(PROGRAM)

--- a/metric_providers/lmsensors/Makefile
+++ b/metric_providers/lmsensors/Makefile
@@ -1,16 +1,17 @@
+LIB_C = ../../lib/c
 PROGRAM = metric-provider-binary
 SOURCES = source.c chips.c
 GLIBLIB = $(shell pkg-config --libs glib-2.0)
 GLIBGLAGS = $(shell pkg-config --cflags glib-2.0)
-CFLAGS = -O3 -Wall -Werror -Llib -lsensors $(GLIBLIB) $(GLIBGLAGS) -I../../lib/c
+CFLAGS = -O3 -Wall -Werror -Llib -lsensors $(GLIBLIB) $(GLIBGLAGS) -I$(LIB_C)
 
-$(PROGRAM): $(SOURCES) ../../lib/c/gmt-lib.o ../../lib/c/gmt-lib.h
-	gcc ../../lib/c/gmt-lib.o $(SOURCES) $(CFLAGS) -o $(PROGRAM)
+$(PROGRAM): $(SOURCES) $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $(SOURCES) $(CFLAGS) -o $(PROGRAM)
 
 binary: $(PROGRAM)
 
 lint:
 	cpplint *.c *.h
 
-debug: $(SOURCES) ../../lib/c/gmt-lib.o ../../lib/c/gmt-lib.h
-	gcc ../../lib/c/gmt-lib.o $(SOURCES) $(CFLAGS) -g -o $(PROGRAM)
+debug: $(SOURCES) $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $(SOURCES) $(CFLAGS) -g -o $(PROGRAM)

--- a/metric_providers/memory/energy/rapl/msr/component/Makefile
+++ b/metric_providers/memory/energy/rapl/msr/component/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/memory/energy/rapl/msr/component/Makefile
+++ b/metric_providers/memory/energy/rapl/msr/component/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
+LIB_C = ../../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lm -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/memory/energy/rapl/msr/component/Makefile
+++ b/metric_providers/memory/energy/rapl/msr/component/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/memory/used/cgroup/container/Makefile
+++ b/metric_providers/memory/used/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/cgroup/container/Makefile
+++ b/metric_providers/memory/used/cgroup/container/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/cgroup/container/Makefile
+++ b/metric_providers/memory/used/cgroup/container/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/cgroup/system/Makefile
+++ b/metric_providers/memory/used/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/cgroup/system/Makefile
+++ b/metric_providers/memory/used/cgroup/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/cgroup/system/Makefile
+++ b/metric_providers/memory/used/cgroup/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/procfs/system/Makefile
+++ b/metric_providers/memory/used/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/procfs/system/Makefile
+++ b/metric_providers/memory/used/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/memory/used/procfs/system/Makefile
+++ b/metric_providers/memory/used/procfs/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/network/io/cgroup/container/Makefile
+++ b/metric_providers/network/io/cgroup/container/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lc -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/container/Makefile
+++ b/metric_providers/network/io/cgroup/container/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/container/Makefile
+++ b/metric_providers/network/io/cgroup/container/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/system/Makefile
+++ b/metric_providers/network/io/cgroup/system/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lc -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
-	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h $(LIB_C)/detect_cgroup_path.o $(LIB_C)/detect_cgroup_path.h
+	gcc $(LIB_C)/gmt-lib.o $(LIB_C)/detect_cgroup_path.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/system/Makefile
+++ b/metric_providers/network/io/cgroup/system/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h ../../../../../lib/c/detect_cgroup_path.o ../../../../../lib/c/detect_cgroup_path.h
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/system/Makefile
+++ b/metric_providers/network/io/cgroup/system/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o
 	gcc ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/detect_cgroup_path.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/procfs/system/Makefile
+++ b/metric_providers/network/io/procfs/system/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
+LIB_C = ../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lc -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/network/io/procfs/system/Makefile
+++ b/metric_providers/network/io/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o ../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/network/io/procfs/system/Makefile
+++ b/metric_providers/network/io/procfs/system/Makefile
@@ -1,4 +1,4 @@
 CFLAGS = -O3 -Wall -Werror -lc -I../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@

--- a/metric_providers/psu/energy/ac/mcp/machine/Makefile
+++ b/metric_providers/psu/energy/ac/mcp/machine/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/ac/mcp/machine/Makefile
+++ b/metric_providers/psu/energy/ac/mcp/machine/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
+LIB_C = ../../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lm -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/ac/mcp/machine/Makefile
+++ b/metric_providers/psu/energy/ac/mcp/machine/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../../lib/c/gmt-lib.o ../../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
+++ b/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../../lib/c
 
-metric-provider-binary: source.c
+metric-provider-binary: source.c ../../../../../../../lib/c/gmt-lib.o
 	gcc ../../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
+++ b/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../../lib/c
 
-metric-provider-binary: source.c ../../../../../../../lib/c/gmt-lib.o
+metric-provider-binary: source.c ../../../../../../../lib/c/gmt-lib.o ../../../../../../../lib/c/gmt-lib.h
 	gcc ../../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
+++ b/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -O3 -Wall -Werror -lm -I../../../../../../../lib/c
+LIB_C = ../../../../../../../lib/c
+CFLAGS = -O3 -Wall -Werror -lm -I$(LIB_C)
 
-metric-provider-binary: source.c ../../../../../../../lib/c/gmt-lib.o ../../../../../../../lib/c/gmt-lib.h
-	gcc ../../../../../../../lib/c/gmt-lib.o $< $(CFLAGS) -o $@
+metric-provider-binary: source.c $(LIB_C)/gmt-lib.o $(LIB_C)/gmt-lib.h
+	gcc $(LIB_C)/gmt-lib.o $< $(CFLAGS) -o $@
 	sudo chown root $@
 	sudo chmod u+s $@


### PR DESCRIPTION
Closes https://github.com/green-coding-solutions/green-metrics-tool/issues/1267

The change was tested successfully:

<img width="1884" height="154" alt="image" src="https://github.com/user-attachments/assets/bd596676-29cb-42dd-9b2c-961126706f20" />

Between the two statements the binary was recompiled with the change introduced in this PR.

This PR includes changes to all Makefiles to add the missing dependency declarations. I had the problem, that re-compiling the metric-provider-binary lead to the message: "'metric-provider-binary' is up to date"
The changed `detect_cgroup_path.o` was not recognized due to the missing dependency declaration. I hope it is ok to include this change here. If not, let me know.