### PR TITLE
Playwright command

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1545,28 +1545,28 @@ class ScenarioRunner:
                             timeout=self._measurement_flow_process_duration,
                         )
 
-                        ps_to_read_tmp.append({
-                            'cmd': docker_exec_command,
-                            'ps': ps,
-                            'container_name': flow['container'],
-                            'read-notes-stdout': cmd_obj.get('read-notes-stdout', False),
-                            'ignore-errors': cmd_obj.get('ignore-errors', False),
-                            'read-sci-stdout': cmd_obj.get('read-sci-stdout', False),
-                            'detail_name': flow['container'],
-                            'detach': cmd_obj.get('detach', False),
-                        })
+                    ps_to_read_tmp.append({
+                        'cmd': docker_exec_command,
+                        'ps': ps,
+                        'container_name': flow['container'],
+                        'read-notes-stdout': cmd_obj.get('read-notes-stdout', False),
+                        'ignore-errors': cmd_obj.get('ignore-errors', False),
+                        'read-sci-stdout': cmd_obj.get('read-sci-stdout', False),
+                        'detail_name': flow['container'],
+                        'detach': cmd_obj.get('detach', False),
+                    })
 
-                        # we need to check the ready IPC endpoint to find out if the process is done
-                        # this command will block until something is received
-                        if cmd_obj['type'] == 'playwright':
-                            print("Awaiting Playwright function return")
-                            ps = subprocess.run(
-                                ['docker', 'exec', flow['container'], 'cat', '/tmp/playwright-ipc-ready'],
-                                check=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                timeout=60, # 60 seconds should be reasonable for any playwright command we know
-                            )
+                    # we need to check the ready IPC endpoint to find out if the process is done
+                    # this command will block until something is received
+                    if cmd_obj['type'] == 'playwright':
+                        print("Awaiting Playwright function return")
+                        ps = subprocess.run(
+                            ['docker', 'exec', flow['container'], 'cat', '/tmp/playwright-ipc-ready'],
+                            check=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            timeout=60, # 60 seconds should be reasonable for any playwright command we know
+                        )
 
 
                     if self._debugger.active:

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1567,8 +1567,7 @@ class ScenarioRunner:
                                 stderr=subprocess.PIPE,
                                 timeout=60, # 60 seconds should be reasonable for any playwright command we know
                             )
-                            print("stdout", ps.stdout)
-                            print("stderr", ps.stderr)
+
 
                     if self._debugger.active:
                         self._debugger.pause('Waiting to start next command in flow')

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -177,7 +177,7 @@ class SchemaChecker():
                 'name': And(str, Use(self.not_empty), Regex(r'^[\.\s0-9a-zA-Z_\(\)-]+$')),
                 'container': And(str, Use(self.not_empty), Use(self.contains_no_invalid_chars)),
                 'commands': [{
-                    'type': 'console',
+                    'type': Or('console', 'playwright'),
                     'command': And(str, Use(self.not_empty)),
                     Optional('detach'): bool,
                     Optional('note'): And(str, Use(self.not_empty)),

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -82,51 +82,51 @@ class SchemaChecker():
     def check_usage_scenario(self, usage_scenario):
         # Anything with Optional() is not needed, but if it exists must conform to the definition specified
         usage_scenario_schema = Schema({
-            "name": str,
-            "author": And(str, Use(self.not_empty)),
-            "description": And(str, Use(self.not_empty)),
-            Optional("ignore-unsupported-compose"): bool,
-            Optional("version"): Or(str, int, float, datetime), # is part of compose. we ignore it as it is non functionaly anyway
-            Optional("architecture"): And(str, Use(self.not_empty)),
-            Optional("sci"): {
+            'name': str,
+            'author': And(str, Use(self.not_empty)),
+            'description': And(str, Use(self.not_empty)),
+            Optional('ignore-unsupported-compose'): bool,
+            Optional('version'): Or(str, int, float, datetime), # is part of compose. we ignore it as it is non functionaly anyway
+            Optional('architecture'): And(str, Use(self.not_empty)),
+            Optional('sci'): {
                 'R_d': And(str, Use(self.not_empty)),
             },
 
-            Optional("networks"): Or(
+            Optional('networks'): Or(
                 dict,
                 [And(str, Use(self.contains_no_invalid_chars))],
             ),
-            Optional("volumes"): Or(
+            Optional('volumes'): Or(
                 dict,
                 And(str, Use(self.contains_no_invalid_chars))
             ),
-            Optional("services"): {
+            Optional('services'): {
                 Use(self.contains_no_invalid_chars): {
-                    Optional("restart"): str, # is part of compose. we ignore it as GMT has own orchestration
-                    Optional("expose"): [str, int], # is part of compose. we ignore it as it is non functionaly anyway
-                    Optional("init"): bool,
-                    Optional("type"): Use(self.valid_service_types),
-                    Optional("image"): And(str, Use(self.not_empty)),
-                    Optional("build"): Or(Or({And(str, Use(self.not_empty)):And(str, Use(self.not_empty))},list),And(str, Use(self.not_empty))),
-                    Optional("networks"): Or(
+                    Optional('restart'): str, # is part of compose. we ignore it as GMT has own orchestration
+                    Optional('expose'): [str, int], # is part of compose. we ignore it as it is non functionaly anyway
+                    Optional('init'): bool,
+                    Optional('type'): Use(self.valid_service_types),
+                    Optional('image'): And(str, Use(self.not_empty)),
+                    Optional('build'): Or(Or({And(str, Use(self.not_empty)):And(str, Use(self.not_empty))},list),And(str, Use(self.not_empty))),
+                    Optional('networks'): Or(
                         [And(str, Use(self.contains_no_invalid_chars))],
                         {
                             Use(self.contains_no_invalid_chars):
                                 Or(
                                     None,
-                                    { "aliases": [Use(self.contains_no_invalid_chars)] }
+                                    { 'aliases': [Use(self.contains_no_invalid_chars)] }
                                 )
                         }
                     ),
-                    Optional("environment"): Or(
+                    Optional('environment'): Or(
                         dict,
                         [And(str, Use(self.not_empty))]
                     ),
-                    Optional("labels"): Or(
+                    Optional('labels'): Or(
                         dict,
                         [And(str, Use(self.not_empty))]
                     ),
-                    Optional("ports"): [Or( # we do not support the long form as mappings
+                    Optional('ports'): [Or( # we do not support the long form as mappings
                         int,
                         And(str, Use(self.not_empty))
                     )],
@@ -146,7 +146,7 @@ class SchemaChecker():
                     Optional('cpus') : Or(And(str, Use(self.not_empty)), float, int),
                     Optional('container_name'): And(str, Use(self.not_empty)),
                     Optional('shm_size'): Or(And(str, Use(self.not_empty)), float, int),
-                    Optional("healthcheck"): {
+                    Optional('healthcheck'): {
                         Optional('test'): Or(list, And(str, Use(self.not_empty))),
                         Optional('interval'): And(str, Use(self.not_empty)),
                         Optional('timeout'): And(str, Use(self.not_empty)),
@@ -155,43 +155,43 @@ class SchemaChecker():
                         Optional('start_interval'): And(str, Use(self.not_empty)),
                         Optional('disable'): bool,
                     },
-                    Optional("setup-commands"): [{
+                    Optional('setup-commands'): [{
                         'command': And(str, Use(self.not_empty)),
-                        Optional("detach"): bool,
-                        Optional("shell"): And(str, Use(self.not_empty)),
+                        Optional('detach'): bool,
+                        Optional('shell'): And(str, Use(self.not_empty)),
                     }],
-                    Optional("volumes"): [And(str, Use(self.not_empty))],
-                    Optional("folder-destination"):And(str, Use(self.not_empty)),
-                    Optional("entrypoint"): Or(str, [str]), # can be empty!
-                    Optional("command"): Or(And(str, Use(self.not_empty)), [And(str, Use(self.not_empty))]),
-                    Optional("log-stdout"): bool,
-                    Optional("log-stderr"): bool,
-                    Optional("read-notes-stdout"): bool,
-                    Optional("read-sci-stdout"): bool,
-                    Optional("docker-run-args"): [And(str, Use(self.not_empty))],
+                    Optional('volumes'): [And(str, Use(self.not_empty))],
+                    Optional('folder-destination'):And(str, Use(self.not_empty)),
+                    Optional('entrypoint'): Or(str, [str]), # can be empty!
+                    Optional('command'): Or(And(str, Use(self.not_empty)), [And(str, Use(self.not_empty))]),
+                    Optional('log-stdout'): bool,
+                    Optional('log-stderr'): bool,
+                    Optional('read-notes-stdout'): bool,
+                    Optional('read-sci-stdout'): bool,
+                    Optional('docker-run-args'): [And(str, Use(self.not_empty))],
 
                 }
             },
 
-             "flow": [{
-                "name": And(str, Use(self.not_empty), Regex(r'^[\.\s0-9a-zA-Z_\(\)-]+$')),
-                "container": And(str, Use(self.not_empty), Use(self.contains_no_invalid_chars)),
-                "commands": [{
-                    "type":"console",
-                    "command": And(str, Use(self.not_empty)),
-                    Optional("detach"): bool,
-                    Optional("note"): And(str, Use(self.not_empty)),
-                    Optional("read-notes-stdout"): bool,
-                    Optional("read-sci-stdout"): bool,
-                    Optional("ignore-errors"): bool,
-                    Optional("shell"): And(str, Use(self.not_empty)),
-                    Optional("log-stdout"): bool,
-                    Optional("log-stderr"): bool,
+             'flow': [{
+                'name': And(str, Use(self.not_empty), Regex(r'^[\.\s0-9a-zA-Z_\(\)-]+$')),
+                'container': And(str, Use(self.not_empty), Use(self.contains_no_invalid_chars)),
+                'commands': [{
+                    'type': 'console',
+                    'command': And(str, Use(self.not_empty)),
+                    Optional('detach'): bool,
+                    Optional('note'): And(str, Use(self.not_empty)),
+                    Optional('read-notes-stdout'): bool,
+                    Optional('read-sci-stdout'): bool,
+                    Optional('ignore-errors'): bool,
+                    Optional('shell'): And(str, Use(self.not_empty)),
+                    Optional('log-stdout'): bool,
+                    Optional('log-stderr'): bool,
                 }],
 
             }],
 
-            Optional("compose-file"): Use(self.validate_compose_include)
+            Optional('compose-file'): Use(self.validate_compose_include)
         }, ignore_extra_keys=bool(usage_scenario.get('ignore-unsupported-compose', False)))
 
         # First we check the general structure. Otherwise we later cannot even iterate over it

--- a/templates/website/compose.yml
+++ b/templates/website/compose.yml
@@ -1,6 +1,6 @@
 services:
-  gcb-playwright:
-    image: greencoding/gcb_playwright:v20
+  playwright-nodejs:
+    image: mcr.microsoft.com/playwright:v1.55.0-noble
 #    volumes:
 #       - /tmp/.X11-unix:/tmp/.X11-unix # for debugging in non-headless mode
     environment:
@@ -8,6 +8,12 @@ services:
     depends_on:
       squid:
         condition: service_healthy
+    setup-commands:
+        # install playwright libraries
+      - command: mkdir /tmp/energy-tests
+      - command: cp -R /tmp/repo/. /tmp/energy-tests
+      - command: cd /tmp/energy-tests && npm init -y && npm install playwright
+        shell: bash
 
   squid:
     image: greencoding/squid_reverse_proxy:v4

--- a/templates/website/playwright-ipc.js
+++ b/templates/website/playwright-ipc.js
@@ -56,9 +56,7 @@ async function run(browserName, headless, proxy) {
 
   await startFifoReader("/tmp/playwright-ipc-commands", async (data) => {
       if (data == 'end') {
-          browser.close()
-          context.close()
-          page.close()
+          await browser.close()
           fs.writeFileSync("/tmp/playwright-ipc-ready", "ready", "utf-8");   // signal that browser is ready although
           process.exit(0)
       } else {

--- a/templates/website/playwright-ipc.js
+++ b/templates/website/playwright-ipc.js
@@ -1,0 +1,91 @@
+import { firefox, chromium } from "playwright";
+import fs from "fs";
+import { execSync } from "child_process";
+
+
+const defaultProxy = { server: "http://squid:3128" };
+const contextOptions = {
+  viewport: { width: 1280, height: 800 },
+  ignoreHTTPSErrors: true, // <--- disables SSL check as we funnel requests through proxy
+  timeout: 5000,
+};
+
+function logNote(message) {
+  const timestamp = String(BigInt(Date.now()) * 1000000n).slice(0, 16);
+  console.log(`${timestamp} ${message}`);
+}
+
+async function startFifoReader(fifoPath, callback) {
+  function openStream() {
+    const stream = fs.createReadStream(fifoPath, { encoding: "utf-8" });
+    stream.on("data", (chunk) => callback(chunk.trim()));
+    stream.on("end", () => {
+      // Writer closed FIFO, reopen it
+      openStream();
+    });
+    stream.on("error", (err) => {
+      console.error(err);
+      throw err
+      // setTimeout(openStream, 100); // reopening is not really an option for us as we run inside container
+    });
+  }
+  openStream();
+}
+
+
+// Test 1 - BRANCH: Launch Branch website with no cookies
+async function run(browserName, headless, proxy) {
+  let browser = null;
+  const launchOptions = { headless, proxy };
+
+  if (browserName === "firefox") {
+    browser = await firefox.launch(launchOptions);
+  } else {
+    browser = await chromium.launch({
+      ...launchOptions,
+      args: headless ? ["--headless=new"] : [],
+    });
+  }
+  
+  let context = await browser.newContext(contextOptions);
+  await context.clearCookies();
+  let page = await context.newPage()
+
+  execSync(`mkfifo /tmp/playwright-ipc-ready`); // signal that browser is launched
+  execSync(`mkfifo /tmp/playwright-ipc-commands`); // create pipe to get commands
+
+  await startFifoReader("/tmp/playwright-ipc-commands", async (data) => {
+      if (data == 'end') {
+          browser.close()
+          context.close()
+          page.close()
+          fs.writeFileSync("/tmp/playwright-ipc-ready", "ready", "utf-8");   // signal that browser is ready although
+          process.exit(0)
+      } else {
+          console.log('Evaluating', data);
+          await eval(`(async () => { ${data} })()`);
+          fs.writeFileSync("/tmp/playwright-ipc-ready", "ready", "utf-8");   // signal that browser is ready for next command
+      }
+  });
+
+};
+
+// CLI args
+const argv = process.argv;
+const args = {};
+for (let i = 2; i < argv.length; i++) {
+  if (argv[i] === "--browser" && argv[i + 1]) {
+    args.browser = argv[++i];
+  } else if (argv[i] === "--headless" && argv[i + 1]) {
+    args.headless = argv[++i].toLowerCase() === "true";
+  } else if (argv[i] === "--proxy" && argv[i + 1]) {
+    args.proxy = argv[++i] === "null" ? null : { server: argv[i] };
+  }
+}
+
+await run(
+  (args.browser || "chromium").toLowerCase(),
+  args.headless !== undefined ? args.headless : true,
+  args.proxy !== undefined ? args.proxy : defaultProxy
+);
+

--- a/templates/website/usage_scenario.yml
+++ b/templates/website/usage_scenario.yml
@@ -29,9 +29,7 @@ flow:
       - type: console
         command: sleep '__GMT_VAR_SLEEP__'
       - type: playwright
-        command: context.close()
-      - type: playwright
-        command: page.close()
+        command: await context.close()
       - type: playwright
         command: context = await browser.newContext(contextOptions);
       - type: playwright

--- a/templates/website/usage_scenario.yml
+++ b/templates/website/usage_scenario.yml
@@ -8,42 +8,53 @@ sci:
 
 compose-file: !include compose.yml
 
-services:
-  gcb-playwright:
-    setup-commands:
-      - command: mkfifo /tmp/my_fifo
-      - command: python3 /tmp/repo/templates/website/visit.py --browser chromium
-        detach: true
-      - command: until [ -f "/tmp/browser_ready" ]; do sleep 1; done && echo "Browser ready!"
-        shell: bash
-      - command: echo '__GMT_VAR_PAGE__' > /tmp/my_fifo # warmup
-        shell: bash
-      - command: sleep '__GMT_VAR_SLEEP__' # we need same sleep as later as some resources might only be fetched from the website after staying on the page for a while
-
 flow:
+  - name: Starting browser IPC
+    container: playwright-nodejs
+    commands:
+      - type: console
+        command: node /tmp/energy-tests/templates/website/playwright-ipc.js --headless true --browser firefox
+        note: Starting browser in background process with IPC
+        detach: true
+      - type: console
+        command: until [ -p "/tmp/playwright-ipc-ready" ]; do sleep 1; done && echo "Browser ready!"
+        shell: bash
+        note: Waiting for website stepper loop to start by monitoring rendevous file endpoint
+
+  - name: Warmup and Caching
+    container: playwright-nodejs
+    commands:
+      - type: playwright
+        command: await page.goto("__GMT_VAR_PAGE__");
+      - type: console
+        command: sleep '__GMT_VAR_SLEEP__'
+      - type: playwright
+        command: context.close()
+      - type: playwright
+        command: page.close()
+
   - name: Dump Log (Warmup)
     container: squid
     commands:
       - type: console
         command: cat /apps/squid/var/logs/access.log
-        log-stdout: true
-        log-stderr: true
       - type: console
         command: grep 'TCP_MISS/' /apps/squid/var/logs/access.log #validate that TCP_MISSes present
       - type: console
         command: echo > /apps/squid/var/logs/access.log
         shell: bash
-        log-stdout: true
-        log-stderr: true
+
   - name: Load and idle
-    container: gcb-playwright
+    container: playwright-nodejs
     commands:
+      - type: playwright
+        command: context = await browser.newContext(contextOptions);
+      - type: playwright
+        command: page = await context.newPage()
+      - type: playwright
+        command: await page.goto("__GMT_VAR_PAGE__");
       - type: console
-        shell: bash
-        command: "echo '__GMT_VAR_PAGE__' > /tmp/my_fifo && sleep __GMT_VAR_SLEEP__"
-        read-notes-stdout: true
-        log-stdout: true
-        log-stderr: true
+        command: sleep '__GMT_VAR_SLEEP__'
 
   - name: Dump Log (Load and idle)
     container: squid
@@ -51,8 +62,6 @@ flow:
       - type: console
         command: cat /apps/squid/var/logs/access.log
         read-notes-stdout: true
-        log-stdout: true
-        log-stderr: true
       - type: console
         command: grep 'TCP_MEM_HIT/' /apps/squid/var/logs/access.log #validate that TCP_MEM_HITs present
         # This is sadly too strict. Pages fingerprint you all the time and a new request might get a new fingerprint that will not be cached

--- a/templates/website/usage_scenario.yml
+++ b/templates/website/usage_scenario.yml
@@ -32,6 +32,10 @@ flow:
         command: context.close()
       - type: playwright
         command: page.close()
+      - type: playwright
+        command: context = await browser.newContext(contextOptions);
+      - type: playwright
+        command: page = await context.newPage()
 
   - name: Dump Log (Warmup)
     container: squid
@@ -47,10 +51,6 @@ flow:
   - name: Load and idle
     container: playwright-nodejs
     commands:
-      - type: playwright
-        command: context = await browser.newContext(contextOptions);
-      - type: playwright
-        command: page = await context.newPage()
       - type: playwright
         command: await page.goto("__GMT_VAR_PAGE__");
       - type: console


### PR DESCRIPTION
This PR introduces the concept of having playwright commands directly in the usage scenario.

This was made based on an idea of @davidkopp 

To make the commands work we need IPC between playwright and GMT.

To make this low overhead we use native I/O blocking from the linux subsystem by creating two files:
- /tmp/playwright-ipc-ready 
  - This is used to signal to GMT that playwright is ready for the next command
- /tmp/playwright-ipc-commands 
  - This is used for playwright to ingest the command

The functionality is kept hidden from the user only exposing a simple string based YML syntax.

Example can be seen here: 
https://github.com/green-coding-solutions/branch-magazine-energy-tests/blob/2741f206385a5280bb275da1b5bf2db46f148185/usage_scenario_normal.yml#L66

@davidkopp How do you like this interface?  