### PR TITLE
Fix note 'pulling image' in charts

### DIFF
--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -475,6 +475,35 @@ const buildTimelineChartData = async (measurements_data) => {
     return metrics;
 }
 
+const wrapNoteText = (text, maxLength = 80) => {
+    if (text.length <= maxLength) return text;
+
+    const lines = [];
+    let currentLine = '';
+    const breakChars = [' ', '/', ':', '-', '_'];
+
+    for (const char of text) {
+        currentLine += char;
+
+        if (currentLine.length >= maxLength) {
+            const breakIndex = currentLine.split('').findLastIndex(c => breakChars.includes(c));
+
+            if (breakIndex > maxLength * 0.5) {
+                const breakChar = currentLine[breakIndex];
+                const endIndex = breakChar === ' ' ? breakIndex : breakIndex + 1;
+                lines.push(currentLine.substring(0, endIndex));
+                currentLine = currentLine.substring(breakIndex + 1);
+            } else {
+                lines.push(currentLine.substring(0, maxLength));
+                currentLine = currentLine.substring(maxLength);
+            }
+        }
+    }
+
+    if (currentLine) lines.push(currentLine);
+    return lines.join('\n');
+};
+
 const displayTimelineCharts = async (metrics, notes) => {
 
     const note_positions = [
@@ -517,7 +546,7 @@ const displayTimelineCharts = async (metrics, notes) => {
         let inner_counter = 0;
         if (notes != null) {
             notes.forEach(note => {
-                notes_labels.push({xAxis: note[3]/1000, label: {formatter: note[2], position: note_positions[inner_counter%2]}})
+                notes_labels.push({xAxis: note[3]/1000, label: {formatter: wrapNoteText(note[2]), position: note_positions[inner_counter%2]}})
                 inner_counter++;
             });
         }

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -517,7 +517,7 @@ const displayTimelineCharts = async (metrics, notes) => {
         let inner_counter = 0;
         if (notes != null) {
             notes.forEach(note => {
-                notes_labels.push({xAxis: note[3]/1000, label: {formatter: escapeString(note[2]), position: note_positions[inner_counter%2]}})
+                notes_labels.push({xAxis: note[3]/1000, label: {formatter: note[2], position: note_positions[inner_counter%2]}})
                 inner_counter++;
             });
         }

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -821,7 +821,7 @@ class ScenarioRunner:
 
             else:
                 print(f"Pulling {service['image']}")
-                self.__notes_helper.add_note( note="Pulling {service['image']}" , detail_name='[NOTES]', timestamp=int(time.time_ns() / 1_000))
+                self.__notes_helper.add_note( note=f"Pulling {service['image']}" , detail_name='[NOTES]', timestamp=int(time.time_ns() / 1_000))
 
                 slash_splitted_image_name = service['image'].split('/')
                 if '.' in slash_splitted_image_name[0]: # we have already a set registry


### PR DESCRIPTION
This PR fixes 3 issues regarding the display of the note `pulling {image}` in the charts:
1. Remove unnecessary double-escaping of notes (was accidentally introduced by https://github.com/green-coding-solutions/green-metrics-tool/pull/1329)
   <img width="158" height="574" alt="image" src="https://github.com/user-attachments/assets/df2b0e69-3a3e-47ca-abdc-d4bafd4be507" />
2. Fix show actual pulled image name in notes
   <img width="146" height="556" alt="image" src="https://github.com/user-attachments/assets/ea8800b4-47f4-4fb0-a637-edcded930674" />
3. Add automatic text wrapping for long notes
    <img width="192" height="591" alt="image" src="https://github.com/user-attachments/assets/b9c20909-163f-43be-8362-aee83f4adedd" />

Final result:
<img width="1067" height="578" alt="image" src="https://github.com/user-attachments/assets/fca45d65-e17e-45b8-976a-daf7d7e805b4" />
