### PR TITLE
Using custom build cache in user home directory

### DIFF
--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -54,6 +54,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-gunicorn
+      cache_from:
+        - type=local,src=$HOME/.cache/buildkit-gmt/
+      cache_to:
+        - type=local,dest=$HOME/.cache/buildkit-gmt/
     container_name: green-coding-gunicorn-container
     init: true
     depends_on:


### PR DESCRIPTION
These settings would help speed up the build on systems where GMT is tested DinD
 As caches are then mounted into the container where GMT is built

However docker drivers which support DinD often do not support the cache_from and cache_to
We keep this in for now for processing in the future. For now implementation of this is blocked
      

Error message we get:
```log
Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/build-cache-backends/
```