### PR TITLE
Fix output of container logs with the "print-logs" flag

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1893,8 +1893,10 @@ class ScenarioRunner:
             self.__start_measurement = None
             self.__start_measurement_seconds = None
             self.__notes_helper = Notes()
-
-        self.__stdout_logs.clear()
+        else:
+            # Only clear logs when continuing measurement (debugging mode)
+            # For normal completion, preserve logs for --print-logs functionality
+            self.__stdout_logs.clear()
         self.__phases.clear()
         self.__end_measurement = None
         self.__join_default_network = False

--- a/runner.py
+++ b/runner.py
@@ -237,10 +237,13 @@ if __name__ == '__main__':
         error_helpers.log_error('Base exception occured in runner.py', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
     finally:
         if args.print_logs and runner:
-            for container_id_outer, std_out in runner.get_logs().items():
-                print(f"Container logs of '{container_id_outer}':")
-                print(std_out)
-                print('\n-----------------------------\n')
+            logs = runner._get_logs()
+            if logs:
+                print("Container logs:")
+                for log_entry in logs:
+                    print(log_entry)
+                    print('-----------------------------')
+                print()
 
         # Last thing before we exit is to shutdown the DB Pool
         DB().shutdown()

--- a/tests/data/usage_scenarios/capture_logs.yml
+++ b/tests/data/usage_scenarios/capture_logs.yml
@@ -1,0 +1,21 @@
+---
+name: Capture Logs
+author: David Kopp
+description: Capture logs from stdout and sterr
+
+services:
+  test-container:
+    type: container
+    image: alpine
+    log-stdout: true
+    log-stderr: true
+
+flow:
+  - name: Logging
+    container: test-container
+    commands:
+      - type: console
+        command: echo "Test log message" && echo "Test error message" >&2
+        shell: /bin/sh
+        log-stdout: true
+        log-stderr: true

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -497,3 +497,31 @@ def wip_test_verbose_provider_boot():
         diff = (notes[i+1][0] - notes[i][0])/1000000
         assert 9.9 <= diff <= 10.1, \
             Tests.assertion_info('10s apart', f"time difference of notes: {diff}s")
+
+## --print-logs
+def test_print_logs_flag():
+    """Test that --print-logs flag actually prints logs when they exist"""
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/capture_logs.yml',
+                          skip_system_checks=True, dev_cache_build=True, dev_no_sleeps=True,
+                          dev_no_metrics=True, dev_no_phase_stats=True, dev_no_save=True)
+
+    runner.run()
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        logs = runner._get_logs()
+        if logs:
+            print("Container logs:")
+            for log_entry in logs:
+                print(log_entry)
+                print('-----------------------------')
+            print()
+
+    output = out.getvalue()
+    logs = runner._get_logs()
+    assert logs, "No logs were captured from the scenario"
+    assert "Container logs:" in output
+    assert "test-container" in output
+    assert "Test log message" in output
+    assert "Test error message" in output
+    assert "-----------------------------" in output


### PR DESCRIPTION
The argument `--print-logs` did not work anymore. There were multiple issues. This PR fixes them.

[Docs](https://docs.green-coding.io/docs/measuring/runner-switches/):
> `--print-logs` Prints the container and process logs to stdout