### PR TITLE
Adds a simple redirect

### DIFF
--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -48,6 +48,7 @@ services:
       - ./nginx/api.conf:/etc/nginx/conf.d/api_nginx.conf:ro
       - ./nginx/block.conf:/etc/nginx/conf.d/block_nginx.conf:ro
       - ./nginx/frontend.conf:/etc/nginx/conf.d/default.conf:ro
+      # - ./nginx/httpredirect.conf:/etc/nginx/conf.d/httpredirect.conf:ro
       # - TEST_CONFIG_SETUP:/var/www/green-metrics-tool/config.yml
       - ./nginx/ssl:/etc/ssl:ro
   green-coding-gunicorn:

--- a/docker/nginx/httpredirect.conf
+++ b/docker/nginx/httpredirect.conf
@@ -1,0 +1,4 @@
+server {
+    listen 80;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
When accessing http://metrics.green-coding.io I can't connect as nothing is listing on port 80. On the server we can now uncomment the nginx line and enable a https redirect. I made it very simple as this will probably only be for us and not worth a modification of the install script 