### PR TITLE
Blocking joining or creating pre-defined networks

### DIFF
--- a/tests/data/usage_scenarios/network_host_create.yml
+++ b/tests/data/usage_scenarios/network_host_create.yml
@@ -1,0 +1,22 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+  test-container:
+    type: container
+    image: gcb_stress
+    build:
+      context: ../stress-application
+
+networks:
+  - host
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/data/usage_scenarios/network_host_join.yml
+++ b/tests/data/usage_scenarios/network_host_join.yml
@@ -1,0 +1,21 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+  test-container:
+    type: container
+    image: gcb_stress
+    build:
+      context: ../stress-application
+    networks:
+      - host
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -576,6 +576,22 @@ def test_network_alias_added():
     assert '--network-alias test-alias' in docker_run_command
 
 
+def test_network_host_join_blocked():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/network_host_join.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    with pytest.raises(ValueError) as e,Tests.RunUntilManager(runner) as context:
+        context.run_until('setup_services')
+
+    assert "Docker network host is restricted in GMT and cannot be joined. If running in CLI mode or if you have cluster capabilities try again with --allow-unsafe." in str(e.value)
+
+
+def test_network_host_creation_blocked():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/network_host_create.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)
+    with pytest.raises(ValueError) as e,Tests.RunUntilManager(runner) as context:
+        context.run_until('setup_networks')
+
+    assert "Pre-defined networks like host, none and bridge cannot be created with Docker orchestrator. They already exist and can only be joined." in str(e.value)
+
+
 
 def test_cmd_entrypoint():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/test_docker_compose_entrypoint.yml', skip_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True)


### PR DESCRIPTION
This PR addresses a potential security vulnerability in GMT.

Currently no check is done if the network that will be joined might have pre-defined elevated capabilities / is un-isolated.

To our knowledge this is only the case for the *host* network.

This PR restricts joining the network to `--allow-unsafe` use cases.

Furthermore creation of pre-defined networks is blocked (although docker-cli would also disallow it). But the error is nicer in GMT and we are unsure how other orchestrators in the future like podman handle this.

Joining the `bridge` network is to our understanding no security issue and thus allowed.