### PR TITLE
Bare metal tests sysbox

### DIFF
--- a/docker/Dockerfile-gunicorn
+++ b/docker/Dockerfile-gunicorn
@@ -1,6 +1,13 @@
 FROM python:3.13.7-slim-bookworm
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
 WORKDIR /var/www/startup/
 COPY requirements.txt requirements.txt
 RUN python -m venv venv

--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -54,6 +54,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-gunicorn
+      args:
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTPS_PROXY}
+        NO_PROXY: ${NO_PROXY}
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+        no_proxy: ${no_proxy}
     container_name: green-coding-gunicorn-container
     init: true
     depends_on:

--- a/tests/data/bare-metal/Dockerfile
+++ b/tests/data/bare-metal/Dockerfile
@@ -1,0 +1,16 @@
+FROM nestybox/ubuntu-noble-systemd-docker@sha256:8b1c4409fe89bc110e1e468767074fe4403ba6bb2d1b34881fec5df8b6c2f9c3
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN \
+    apt-get update && \
+    apt-get install -y curl git make gcc python3 python3-pip python3-venv sudo && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV USER=root
+USER root
+
+WORKDIR /root
+
+# ENTRYPOINT ['/sbin/init', '--log-level=err'] # is used from base image. Here just for clarity.

--- a/tests/data/bare-metal/README.md
+++ b/tests/data/bare-metal/README.md
@@ -1,0 +1,24 @@
+## What is this directory?
+
+We are using the *usage_scenario* to run the GMT tests itself in GMT.
+
+This can be done by creating a Docker container that has systemd and Docker-in-Docker (DinD) enabled.
+
+This Docker container can only be run with a matching container runtime. We use [sysbox](https://github.com/nestybox/sysbox).
+
+In order to run the tests the user must have a new `docker allowed_run_args`  entry set:
+- `--runtime sysbox-runc`
+
+Example:
+```json
+{
+    ...
+            "orchestrators": {
+                "docker": {
+                    "allowed_run_args": [
+                        '--runtime docker-args'
+                    ]
+                }
+            },
+    ...
+```

--- a/tests/data/bare-metal/README.md
+++ b/tests/data/bare-metal/README.md
@@ -22,3 +22,11 @@ Example:
             },
     ...
 ```
+
+Alternatively the `sysbox-runc` runtime can be set as the default runtime for the machine. This is the current setup that we are using.
+
+## Caveats
+
+The `Dockerfile` can currently not be built with the GMT as our build isolation layer *kaniko* has some issues with removing certain files. It sets certain paths as read-only and thus the build fails.
+
+Thus we are using `greencoding/ubuntu-systemd-docker` as the image to pull, which is effectively the Dockerfile.

--- a/tests/data/bare-metal/usage_scenario.yml
+++ b/tests/data/bare-metal/usage_scenario.yml
@@ -1,0 +1,56 @@
+---
+
+name: GMT Tests native
+author: Arne Tarara <arne@green-coding.io>
+description: Run GMT Tests inside systemd and DinD compatible sysbox-runc container
+
+services:
+  ubuntu-systemd-docker:
+    type: container
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+flow:
+  - name: Pull GMT
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: git clone https://github.com/green-coding-solutions/green-metrics-tool
+  - name: Install GMT base
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: cd ~/green-metrics-tool && ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -B -T -L -z -f -j -d -g -e github-actions-test --nvidia-gpu --ai
+        shell: bash
+
+  - name: Install GMT dev requirements
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: cd ~/green-metrics-tool && source venv/bin/activate && python3 -m pip install -r requirements-dev.txt && playwright install --with-deps firefox && cd tests && python3 setup-test-env.py --no-docker-build --ee
+        shell: bash
+
+  - name: Start Test Containers
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: cd ~/green-metrics-tool/tests && source ../venv/bin/activate && ./start-test-containers.sh -d
+        shell: bash
+
+  - name: Run Tests
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: cd ~/green-metrics-tool/tests && python3 -m pytest -vv -rA
+        shell: bash
+
+  - name: Stop Test Containers
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: cd ~/green-metrics-tool/tests && ./stop-test-containers.sh
+        shell: bash
+
+
+

--- a/tests/data/bare-metal/usage_scenario_enterprise.yml
+++ b/tests/data/bare-metal/usage_scenario_enterprise.yml
@@ -17,6 +17,22 @@ flow:
         command: git clone https://github.com/green-coding-solutions/green-metrics-tool --depth 1 --single-branch --recurse-submodules --shallow-submodules
         log-stdout: true
 
+  - name: Setup SSH keys
+    container: ubuntu-systemd-docker
+    commands:
+      - type: console
+        command: |
+          cd ~/green-metrics-tool
+          sed -i "s#git@github.com:green-coding-solutions/gmt-enterprise.git#git@github-custom:green-coding-solutions/gmt-enterprise.git#" .gitmodules
+          git submodule sync
+          mkdir -p ~/.ssh
+          echo '__GMT_VAR_SSH_PRIVATE_KEY__' > ~/.ssh/id_github
+          chmod 0600 ~/.ssh/id_github
+          echo -e '\nHost github-custom\n    HostName github.com\n    User git\n    IdentityFile ~/.ssh/id_github' >> ~/.ssh/config
+        shell: bash
+        log-stdout: true
+
+
   - name: Install GMT base
     container: ubuntu-systemd-docker
     commands:
@@ -24,9 +40,10 @@ flow:
         # we set here --nvidia-gpu altough the M4 machine does not have any. We want to test if the headers can be correctly downloaded
         command: |
           cd ~/green-metrics-tool
-          ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -T -L -z -f -j -d -g --nvidia-gpu
+          ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -T -L -z -f -j -d -g -e bare-metal-M4-tests --no-ai --nvidia-gpu
         shell: bash
         log-stdout: true
+
 
   - name: Install GMT dev requirements
     container: ubuntu-systemd-docker
@@ -48,7 +65,7 @@ flow:
         command: |
           source venv/bin/activate
           cd ~/green-metrics-tool/tests
-          python3 setup-test-env.py
+          python3 setup-test-env.py --ee
         shell: bash
         log-stdout: true
 
@@ -64,6 +81,7 @@ flow:
         shell: bash
         log-stdout: true
 
+
   - name: Run Tests
     container: ubuntu-systemd-docker
     commands:
@@ -73,7 +91,7 @@ flow:
           python3 -m pytest -vv -rA
         shell: bash
         log-stdout: true
-        log-stdout: true
+
 
   - name: Stop Test Containers
     container: ubuntu-systemd-docker


### PR DESCRIPTION
This PR introduces the functionality to test the unit-tests of GMT itself inside of a specially crafted [sysbox](https://github.com/nestybox/sysbox) container.

Tests can only be run when the *sysbox-runc* runtime is active for the docker host. See Readme for details