### PR TITLE
Fix NetworkIoCgroupSystemProvider doesn't create a value column

### DIFF
--- a/metric_providers/network/io/cgroup/system/provider.py
+++ b/metric_providers/network/io/cgroup/system/provider.py
@@ -1,5 +1,6 @@
 import os
 
+from lib import utils
 from metric_providers.cgroup import CgroupMetricProvider
 
 class NetworkIoCgroupSystemProvider(CgroupMetricProvider):
@@ -13,3 +14,31 @@ class NetworkIoCgroupSystemProvider(CgroupMetricProvider):
             skip_check=skip_check,
             cgroups=cgroups,
         )
+
+    def _parse_metrics(self, df):
+        df = super()._parse_metrics(df) # sets detail_name
+
+        df = df.sort_values(by=['detail_name', 'time'], ascending=True)
+
+        df['transmitted_bytes_intervals'] = df.groupby(['detail_name'])['transmitted_bytes'].diff()
+        df['transmitted_bytes_intervals'] = df.groupby('detail_name')['transmitted_bytes_intervals'].transform(utils.df_fill_mean) # fill first NaN value resulted from diff()
+
+        df['received_bytes_intervals'] = df.groupby(['detail_name'])['received_bytes'].diff()
+        df['received_bytes_intervals'] = df.groupby('detail_name')['received_bytes_intervals'].transform(utils.df_fill_mean) # fill first NaN value resulted from diff()
+
+        # we checked at ingest if it contains NA values. So NA can only occur if group diff resulted in only one value.
+        # Since one value is useless for us we drop the row
+        df.dropna(inplace=True)
+
+        if (df['received_bytes_intervals'] < 0).any():
+            raise ValueError('NetworkIoCgroupSystemProvider data column received_bytes_intervals had negative values.')
+
+        if (df['transmitted_bytes_intervals'] < 0).any():
+            raise ValueError('NetworkIoCgroupSystemProvider data column transmitted_bytes_intervals had negative values.')
+
+        df['value'] = df['received_bytes_intervals'] + df['transmitted_bytes_intervals']
+        df['value'] = df.value.astype('int64')
+
+        df = df.drop(columns=['received_bytes','transmitted_bytes', 'transmitted_bytes_intervals', 'received_bytes_intervals'])  # clean up
+
+        return df


### PR DESCRIPTION
Issue: NetworkIoCgroupSystemProvider doesn't implement the `_parse_metrics` method to create a value column, while NetworkIoCgroupContainerProvider does. The base metric processing code expects all metric providers to have a single value column.

Fix: The NetworkIoCgroupSystemProvider uses the same `_parse_metrics` method as the working NetworkIoCgroupContainerProvider. This creates the required value column by combining received and transmitted bytes intervals.

See successful test in https://github.com/green-coding-solutions/green-metrics-tool/pull/1273