### PR TITLE
Remove html escape

### DIFF
--- a/api/eco_ci.py
+++ b/api/eco_ci.py
@@ -5,7 +5,7 @@ from fastapi import Request, Response, Depends
 from fastapi.responses import ORJSONResponse
 from fastapi.exceptions import RequestValidationError
 
-from api.api_helpers import authenticate, html_escape_multi, get_connecting_ip, convert_value
+from api.api_helpers import authenticate, get_connecting_ip, convert_value
 from api.object_specifications import CI_Measurement
 
 import anybadge
@@ -29,8 +29,6 @@ async def post_ci_measurement_add(
     measurement: CI_Measurement,
     user: User = Depends(authenticate) # pylint: disable=unused-argument
     ):
-
-    measurement = html_escape_multi(measurement)
 
     params = [measurement.energy_uj, measurement.repo, measurement.branch,
             measurement.workflow, measurement.run_id, measurement.label, measurement.source, measurement.cpu,

--- a/api/main.py
+++ b/api/main.py
@@ -14,7 +14,7 @@ from starlette.responses import RedirectResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.datastructures import Headers as StarletteHeaders
 
-from api.api_helpers import authenticate, html_escape_multi
+from api.api_helpers import authenticate
 
 from lib.global_config import GlobalConfig
 from lib import error_helpers
@@ -144,7 +144,6 @@ async def get_user_settings(user: User = Depends(authenticate)):
 
 @app.put('/v1/user/setting')
 async def update_user_setting(setting: UserSetting, user: User = Depends(authenticate)):
-    setting = html_escape_multi(setting)
 
     try:
         user.change_setting(setting.name, setting.value)

--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -14,7 +14,7 @@ import anybadge
 from api.object_specifications import Software, JobChange
 from api.api_helpers import (ORJSONResponseObjKeep, add_phase_stats_statistics,
                          determine_comparison_case,get_comparison_details,
-                         html_escape_multi, get_phase_stats, get_phase_stats_object, check_run_failed,
+                         get_phase_stats, get_phase_stats_object, check_run_failed,
                          is_valid_uuid, convert_value, get_timeline_query,
                          get_run_info, get_machine_list, get_artifact, store_artifact,
                          authenticate, check_int_field_api)
@@ -168,8 +168,7 @@ async def get_notes(run_id, user: User = Depends(authenticate)):
     if data is None or data == []:
         return Response(status_code=204) # No-Content
 
-    escaped_data = [html_escape_multi(note) for note in data]
-    return ORJSONResponseObjKeep({'success': True, 'data': escaped_data})
+    return ORJSONResponseObjKeep({'success': True, 'data': data})
 
 
 @router.get('/v1/warnings/{run_id}')
@@ -192,8 +191,7 @@ async def get_warnings(run_id, user: User = Depends(authenticate)):
     if data is None or data == []:
         return Response(status_code=204)
 
-    escaped_data = [html_escape_multi(note) for note in data]
-    return ORJSONResponseObjKeep({'success': True, 'data': escaped_data})
+    return ORJSONResponseObjKeep({'success': True, 'data': data})
 
 
 @router.get('/v1/network/{run_id}')
@@ -213,8 +211,7 @@ async def get_network(run_id, user: User = Depends(authenticate)):
     params = (user.is_super_user(), user.visible_users(), run_id)
     data = DB().fetch_all(query, params=params)
 
-    escaped_data = html_escape_multi(data)
-    return ORJSONResponseObjKeep({'success': True, 'data': escaped_data})
+    return ORJSONResponseObjKeep({'success': True, 'data': data})
 
 
 @router.get('/v1/repositories')
@@ -262,9 +259,7 @@ async def get_repositories(uri: str | None = None, branch: str | None = None, ma
     if data is None or data == []:
         return Response(status_code=204) # No-Content
 
-    escaped_data = [html_escape_multi(run) for run in data]
-
-    return ORJSONResponse({'success': True, 'data': escaped_data})
+    return ORJSONResponse({'success': True, 'data': data})
 
 
 @router.get('/v1/runs', deprecated=True)
@@ -330,9 +325,7 @@ async def get_runs(uri: str | None = None, branch: str | None = None, machine_id
     if data is None or data == []:
         return Response(status_code=204) # No-Content
 
-    escaped_data = [html_escape_multi(run) for run in data]
-
-    return ORJSONResponse({'success': True, 'data': escaped_data})
+    return ORJSONResponse({'success': True, 'data': data})
 
 
 # Just copy and paste if we want to deprecate URLs
@@ -714,8 +707,6 @@ async def get_watchlist(user: User = Depends(authenticate)):
 @router.post('/v1/software/add')
 async def software_add(software: Software, user: User = Depends(authenticate)):
 
-    software = html_escape_multi(software)
-
     if software.name is None or software.name.strip() == '':
         raise RequestValidationError('Name is empty')
 
@@ -798,8 +789,6 @@ async def get_run(run_id: str, user: User = Depends(authenticate)):
 
     if data is None or data == []:
         return Response(status_code=204) # No-Content
-
-    data = html_escape_multi(data)
 
     return ORJSONResponseObjKeep({'success': True, 'data': data})
 

--- a/frontend/js/ci-index.js
+++ b/frontend/js/ci-index.js
@@ -81,7 +81,7 @@ const getCIRunsTable = async (el, url, include_uri=true, include_button=true, se
     const columns = [
         {
             data: 0, title: 'Workflow', render: function(el,type,row) {
-                return `<a href="/ci.html?repo=${row[0]}&branch=${row[1]}&workflow=${row[2]}">${row[5]}</a>`;
+                return `<a href="/ci.html?repo=${escapeString(row[0])}&branch=${escapeString(row[1])}&workflow=${escapeString(row[2])}">${escapeString(row[5])}</a>`;
             }
         },
         {data : 1, title: 'Branch'},
@@ -94,7 +94,7 @@ const getCIRunsTable = async (el, url, include_uri=true, include_button=true, se
         },
         {
             title: 'Carbon', render: function(el,type,row) {
-                return `<img src="${API_URL}/v1/ci/badge/get?repo=${row[0]}&branch=${row[1]}&workflow=${row[2]}&mode=totals&metric=carbon&duration_days=30" onerror="this.src='/images/no-data-badge.webp'">`;
+                return `<img src="${API_URL}/v1/ci/badge/get?repo=${escapeString(row[0])}&branch=${escapeString(row[1])}&workflow=${escapeString(row[2])}&mode=totals&metric=carbon&duration_days=30" onerror="this.src='/images/no-data-badge.webp'">`;
             }
         },
 

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -154,7 +154,7 @@ const displayStatsTable = (stats) => {
         const label_stats_avg_node = document.createElement("tr")
         const label = row[21];
         label_stats_avg_node.innerHTML += `
-                                        <td class="td-index" data-tooltip="Averages per step '${label}'"  data-position="top left">${label} <i class="question circle icon small"></i></td>
+                                        <td class="td-index" data-tooltip="Averages per step '${escapeString(label)}'"  data-position="top left">${escapeString(label)} <i class="question circle icon small"></i></td>
                                         <td class=" td-index">${numberFormatter.format(row[0]/1000000)} J (± ${numberFormatter.format(row[3])}%)</td>
                                         <td class=" td-index">${numberFormatter.format(row[4]/1000000)} s (± ${numberFormatter.format(row[7])}%)</td>
                                         <td class=" td-index">${numberFormatter.format(row[8])}% (± ${numberFormatter.format(row[11])}%%)</td>
@@ -166,7 +166,7 @@ const displayStatsTable = (stats) => {
 
         const label_stats_total_node = document.createElement("tr")
         label_stats_total_node.innerHTML += `
-                                        <td class="td-index" data-tooltip="Totals per step '${label}'"  data-position="top left">${label} <i class="question circle icon small"></i></td>
+                                        <td class="td-index" data-tooltip="Totals per step '${escapeString(label)}'"  data-position="top left">${escapeString(label)} <i class="question circle icon small"></i></td>
                                         <td class=" td-index">${numberFormatter.format(row[0]/1000000)} J (± ${numberFormatter.format(row[3])}%)</td>
                                         <td class=" td-index">${numberFormatter.format(row[4]/1000000)} s (± ${numberFormatter.format(row[7])}%)</td>
                                         <td class=" td-index">${numberFormatterLong.format(row[17]/1000000)} gCO2e (± ${numberFormatter.format(row[19])}%)</td>
@@ -196,10 +196,10 @@ const displayRunDetailsTable = (measurements, repo) => {
         const run_id_esc = escapeString(run_id)
 
         if(source == 'github') {
-            run_link = `https://github.com/${repo}/actions/runs/${run_id_esc}`;
+            run_link = `https://github.com/${escapeString(repo)}/actions/runs/${run_id_esc}`;
         }
         else if (source == 'gitlab') {
-            run_link = `https://gitlab.com/${repo}/-/pipelines/${run_id_esc}`
+            run_link = `https://gitlab.com/${escapeString(repo)}/-/pipelines/${run_id_esc}`
         }
 
         const run_link_node = `<a href="${run_link}" target="_blank">${run_id_esc}</a>`
@@ -216,7 +216,7 @@ const displayRunDetailsTable = (measurements, repo) => {
                             <td class="td-index">${escapeString(cpu)}</td>\
                             <td class="td-index">${escapeString(cpu_avg)}%</td>
                             <td class="td-index">${numberFormatter.format(duration_us/1000000)} s</td>
-                            <td class="td-index" ${escapeString(tooltip)}>${escapeString(short_hash)}</td>\
+                            <td class="td-index" title="${escapeString(commit_hash)}">${escapeString(short_hash)}</td>\
                             <td class="td-index">${city_string}</td>
                             <td class="td-index">${escapeString(carbon_intensity_g)} gCO2/kWh</td>
                             <td class="td-index" title="${carbon_ug/1000000}">${escapeString(numberFormatterLong.format(carbon_ug/1000000))} gCO2e</td>
@@ -232,9 +232,9 @@ const getBadges = async (repo, branch, workflow_id) => {
     try {
         const link_node = document.createElement("a")
         const img_node = document.createElement("img")
-        img_node.src = `${API_URL}/v1/ci/badge/get?repo=${repo}&branch=${branch}&workflow=${workflow_id}`
+        img_node.src = `${API_URL}/v1/ci/badge/get?repo=${escapeString(repo)}&branch=${escapeString(branch)}&workflow=${escapeString(workflow_id)}`
         img_node.onerror = function() {this.src='/images/no-data-badge.webp'}
-        link_node.href = `${METRICS_URL}/ci.html?repo=${repo}&branch=${branch}&workflow=${workflow_id}`
+        link_node.href = `${METRICS_URL}/ci.html?repo=${escapeString(repo)}&branch=${escapeString(branch)}&workflow=${escapeString(workflow_id)}`
         link_node.rel = 'noopener'
         link_node.target = '_blank'
 
@@ -290,7 +290,7 @@ const getBadges = async (repo, branch, workflow_id) => {
 
 const getMeasurementsAndStats = async (repo, branch, workflow_id, start_date, end_date) => {
 
-    const query_string=`repo=${repo}&branch=${branch}&workflow=${workflow_id}&start_date=${start_date}&end_date=${end_date}`;
+    const query_string=`repo=${escapeString(repo)}&branch=${escapeString(branch)}&workflow=${escapeString(workflow_id)}&start_date=${start_date}&end_date=${end_date}`;
     const [measurements, stats] = await Promise.all([
         makeAPICall(`/v1/ci/measurements?${query_string}`),
         makeAPICall(`/v1/ci/stats?${query_string}`)
@@ -357,23 +357,23 @@ const refreshView = async (repo, branch, workflow_id, chart_instance) => {
 
 const populateRunInfos = async (repo, branch, source, workflow_name, workflow_id) => {
 
-    document.querySelector('#ci-data-branch').innerText =  branch;
-    document.querySelector('#ci-data-workflow-id').innerText =  workflow_id;
+    document.querySelector('#ci-data-branch').innerText =  escapeString(branch);
+    document.querySelector('#ci-data-workflow-id').innerText =  escapeString(workflow_id);
 
     if (workflow_name == '' || workflow_name == null) {
         workflow_name = workflow_id ;
     }
-    document.querySelector('#ci-data-workflow').innerText =  workflow_name;
+    document.querySelector('#ci-data-workflow').innerText =  escapeString(workflow_name);
 
     let repo_link = ''
     if(source == 'github') {
-        repo_link = `https://github.com/${repo}`;
+        repo_link = `https://github.com/${escapeString(repo)}`;
     }
     else if(source == 'gitlab') {
-        repo_link = `https://gitlab.com/${repo}`;
+        repo_link = `https://gitlab.com/${escapeString(repo)}`;
     }
 
-    const repo_link_node = `<a href="${repo_link}" target="_blank">${repo}</a>`
+    const repo_link_node = `<a href="${repo_link}" target="_blank">${escapeString(repo)}</a>`
     document.querySelector('#ci-data-repo').innerHTML =  repo_link_node;
 }
 

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -43,7 +43,7 @@ const fillWarnings = (warnings) => {
     const container = document.querySelector('#run-warnings');
     const ul = container.querySelector('ul');
     unique_warnings.forEach(w => {
-        ul.insertAdjacentHTML('beforeend', `<li>${w}</li>`);
+        ul.insertAdjacentHTML('beforeend', `<li>${escapeString(w)}</li>`);
     });
     container.classList.remove('hidden');
 };
@@ -78,7 +78,7 @@ $(document).ready( (e) => {
 
         let comparison_identifiers = phase_stats_data.comparison_identifiers.map((el) => replaceRepoIcon(el));
         comparison_identifiers = comparison_identifiers.join(' vs. ')
-        document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Comparison Type</strong></td><td>${phase_stats_data.comparison_case}</td></tr>`)
+        document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Comparison Type</strong></td><td>${escapeString(phase_stats_data.comparison_case)}</td></tr>`)
         document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>Number of runs compared</strong></td><td>${run_count}</td></tr>`)
         if (phase_stats_data.comparison_case == 'Machine') {
             const regex = /(\d+)\s+vs\.\s+(\d+)/;
@@ -87,15 +87,15 @@ $(document).ready( (e) => {
             if (match) {
                 const num1 = parseInt(match[1], 10); // First number
                 const num2 = parseInt(match[2], 10); // Second number
-                document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${num1} (${GMT_MACHINES[num1]}) vs. ${num2} (${GMT_MACHINES[num2]})</td></tr>`)
+                document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(phase_stats_data.comparison_case)}</strong></td><td>${num1} (${escapeString(GMT_MACHINES[num1])}) vs. ${num2} (${escapeString(GMT_MACHINES[num2])})</td></tr>`)
             } else {
-                document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${GMT_MACHINES[comparison_identifiers] || comparison_identifiers}</td></tr>`)
+                document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(phase_stats_data.comparison_case)}</strong></td><td>${escapeString(GMT_MACHINES[comparison_identifiers] || comparison_identifiers)}</td></tr>`)
             }
         } else {
-            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${phase_stats_data.comparison_case}</strong></td><td>${comparison_identifiers}</td></tr>`)
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(phase_stats_data.comparison_case)}</strong></td><td>${comparison_identifiers}</td></tr>`)
         }
         Object.keys(phase_stats_data['common_info']).forEach(function(key) {
-            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${key}</strong></td><td>${phase_stats_data['common_info'][key]}</td></tr>`)
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(key)}</strong></td><td>${escapeString(phase_stats_data['common_info'][key])}</td></tr>`)
           });
 
         document.querySelector('#loader-compare-meta').remove();

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -141,7 +141,7 @@ async function getRepositories(sort_by = 'date') {
         let uri_link = replaceRepoIcon(uri);
 
         if (uri.startsWith("http")) {
-            uri_link = `${uri_link} <a href="${uri}"><i class="icon external alternate"></i></a>`;
+            uri_link = `${uri_link} <a href="${escapeString(uri)}"><i class="icon external alternate"></i></a>`;
         }
 
         let row = table_body.insertRow()
@@ -152,7 +152,7 @@ async function getRepositories(sort_by = 'date') {
                     <i class="dropdown icon"></i> ${uri_link}
                     <span class="ui label float-right"><i class="clock icon"></i> ${dateToYMD(new Date(last_run), short=true)}</span>
                   </div>
-                  <div class="content" data-uri="${uri}">
+                  <div class="content" data-uri="${escapeString(uri)}">
                       <table class="ui celled striped table"></table>
                   </div>
                 </div>
@@ -191,9 +191,9 @@ const getRunsTable = async (el, url, include_uri=true, include_button=true, sear
                 else if(row[10] == null) el = `${el} (in progress 🔥)`;
 
 
-                if(row[5] != 0) el = `${el} <span class="ui yellow horizontal label" title="${row[5]}">Warnings</span>`;
+                if(row[5] != 0) el = `${el} <span class="ui yellow horizontal label" title="${escapeString(row[5])}">Warnings</span>`;
 
-                return `<a href="/stats.html?id=${row[0]}" target="_blank">${el}</a>`
+                return `<a href="/stats.html?id=${row[0]}" target="_blank">${escapeString(el)}</a>`
             },
         },
     ]
@@ -206,21 +206,21 @@ const getRunsTable = async (el, url, include_uri=true, include_button=true, sear
                     let uri_link = replaceRepoIcon(el);
 
                     if (el.startsWith("http")) {
-                        uri_link = `${uri_link} <a href="${el}"><i class="icon external alternate"></i></a>`;
+                        uri_link = `${uri_link} <a href="${escapeString(el)}"><i class="icon external alternate"></i></a>`;
                     }
                     return uri_link
                 },
         })
     }
 
-    columns.push({ data: 3, title: '<i class="icon code branch"></i>Branch'});
+    columns.push({ data: 3, title: '<i class="icon code branch"></i>Branch', render: (el, type, row) => escapeString(el) });
 
     columns.push({
         data: 9,
         title: '<i class="icon history"></i>Commit</th>',
         render: function(el, type, row) {
           // Modify the content of the "Name" column here
-          return el == null ? null : `${el.substr(0,3)}...${el.substr(-3,3)}`
+          return el == null ? null : `${escapeString(el.substr(0,3))}...${escapeString(el.substr(-3,3))}`
         },
     });
 
@@ -228,12 +228,12 @@ const getRunsTable = async (el, url, include_uri=true, include_button=true, sear
         data: 6,
         title: '<i class="icon file alternate"></i>Filename',
         render: function(el, type, row) {
-            const usage_scenario_variables = Object.entries(row[7]).map(([k, v]) => `<span class="ui label">${k}=${v}</span>`);
-            return `${el} ${usage_scenario_variables.join(' ')}`
+            const usage_scenario_variables = Object.entries(row[7]).map(([k, v]) => `<span class="ui label">${escapeString(k)}=${escapeString(v)}</span>`);
+            return `${escapeString(el)} ${usage_scenario_variables.join(' ')}`
         }
     });
-    columns.push({ data: 8, title: '<i class="icon laptop code"></i>Machine</th>' });
-    columns.push({ data: 4, title: '<i class="icon calendar"></i>Last run</th>', render: (el, type, row) => el == null ? '-' : `${dateToYMD(new Date(el))}<br><a href="/timeline.html?uri=${row[2]}&branch=${row[3]}&machine_id=${row[12]}&filename=${row[6]}&metrics=key" class="ui teal horizontal label  no-wrap"><i class="ui icon clock"></i>History &nbsp;</a>` });
+    columns.push({ data: 8, title: '<i class="icon laptop code"></i>Machine</th>', render: (el, type, row) => escapeString(el) });
+    columns.push({ data: 4, title: '<i class="icon calendar"></i>Last run</th>', render: (el, type, row) => el == null ? '-' : `${dateToYMD(new Date(el))}<br><a href="/timeline.html?uri=${escapeString(row[2])}&branch=${escapeString(row[3])}&machine_id=${row[12]}&filename=${escapeString(row[6])}&metrics=key" class="ui teal horizontal label  no-wrap"><i class="ui icon clock"></i>History &nbsp;</a>` });
 
     columns.push({
         data: 0,

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -87,7 +87,7 @@ const fetchAndFillRunData = async (url_params) => {
 
     for (const item in run_data) {
         if (item == 'machine_id') {
-            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${run_data?.[item]} (${GMT_MACHINES[run_data?.[item]] || run_data?.[item]})</td></tr>`);
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td>${escapeString(run_data?.[item])} (${escapeString(GMT_MACHINES[run_data?.[item]] || run_data?.[item])})</td></tr>`);
         } else if (item == 'runner_arguments') {
             fillRunTab('#runner-arguments', run_data[item]); // recurse
         } else if (item == 'machine_specs') {
@@ -99,7 +99,7 @@ const fetchAndFillRunData = async (url_params) => {
             if (Object.keys(run_data[item]).length > 0) {
                 const container = document.querySelector("#usage-scenario-variables ul");
                 for (const key in run_data[item]) {
-                    container.insertAdjacentHTML('beforeend', `<li><span class="ui label">${key}=${run_data[item][key]}</span></li>`)
+                    container.insertAdjacentHTML('beforeend', `<li><span class="ui label">${escapeString(key)}=${escapeString(run_data[item][key])}</span></li>`)
                 }
             } else {
                 document.querySelector("#usage-scenario-variables").insertAdjacentHTML('beforeend', `N/A`)
@@ -115,23 +115,23 @@ const fetchAndFillRunData = async (url_params) => {
         }  else if(item == 'commit_hash') {
             if (run_data?.[item] == null) continue; // some old runs did not save it
             let commit_link = buildCommitLink(run_data);
-            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td><a href="${commit_link}" target="_blank">${run_data?.[item]}</a></td></tr>`)
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td><a href="${escapeString(commit_link)}" target="_blank">${escapeString(run_data?.[item])}</a></td></tr>`)
         } else if(item == 'name' || item == 'filename' || item == 'branch') {
-            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${run_data?.[item]}</td></tr>`)
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td>${escapeString(run_data?.[item])}</td></tr>`)
         } else if(item == 'failed' && run_data?.[item] == true) {
             document.querySelector('#run-failed').classList.remove('hidden');
         } else if(item == 'start_measurement' || item == 'end_measurement') {
-            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td title="${run_data?.[item]}">${new Date(run_data?.[item] / 1e3)}</td></tr>`)
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td title="${escapeString(run_data?.[item])}">${new Date(run_data?.[item] / 1e3)}</td></tr>`)
         } else if(item == 'created_at' ) {
-            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td title="${run_data?.[item]}">${new Date(run_data?.[item])}</td></tr>`)
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td title="${escapeString(run_data?.[item])}">${new Date(run_data?.[item])}</td></tr>`)
         } else if(item == 'gmt_hash') {
-            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td><a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${run_data?.[item]}">${run_data?.[item]}</a></td></tr>`);
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td><a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${escapeString(run_data?.[item])}">${escapeString(run_data?.[item])}</a></td></tr>`);
         } else if(item == 'uri') {
-            let entry = run_data?.[item];
-            if(run_data?.[item].indexOf('http') === 0) entry = `<a href="${run_data?.[item]}">${run_data?.[item]}</a>`;
-            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${entry}</td></tr>`);
+            let entry = escapeString(run_data?.[item]);
+            if(run_data?.[item].indexOf('http') === 0) entry = `<a href="${escapeString(run_data?.[item])}">${escapeString(run_data?.[item])}</a>`;
+            document.querySelector('#run-data-top').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td>${entry}</td></tr>`);
         } else {
-            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${item}</strong></td><td>${run_data?.[item]}</td></tr>`)
+            document.querySelector('#run-data-accordion').insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(item)}</strong></td><td>${escapeString(run_data?.[item])}</td></tr>`)
         }
     }
 
@@ -163,11 +163,11 @@ const fillRunTab = async (selector, data, parent = '') => {
 
         if(data[item] != null && typeof data[item] == 'object') {
             if (parent == '') {
-                document.querySelector(selector).insertAdjacentHTML('beforeend', `<tr><td><strong><h2>${item}</h2></strong></td><td></td></tr>`)
+                document.querySelector(selector).insertAdjacentHTML('beforeend', `<tr><td><strong><h2>${escapeString(item)}</h2></strong></td><td></td></tr>`)
             }
             fillRunTab(selector, data[item], `${item}.`)
         } else {
-            document.querySelector(selector).insertAdjacentHTML('beforeend', `<tr><td><strong>${parent}${item}</strong></td><td>${data?.[item]}</td></tr>`)
+            document.querySelector(selector).insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(parent)}${escapeString(item)}</strong></td><td>${escapeString(data?.[item])}</td></tr>`)
         }
     }
 }
@@ -337,11 +337,11 @@ const renderBadges = async (url_params, phase_stats) => {
         badge_container.innerHTML += `
             <div class="inline field">
                 <a href="${METRICS_URL}/stats.html?id=${url_params['id']}">
-                    <img src="${API_URL}/v1/badge/single/${url_params['id']}?metric=${metric_name}" loading="lazy">
+                    <img src="${API_URL}/v1/badge/single/${url_params['id']}?metric=${escapeString(metric_name)}" loading="lazy">
                 </a>
                 <a class="copy-badge"><i class="copy icon"></i></a>
                 <div class="ui left pointing blue basic label">
-                    ${METRIC_MAPPINGS[metric_name]['explanation']}
+                    ${escapeString(METRIC_MAPPINGS[metric_name]['explanation'])}
                 </div>
             </div>
             <hr class="ui divider"></hr>`;
@@ -391,7 +391,7 @@ const fetchAndFillNetworkIntercepts = async (url_params) => {
     } else {
         for (const item of network.data) {
             const date = (new Date(Number(item[2]))).toLocaleString();
-            document.querySelector("#network-intercepts").insertAdjacentHTML('beforeend', `<tr><td><strong>${date}</strong></td><td>${item[3]}</td><td>${item[4]}</td></tr>`)
+            document.querySelector("#network-intercepts").insertAdjacentHTML('beforeend', `<tr><td><strong>${escapeString(date)}</strong></td><td>${escapeString(item[3])}</td><td>${escapeString(item[4])}</td></tr>`)
         }
     }
 }
@@ -428,16 +428,16 @@ const fetchAndFillOptimizationsData = async (url_params) => {
 
     optimizations.data.forEach(optimization => {
         let optimizationHTML = optimizationTemplate
-            .replace("{{header}}", optimization[0])
-            .replace("{{label}}", optimization[1])
-            .replace("{{label_colour}}", optimization[2])
-            .replace("{{description}}", optimization[5])
-            .replace("{{subsystem}}", optimization[3])
-            .replace("{{subsystem_icon}}", optimization[4])
+            .replace("{{header}}", escapeString(optimization[0]))
+            .replace("{{label}}", escapeString(optimization[1]))
+            .replace("{{label_colour}}", escapeString(optimization[2]))
+            .replace("{{description}}", escapeString(optimization[5]))
+            .replace("{{subsystem}}", escapeString(optimization[3]))
+            .replace("{{subsystem_icon}}", escapeString(optimization[4]))
 
         if (optimization[6]){
             optimizationHTML = optimizationHTML.replace("{{link}}", `
-            <a class="ui mini icon primary basic button" href="${optimization[6]}">
+            <a class="ui mini icon primary basic button" href="${escapeString(optimization[6])}">
                 <i class="angle right icon"></i>
             </a>`);
         }else{
@@ -521,12 +521,12 @@ const fetchAndFillAIData = async (url_params) => {
 
     ai_data.forEach(d => {
         let optimizationHTML = aiTemplate
-            .replace("{{function_name}}", d.name)
-            .replace("{{rating}}", d.rating)
-            .replace("{{filename}}", d.filename)
-            .replace("{{code}}", d.code)
-            .replace("{{model}}", d.model)
-            .replace("{{color}}", d.color)
+            .replace("{{function_name}}", escapeString(d.name))
+            .replace("{{rating}}", escapeString(d.rating))
+            .replace("{{filename}}", escapeString(d.filename))
+            .replace("{{code}}", escapeString(d.code))
+            .replace("{{model}}", escapeString(d.model))
+            .replace("{{color}}", escapeString(d.color))
             .replace("{{ret_val}}", (d.ret_val || '').replace(/\n/g, '<br>'))
 
         const optimizationElement = document.createElement("div");
@@ -605,7 +605,7 @@ const fetchAndFillWarnings = async (url_params) => {
     const container = document.querySelector('#run-warnings');
     const ul = container.querySelector('ul');
     warnings.data.forEach(w => {
-        ul.insertAdjacentHTML('beforeend', `<li>${w[1]}</li>`);
+        ul.insertAdjacentHTML('beforeend', `<li>${escapeString(w[1])}</li>`);
     });
     container.classList.remove('hidden');
 }

--- a/frontend/js/status.js
+++ b/frontend/js/status.js
@@ -39,38 +39,38 @@ $(document).ready(function () {
             searching: false,
             columns: [
                 { data: 0, title: 'ID'},
-                { data: 1, title: 'Name'},
+                { data: 1, title: 'Name', render: (el) => escapeString(el)},
                 { data: 2, title: 'Available', render: function(el) {
                     return (el == true) ? '<i class="ui label mini empty green circular"></i>': '<i class="ui label mini empty red circular"></i>';
                 }},
                 { data: 5, title: 'Jobs processing'},
                 { data: 3, title: 'State', render: function(el) {
                     switch (el) {
-                            case 'job_no': return `${el} <span data-inverted data-tooltip="No job currently in queue"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'job_start': return `${el} <span data-inverted data-tooltip="Current Job has started running"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'job_error': return `${el} <span data-inverted data-tooltip="Last job failed"></i></span>`;
-                            case 'job_end': return `${el} <span data-inverted data-tooltip="Current job ended"></i></span>`;
-                            case 'maintenance_start': return `${el} <span data-inverted data-tooltip="Maintenance after job has started"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'maintenance_end': return `${el} <span data-inverted data-tooltip="Maintenance after job has finished"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'measurement_control_start': return `${el} <span data-inverted data-tooltip="Periodic Measurement Control job has started"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'cooldown': return `${el} <span data-inverted data-tooltip="Machine is currently cooling down to base temperature"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'measurement_control_error': return `${el} <span data-inverted data-tooltip="Last periodic Measurement Control job has failed"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'measurement_control_end': return `${el} <span data-inverted data-tooltip="Periodic Measurement Control job has finished"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'job_no': return `${escapeString(el)} <span data-inverted data-tooltip="No job currently in queue"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'job_start': return `${escapeString(el)} <span data-inverted data-tooltip="Current Job has started running"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'job_error': return `${escapeString(el)} <span data-inverted data-tooltip="Last job failed"></i></span>`;
+                            case 'job_end': return `${escapeString(el)} <span data-inverted data-tooltip="Current job ended"></i></span>`;
+                            case 'maintenance_start': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has started"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'maintenance_end': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has finished"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'measurement_control_start': return `${escapeString(el)} <span data-inverted data-tooltip="Periodic Measurement Control job has started"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'cooldown': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is currently cooling down to base temperature"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'measurement_control_error': return `${escapeString(el)} <span data-inverted data-tooltip="Last periodic Measurement Control job has failed"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'measurement_control_end': return `${escapeString(el)} <span data-inverted data-tooltip="Periodic Measurement Control job has finished"><i class="ui question circle icon fluid"></i></span>`;
                             case undefined: // fallthrough
                             case null: return '-';
                     }
-                    return el;
+                    return escapeString(el);
                 }},
                 { data: 6, title: 'GMT version', render: function(el, type, row) {
                     if (el == null) return '-';
 
-                    return `<a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${el}" title="${dateToYMD(new Date(row[7]))}">${`${el.substr(0,3)}...${el.substr(-3,3)}`}</a>`;
+                    return `<a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${escapeString(el)}" title="${dateToYMD(new Date(row[7]))}">${`${escapeString(el.substr(0,3))}...${escapeString(el.substr(-3,3))}`}</a>`;
 
                 }},
                 { data: 13, title: 'Details', render: function(el, type, row) {
                     return `<button class="ui icon button show-machine-configuration">
                               <i class="ui info icon"></i>
-                              <span class="machine-configuration-details" style="display:none; ">${JSON.stringify(el, undefined, 2)}</span>
+                              <span class="machine-configuration-details" style="display:none; ">${escapeString(JSON.stringify(el, undefined, 2))}</span>
                             </button>`;
                 }},
                 { data: 8, title: 'Base temp (°)'},
@@ -101,18 +101,18 @@ $(document).ready(function () {
             data: jobs_data?.data,
             columns: [
                 { data: 0, title: 'ID'},
-                { data: 2, title: 'Name', render: (name, type, row) => row[1] == null ? name : `<a href="/stats.html?id=${row[1]}">${name}</a>`  },
-                { data: 3, title: 'Url'},
+                { data: 2, title: 'Name', render: (name, type, row) => row[1] == null ? escapeString(name) : `<a href="/stats.html?id=${row[1]}">${escapeString(name)}</a>`  },
+                { data: 3, title: 'Url', render: (el) => escapeString(el)},
                 {
                     data: 4,
                     title: 'Filename',
                     render: function(el, type, row) {
-                        const usage_scenario_variables = Object.entries(row[5]).map(([k, v]) => `<span class="ui label">${k}=${v}</span>`);
-                        return `${el} ${usage_scenario_variables.join(' ')}`
+                        const usage_scenario_variables = Object.entries(row[5]).map(([k, v]) => `<span class="ui label">${escapeString(k)}=${escapeString(v)}</span>`);
+                        return `${escapeString(el)} ${usage_scenario_variables.join(' ')}`
                     }},
-                { data: 6, title: 'Branch'},
-                { data: 7, title: 'Machine'},
-                { data: 8, title: 'State', class: "job-state"},
+                { data: 6, title: 'Branch', render: (el) => escapeString(el)},
+                { data: 7, title: 'Machine', render: (el) => escapeString(el)},
+                { data: 8, title: 'State', class: "job-state", render: (el) => escapeString(el)},
                 { data: 10, title: 'Created at', render: (el) => el == null ? '-' : dateToYMD(new Date(el)) },
                 { data: 9, title: 'Updated at', render: (el) => el == null ? '-' : dateToYMD(new Date(el)) },
                 { data: 8,  title: '-', class: "job-action",  render: (el, type, row) => {

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -178,25 +178,25 @@ const loadCharts = async () => {
         let badge = `
                 <div class="field">
                     <div class="header title">
-                        <strong>${getPretty(series[my_series].metric_name, 'clean_name')}</strong> via
-                        <strong>${getPretty(series[my_series].metric_name, 'source')}</strong>
-                         - ${series[my_series].detail_name}
-                        <i data-tooltip="${getPretty(series[my_series].metric_name, 'explanation')}" data-position="bottom center" data-inverted>
+                        <strong>${escapeString(getPretty(series[my_series].metric_name, 'clean_name'))}</strong> via
+                        <strong>${escapeString(getPretty(series[my_series].metric_name, 'source'))}</strong>
+                         - ${escapeString(series[my_series].detail_name)}
+                        <i data-tooltip="${escapeString(getPretty(series[my_series].metric_name, 'explanation'))}" data-position="bottom center" data-inverted>
                             <i class="question circle icon link"></i>
                         </i>
                     </div>
-                    <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?${buildQueryParams()}" target="_blank"><img src="${API_URL}/v1/badge/timeline?${buildQueryParams(skip_dates=false,metric_override=series[my_series].metric_name,detail_name=series[my_series].detail_name)}&unit=joules"></a></span>
+                    <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?${buildQueryParams()}" target="_blank"><img src="${API_URL}/v1/badge/timeline?${buildQueryParams(skip_dates=false,metric_override=series[my_series].metric_name,detail_name=series[my_series].detail_name)}"&unit=joules"></a></span>
                     <a class="copy-badge"><i class="copy icon"></i></a>
                 </div>
                 <p></p>`
         document.querySelector("#badge-container").innerHTML += badge;
 
 
-        const element = createChartContainer("#chart-container", `${getPretty(series[my_series].metric_name, 'clean_name')} via ${getPretty(series[my_series].metric_name, 'source')} - ${series[my_series].detail_name} <i data-tooltip="${getPretty(series[my_series].metric_name, 'explanation')}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
+        const element = createChartContainer("#chart-container", `${escapeString(getPretty(series[my_series].metric_name, 'clean_name'))} via ${escapeString(getPretty(series[my_series].metric_name, 'source'))} - ${escapeString(series[my_series].detail_name)} <i data-tooltip="${escapeString(getPretty(series[my_series].metric_name, 'explanation'))}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></i>`);
 
         const chart_instance = echarts.init(element);
 
-        const my_values = generateColoredValues(series[my_series].values, $('.radio-coloring:checked').val());
+        const my_values = generateColoredValues(series[my_series].values, $(".radio-coloring:checked").val());
 
         let data_series = [{
             name: my_series,
@@ -207,7 +207,7 @@ const loadCharts = async () => {
             data: my_values,
             markLine: {
                 precision: 4, // generally annoying that precision is by default 2. Wrong AVG if values are smaller than 0.001 and no autoscaling!
-                data: [ {type: "average",label: {formatter: "AVG:\n{c}"}}]
+                data: [ {type: "average",label: {formatter: "AVG:\n{c}"}}] 
             }
         }]
 
@@ -217,15 +217,15 @@ const loadCharts = async () => {
             triggerOn: 'click',
             formatter: function (params, ticket, callback) {
                 if(series[params.seriesName]?.notes == null) return; // no notes for the MovingAverage
-                return `<strong>${series[params.seriesName].notes[params.dataIndex].run_name}</strong><br>
+                return `<strong>${escapeString(series[params.seriesName].notes[params.dataIndex].run_name)}</strong><br>
                         run_id: <a href="/stats.html?id=${series[params.seriesName].notes[params.dataIndex].run_id}"  target="_blank">${series[params.seriesName].notes[params.dataIndex].run_id}</a><br>
                         date: ${series[params.seriesName].notes[params.dataIndex].created_at}<br>
-                        metric_name: ${params.seriesName}<br>
-                        phase: ${series[params.seriesName].notes[params.dataIndex].phase}<br>
+                        metric_name: ${escapeString(params.seriesName)}<br>
+                        phase: ${escapeString(series[params.seriesName].notes[params.dataIndex].phase)}<br>
                         value: ${numberFormatter.format(series[params.seriesName].values[params.dataIndex].value)}<br>
                         commit_timestamp: ${series[params.seriesName].notes[params.dataIndex].commit_timestamp}<br>
-                        commit_hash: <a href="${$("#uri").text()}/commit/${series[params.seriesName].notes[params.dataIndex].commit_hash}" target="_blank">${series[params.seriesName].notes[params.dataIndex].commit_hash}</a><br>
-                        gmt_hash: <a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${series[params.seriesName].notes[params.dataIndex].gmt_hash}" target="_blank">${series[params.seriesName].notes[params.dataIndex].gmt_hash}</a><br>
+                        commit_hash: <a href="${escapeString($("#uri").text())}/commit/${escapeString(series[params.seriesName].notes[params.dataIndex].commit_hash)}" target="_blank">${escapeString(series[params.seriesName].notes[params.dataIndex].commit_hash)}</a><br>
+                        gmt_hash: <a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${escapeString(series[params.seriesName].notes[params.dataIndex].gmt_hash)}" target="_blank">${escapeString(series[params.seriesName].notes[params.dataIndex].gmt_hash)}</a><br>
 
                         <br>
                         👉 <a href="/compare.html?ids=${series[params.seriesName].notes[params.dataIndex].run_id},${series[params.seriesName].notes[params.dataIndex].prun_id}" target="_blank">Diff with previous run</a>

--- a/frontend/js/watchlist.js
+++ b/frontend/js/watchlist.js
@@ -18,24 +18,24 @@ $(document).ready(function () {
             chart_node.classList.add('ui')
             chart_node.classList.add("card");
 
-            const url_link = `${replaceRepoIcon(repo_url)} <a href="${repo_url}" target="_blank"><i class="icon external alternate"></i></a>`;
+            const url_link = `${replaceRepoIcon(repo_url)} <a href="${escapeString(repo_url)}" target="_blank"><i class="icon external alternate"></i></a>`;
             let chart_node_html = `
                 <div class="image">
                     <img src="${escapeString(image_url)}" onerror="this.src='/images/placeholder.webp'" loading="lazy">
                 </div>
                 <div class="content">
-                    <div class="header">${name}</div>
+                    <div class="header">${escapeString(name)}</div>
                     <div class="meta">
                         <span>${url_link}</span>
                     </div>
                 </div>
                 <div class="content">
-                    <p title="${created_at}"><b>Monitoring since: </b>${dateToYMD(new Date(created_at), true)}</p>
-                    <p title="${branch}"><b>Branch: </b> ${branch == '' ? '-': branch}</p>
-                    <p title="${filename}"><b>Filename: </b> ${filename == '' ? '-': filename}</p>
-                    <p title="${machine_description}"><b>Machine: </b>${machine_description}</p>
-                    <p title="${schedule_mode}"><b>Schedule Mode: </b>${schedule_mode}</p>
-                    <p title="${last_run}"><b>Last Run: </b>${last_run == '' ? '-' : dateToYMD(new Date(last_run), false, true)}</p>
+                    <p title="${escapeString(created_at)}"><b>Monitoring since: </b>${dateToYMD(new Date(created_at), true)}</p>
+                    <p title="${escapeString(branch)}"><b>Branch: </b> ${branch == '' ? '-': escapeString(branch)}</p>
+                    <p title="${escapeString(filename)}"><b>Filename: </b> ${filename == '' ? '-': escapeString(filename)}</p>
+                    <p title="${escapeString(machine_description)}"><b>Machine: </b>${escapeString(machine_description)}</p>
+                    <p title="${escapeString(schedule_mode)}"><b>Schedule Mode: </b>${escapeString(schedule_mode)}</p>
+                    <p title="${escapeString(last_run)}"><b>Last Run: </b>${last_run == '' ? '-' : dateToYMD(new Date(last_run), false, true)}</p>
 
                     `
 
@@ -43,21 +43,21 @@ $(document).ready(function () {
                 const [metric_name, detail_name] = metric
                 chart_node_html = `${chart_node_html}
                         <div class="field">
-                            <strong>${getPretty(metric_name, 'clean_name')}</strong>
-                            <i data-tooltip="${getPretty(metric_name, 'explanation')}" data-position="bottom center" data-inverted>
+                            <strong>${escapeString(getPretty(metric_name, 'clean_name'))}</strong>
+                            <i data-tooltip="${escapeString(getPretty(metric_name, 'explanation'))}" data-position="bottom center" data-inverted>
                                 <i class="question circle icon link"></i>
                             </i><br>
-                            <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?uri=${repo_url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}" target="_blank"><img src="${API_URL}/v1/badge/timeline?uri=${repo_url}&branch=${branch}&filename=${filename}&machine_id=${machine_id}&metric=${metric_name}&detail_name=${detail_name}&unit=joules" alt="${metric_name} badge" onerror="this.closest('.field').style.display='none'" loading="lazy"></a></span>
+                            <span class="energy-badge-container"><a href="${METRICS_URL}/timeline.html?uri=${escapeString(repo_url)}&branch=${escapeString(branch)}&filename=${escapeString(filename)}&machine_id=${machine_id}" target="_blank"><img src="${API_URL}/v1/badge/timeline?uri=${escapeString(repo_url)}&branch=${escapeString(branch)}&filename=${escapeString(filename)}&machine_id=${machine_id}&metric=${escapeString(metric_name)}&detail_name=${escapeString(detail_name)}&unit=joules" alt="${escapeString(metric_name)} badge" onerror="this.closest('.field').style.display='none'" loading="lazy"></a></span>
                         </div>`
             })
 
             chart_node_html = `${chart_node_html}
                 </div>
-                <a class="ui button blue" href="/timeline.html?uri=${repo_url}&filename=${filename}&branch=${branch}&machine_id=${machine_id}" target="_blank">
+                <a class="ui button blue" href="/timeline.html?uri=${escapeString(repo_url)}&filename=${escapeString(filename)}&branch=${escapeString(branch)}&machine_id=${machine_id}" target="_blank">
                     Show Timeline <i class="external alternate icon"></i>
                 </a>
                 <hr>
-                <a class="ui button grey" href="/runs.html?uri=${repo_url}&filename=${filename}&branch=${branch}&machine_id=${machine_id}" target="_blank">
+                <a class="ui button grey" href="/runs.html?uri=${escapeString(repo_url)}&filename=${escapeString(filename)}&branch=${escapeString(branch)}&machine_id=${machine_id}" target="_blank">
                     Show All Measurements <i class="external alternate icon"></i>
                 </a>`
             chart_node.innerHTML = chart_node_html;


### PR DESCRIPTION
This PR removes the html escaping in the API and adds escaping to the frontend.

The initial design decision at the time was that we wanted a "clean DB", meaning that we clean everything before it gets in, as we control insert locations easier than read locations.

However over time and many developrs this became quite garbled and inconsistent having multiple escapings "just to be sure".

This PR removes all escaping on the server side and only adds escaping when we output to HTML (aka the Dashboard).

This means:
- DB can contain XSS 
- API can return XSS
- Anybody displaying stuff in HTML / JS frontend must escape

This solution is much cleaner and caters more for the diverse use cases of the GMT Suite as it is now:
- Data being used in may tools that interface with API, but have not actual HTML / JS output
- Data often looked at in CLI and then looks garbled

## TODO
@davidkopp This PR is so far largely untested. 
- Please review the PR manually and then also test it.
- Please create test cases where you inject XSS through the frontend and then validate through a Playwright test that the XSS is not triggered. Happy to talk about how extensive we want to be here once the first test prototype is set up