### PR TITLE
Document the usage of cgroup system metric providers

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -148,7 +148,29 @@ measurement:
 #        sampling_rate: 99
 #      memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
 #        sampling_rate: 99
+    #--- Cgroup system monitoring - These providers can be used to monitor background processes
 #      cpu.utilization.cgroup.system.provider.CpuUtilizationCgroupSystemProvider:
+#        sampling_rate: 99
+#        cgroups:
+#            "org.gnome.Shell@wayland.service":
+#                name: "Window Manager incl. X11"
+#            "session-2.scope":
+#                name: "GNOME Desktop"
+#      memory.used.cgroup.system.provider.MemoryUsedCgroupSystemProvider:
+#        sampling_rate: 99
+#        cgroups:
+#            "org.gnome.Shell@wayland.service":
+#                name: "Window Manager incl. X11"
+#            "session-2.scope":
+#                name: "GNOME Desktop"
+#      disk.io.cgroup.system.provider.DiskIoCgroupSystemProvider:
+#        sampling_rate: 99
+#        cgroups:
+#            "org.gnome.Shell@wayland.service":
+#                name: "Window Manager incl. X11"
+#            "session-2.scope":
+#                name: "GNOME Desktop"
+#      network.io.cgroup.system.provider.NetworkIoCgroupSystemProvider:
 #        sampling_rate: 99
 #        cgroups:
 #            "org.gnome.Shell@wayland.service":

--- a/metric_providers/cpu/time/cgroup/container/source.c
+++ b/metric_providers/cpu/time/cgroup/container/source.c
@@ -56,7 +56,7 @@ static void output_stats(container_t *containers, int length) {
 
 static int parse_containers(container_t** containers, char* containers_string) {
     if(containers_string == NULL) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
 
@@ -83,7 +83,7 @@ static int parse_containers(container_t** containers, char* containers_string) {
     }
 
     if(length == 0) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
     return length;
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         case 'h':
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
-            printf("\t-s      : string of container IDs separated by comma\n");
+            printf("\t-s      : string of container IDs or cgroup names separated by comma\n");
             printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
             printf("\t-c      : check system and exit\n");
             printf("\n");

--- a/metric_providers/cpu/time/cgroup/system/README.md
+++ b/metric_providers/cpu/time/cgroup/system/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/cpu-time-cgroup-system/ for details

--- a/metric_providers/cpu/utilization/cgroup/container/README.md
+++ b/metric_providers/cpu/utilization/cgroup/container/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-Please see https://docs.green-coding.io/docs/measuring/metric-providers/cpu-utilization-cgroup-container-provider/ for details
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/cpu-utilization-cgroup-container/ for details

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -139,7 +139,7 @@ static void output_stats(container_t* containers, int length) {
 
 static int parse_containers(container_t** containers, char* containers_string) {
     if(containers_string == NULL) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
 
@@ -166,7 +166,7 @@ static int parse_containers(container_t** containers, char* containers_string) {
     }
 
     if(length == 0) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
 
@@ -230,7 +230,7 @@ int main(int argc, char **argv) {
         case 'h':
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
-            printf("\t-s      : string of container IDs separated by comma\n");
+            printf("\t-s      : string of container IDs or cgroup names separated by comma\n");
             printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n\n");
             printf("\t-c      : check system and exit\n");
             printf("\n");

--- a/metric_providers/cpu/utilization/cgroup/system/README.md
+++ b/metric_providers/cpu/utilization/cgroup/system/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-Please see https://docs.green-coding.io/docs/measuring/metric-providers/cpu-utilization-cgroup-system-provider/ for details
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/cpu-utilization-cgroup-system/ for details

--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -112,7 +112,7 @@ static void output_stats(container_t *containers, int length) {
 
 static int parse_containers(container_t** containers, char* containers_string) {
     if(containers_string == NULL) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
 
@@ -140,7 +140,7 @@ static int parse_containers(container_t** containers, char* containers_string) {
     }
 
     if(length == 0) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
     return length;
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
         case 'h':
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
-            printf("\t-s      : string of container IDs separated by comma\n");
+            printf("\t-s      : string of container IDs or cgroup names separated by comma\n");
             printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
             printf("\t-c      : check system and exit\n");
             printf("\n");

--- a/metric_providers/disk/io/cgroup/system/README.md
+++ b/metric_providers/disk/io/cgroup/system/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-Please see https://docs.green-coding.io/docs/measuring/metric-providers/disk-io-cgroup-container/ for details
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/disk-io-cgroup-system/ for details

--- a/metric_providers/memory/used/cgroup/container/source.c
+++ b/metric_providers/memory/used/cgroup/container/source.c
@@ -115,7 +115,7 @@ static void output_stats(container_t *containers, int length) {
 
 static int parse_containers(container_t** containers, char* containers_string) {
     if(containers_string == NULL) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
 
@@ -144,7 +144,7 @@ static int parse_containers(container_t** containers, char* containers_string) {
     }
 
     if(length == 0) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
     return length;
@@ -190,7 +190,7 @@ int main(int argc, char **argv) {
         case 'h':
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
-            printf("\t-s      : string of container IDs separated by comma\n");
+            printf("\t-s      : string of container IDs or cgroup names separated by comma\n");
             printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
             printf("\t-c      : check system and exit\n");
             printf("\n");

--- a/metric_providers/memory/used/cgroup/system/README.md
+++ b/metric_providers/memory/used/cgroup/system/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-Please see https://docs.green-coding.io/docs/measuring/metric-providers/memory-used-cgroup-container/ for details
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/memory-used-cgroup-system/ for details

--- a/metric_providers/network/io/cgroup/container/source.c
+++ b/metric_providers/network/io/cgroup/container/source.c
@@ -130,7 +130,7 @@ static void output_stats(container_t *containers, int length) {
 
 static int parse_containers(container_t** containers, char* containers_string) {
     if(containers_string == NULL) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
 
@@ -166,7 +166,7 @@ static int parse_containers(container_t** containers, char* containers_string) {
     }
 
     if(length == 0) {
-        fprintf(stderr, "Please supply at least one container id with -s XXXX\n");
+        fprintf(stderr, "Please supply at least one container id or cgroup name with -s XXXX\n");
         exit(1);
     }
     return length;
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
         case 'h':
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
-            printf("\t-s      : string of container IDs separated by comma\n");
+            printf("\t-s      : string of container IDs or cgroup names separated by comma\n");
             printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
             printf("\t-c      : check system and exit\n");
             printf("\n");

--- a/metric_providers/network/io/cgroup/system/README.md
+++ b/metric_providers/network/io/cgroup/system/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-Please see https://docs.green-coding.io/docs/measuring/metric-providers/network-io-cgroup-container/ for details
+Please see https://docs.green-coding.io/docs/measuring/metric-providers/network-io-cgroup-system/ for details


### PR DESCRIPTION
Corresponding changes in documentation repo: https://github.com/green-coding-solutions/documentation/pull/117

Related to discussion in issue https://github.com/green-coding-solutions/green-metrics-tool/issues/1267

New metric providers in config.yml were tested successfully together with PR https://github.com/green-coding-solutions/green-metrics-tool/pull/1270, with one exception: the cgroup system network provider has an issue (I will create a new PR for that).