### PR TITLE
Make scripts more portable by change the shebang

### DIFF
--- a/.devcontainer/codespace-setup.sh
+++ b/.devcontainer/codespace-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 /workspaces/green-metrics-tool/install_linux.sh -p testpw -a "https://${CODESPACE_NAME}-9142.app.github.dev" -m "https://${CODESPACE_NAME}-9143.app.github.dev" -T -I -S -L -z -Z -f

--- a/.devcontainer/on-start.sh
+++ b/.devcontainer/on-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 etc_hosts_line_1="127.0.0.1 green-coding-postgres-container"

--- a/docker/auxiliary-containers/build-containers.sh
+++ b/docker/auxiliary-containers/build-containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # get list of changed folders

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $(uname) != "Linux" ]]; then

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $(uname) != "Darwin" ]]; then

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GREEN='\033[0;32m'

--- a/run-template.sh
+++ b/run-template.sh
@@ -1,5 +1,5 @@
-# we are omitting the shebang as we want just the shell of the user to execute it and not limit to bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 if [ -z "${1-}" ]; then
   echo "Please supply mode as first argument. Either 'ai' or 'website'"
@@ -9,24 +9,24 @@ fi
 
 GMT_ROOT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 
-if [[ "$1" == "website" ]]; then
+if [ "$1" = "website" ]; then
     if [ -z "${2-}" ]; then
       echo "Please supply the website as second argument with scheme. Example: https://www.example.com"
       exit 1
     fi
 
-    if [[ -n "${3-}" && "${3-}" == '--quick' ]]; then
+    if [ -n "${3-}" ] && [ "${3-}" = '--quick' ]; then
         python3 "${GMT_ROOT_DIR}/runner.py" --uri ${GMT_ROOT_DIR} --filename 'templates/website/usage_scenario.yml' --variables __GMT_VAR_PAGE__="${2}" __GMT_VAR_SLEEP__=0 --dev-no-sleeps --skip-system-checks --dev-cache-build --dev-no-optimizations ${4-} ${5-}
     else
         python3 "${GMT_ROOT_DIR}/runner.py" --uri ${GMT_ROOT_DIR} --filename 'templates/website/usage_scenario.yml' --variables __GMT_VAR_PAGE__="${2}" __GMT_VAR_SLEEP__=5 ${3-} ${4-}
     fi
 
-elif [[ "$1" == "ai" ]]; then
+elif [ "$1" = "ai" ]; then
     if [ -z "${2-}" ]; then
       echo "Please supply the prompt as second argument in single quotes. Example: 'How cool is the GMT?' "
       exit 1
     fi
-    if [[ -n "${3-}" && "${3-}" == '--quick' ]]; then
+    if [ -n "${3-}" ] && [ "${3-}" = '--quick' ]; then
         python3 "${GMT_ROOT_DIR}/runner.py" --uri ${GMT_ROOT_DIR} --filename 'templates/ai/usage_scenario.yml' --variables __GMT_VAR_MODEL__="gemma3:1b" __GMT_VAR_PROMPT__="${2}"  --dev-no-sleeps --skip-system-checks --dev-cache-build --dev-no-optimizations --allow-unsafe ${4-} ${5-}
     else
         python3 "${GMT_ROOT_DIR}/runner.py" --uri ${GMT_ROOT_DIR} --filename 'templates/ai/usage_scenario.yml' --variables __GMT_VAR_MODEL__="gemma3:1b" __GMT_VAR_PROMPT__="${2}" --allow-unsafe ${3-} ${4-}

--- a/tests/bisect-script.sh
+++ b/tests/bisect-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Run git bisect beforehand with
 # $ git bisect start

--- a/tests/edit-etc-hosts.sh
+++ b/tests/edit-etc-hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 etc_hosts_line_1="127.0.0.1 test-green-coding-postgres-container test-green-coding-redis-container"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Starting test containers..."
 ./start-test-containers.sh &>/dev/null &
 sleep 2

--- a/tests/start-test-containers.sh
+++ b/tests/start-test-containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "Running docker containers..."

--- a/tests/stop-test-containers.sh
+++ b/tests/stop-test-containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "Stopping docker containers..."

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -387,7 +387,7 @@ def test_reporters_still_running():
 ## Using template
 def test_template_website():
     ps = subprocess.run(
-        ['bash', os.path.normpath(f"{GMT_DIR}/run-template.sh"), 'website', 'https://www.google.de', '--quick', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/test-config.yml"],
+        ['sh', os.path.normpath(f"{GMT_DIR}/run-template.sh"), 'website', 'https://www.google.de', '--quick', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/test-config.yml"],
         check=True,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,

--- a/tools/import_backup.sh
+++ b/tools/import_backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tools/kill_gmt.sh
+++ b/tools/kill_gmt.sh
@@ -1,4 +1,4 @@
-#!/usr/env bash
+#!/usr/bin/env bash
 
 read -p "This will kill all processes know to be forked by GMT. It may also kill other similar named processes and should only be used on dedicated measurement nodes. In case you are looged in remotely it will also kill the current terminal session, so you must log in again. Do you want to continue? (y/N) : " kill_gmt
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "Please note that this script does not remove pre-requisites like gcc, docker, curl etc. as it does not want to alter the system state"


### PR DESCRIPTION
Converting the shebang `#!/bin/bash` to `#!/usr/bin/env bash` as discussed in https://github.com/green-coding-solutions/green-metrics-tool/pull/1290#discussion_r2284557897.

In addition to that I added a shebang to `run-template.sh` and changed the script to make it compatible with `sh` (which should be available everywhere). If you don't like the change and want me to revert the commit let me know.