### PR TITLE
Add check if container image architecture is compatible

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -803,12 +803,11 @@ class ScenarioRunner:
                         raise OSError(f"Docker pull failed. Is your image name correct and are you connected to the internet: {service['image']}")
 
                 # Check architecture compatibility after pull/verification
-                is_compatible, img_arch, host_arch, error_msg = self._check_image_architecture_compatibility(service['image'])
+                is_compatible, _, _, error_msg = self._check_image_architecture_compatibility(service['image'])
                 if not is_compatible:
                     print(TerminalColors.FAIL, f"ERROR: {error_msg}", TerminalColors.ENDC)
                     raise RuntimeError(error_msg)
 
-                print(f"Image {service['image']} architecture ({img_arch}) is compatible with host ({host_arch})")
 
                 # tagging must be done in pull and local case, so we can get the correct container later
                 subprocess.run(['docker', 'tag', service['image'], tmp_img_name], check=True)

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -289,7 +289,12 @@ class ScenarioRunner:
 
             # Get host architecture
             host_arch = platform.machine()
-            # Normalize architecture names
+            # Normalize architecture names to match Docker's naming conventions
+            # Docker uses 'amd64', 'arm64', 'arm' while host systems use 'x86_64', 'aarch64', 'armv7l'
+            # These 3 mappings cover the vast majority of modern container deployments:
+            # - amd64: Dominant on servers/desktops
+            # - arm64: Apple Silicon, AWS Graviton, etc.
+            # - arm: Embedded/IoT devices, Raspberry Pi
             arch_mapping = {
                 'x86_64': 'amd64',
                 'aarch64': 'arm64',

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -6,6 +6,7 @@ import re
 import os
 import platform
 import subprocess
+import unittest.mock
 import yaml
 
 from contextlib import redirect_stdout, redirect_stderr
@@ -454,6 +455,51 @@ def test_runner_run_invalidated():
     else:
         assert 'Development switches or skip_system_checks were active for this run. This will likely produce skewed measurement data.\n' in messages
 
+
+## Architecture compatibility check
+def test_architecture_compatibility_check_compatible():
+    """Test that architecture check passes when image and host architectures match"""
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/basic_stress.yml',
+                          skip_system_checks=True, dev_no_sleeps=True, dev_no_save=True)
+
+    # Test with a compatible architecture (this should match the current host)
+    is_compatible, img_arch, host_arch, error_msg = runner._check_image_architecture_compatibility('ubuntu:20.04')
+
+    # Since we're testing on the same architecture as ubuntu:20.04, this should be compatible
+    assert is_compatible, Tests.assertion_info('Architecture should be compatible', f"img_arch: {img_arch}, host_arch: {host_arch}")
+    assert error_msg == "", Tests.assertion_info('No error message for compatible architectures', error_msg)
+    assert img_arch is not None and img_arch != "unknown", Tests.assertion_info('Image architecture should be detected', img_arch)
+    assert host_arch is not None and host_arch != "unknown", Tests.assertion_info('Host architecture should be detected', host_arch)
+
+def test_architecture_compatibility_check_incompatible():
+    """Test that architecture check fails appropriately with incompatible architectures"""
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/basic_stress.yml',
+                          skip_system_checks=True, dev_no_sleeps=True, dev_no_save=True)
+
+    # Mock an incompatible architecture scenario by temporarily modifying the method
+    def mock_incompatible_arch(image_name):
+        return False, "arm64", "amd64", f"Architecture mismatch for image '{image_name}': Image is built for arm64 but host platform is amd64."
+
+    with unittest.mock.patch.object(runner, '_check_image_architecture_compatibility', side_effect=mock_incompatible_arch):
+        is_compatible, _, _, error_msg = runner._check_image_architecture_compatibility('test_image')
+
+        assert not is_compatible, Tests.assertion_info('Architecture should be incompatible', is_compatible)
+        assert "arm64" in error_msg, Tests.assertion_info('Error should mention arm64', error_msg)
+        assert "amd64" in error_msg, Tests.assertion_info('Error should mention amd64', error_msg)
+        assert "Architecture mismatch" in error_msg, Tests.assertion_info('Error should mention architecture mismatch', error_msg)
+
+def test_architecture_compatibility_check_nonexistent_image():
+    """Test that architecture check handles nonexistent images gracefully"""
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/basic_stress.yml',
+                          skip_system_checks=True, dev_no_sleeps=True, dev_no_save=True)
+
+    # Test with a nonexistent image
+    is_compatible, img_arch, host_arch, error_msg = runner._check_image_architecture_compatibility('nonexistent_image_12345')
+
+    assert not is_compatible, Tests.assertion_info('Nonexistent image should be incompatible', is_compatible)
+    assert img_arch == "unknown", Tests.assertion_info('Image architecture should be unknown', img_arch)
+    assert host_arch == "unknown", Tests.assertion_info('Host architecture should be unknown', host_arch)
+    assert "Failed to inspect image architecture" in error_msg, Tests.assertion_info('Error should mention inspection failure', error_msg)
 
     ## rethink this one
 def wip_test_verbose_provider_boot():


### PR DESCRIPTION
Two of my colleagues have already encountered the issue of unintentionally using an ARM image as part of a usage scenario for a GMT measurement. Needless to say, the measurement run failed. However, the error message was confusing:

> Health check of container "kadai-postgres" failed terminally with status "unhealthy" after 0s. Health check errors: {"Status":"unhealthy","FailingStreak":0,"Log":[]}

I think it would make sense to add a compatibility check, so a proper error message can be provided.

With this PR the run would fail early directly after the image pull and the error message would be
> Architecture mismatch for image 'kadai-postgres': Image is built for arm64 but host platform is amd64.
