### PR TITLE
Fix null byte handling in logs to prevent PostgreSQL errors

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1472,9 +1472,9 @@ class ScenarioRunner:
         }
 
         if stdout is not None:
-            log_entry['stdout'] = stdout
+            log_entry['stdout'] = stdout.replace('\x00', '')  # Remove null bytes - PostgreSQL can't handle \u0000 in JSON
         if stderr is not None:
-            log_entry['stderr'] = stderr
+            log_entry['stderr'] = stderr.replace('\x00', '')  # Remove null bytes - PostgreSQL can't handle \u0000 in JSON
         if flow is not None:
             log_entry['flow'] = flow
         if exception_class is not None:
@@ -2019,7 +2019,6 @@ class ScenarioRunner:
 
         if self.__current_run_logs:
             logs_as_json = json.dumps(self.__current_run_logs, separators=(',', ':'))  # Compact JSON for efficient storage
-            logs_as_json = logs_as_json.replace('\x00','')
             DB().query("""
                 UPDATE runs
                 SET logs = COALESCE(logs, '{}'::jsonb) || %s::jsonb

--- a/tests/data/usage_scenarios/capture_logs_with_null_bytes.yml
+++ b/tests/data/usage_scenarios/capture_logs_with_null_bytes.yml
@@ -1,0 +1,25 @@
+---
+name: Capture Logs with Null Bytes
+author: David Kopp
+description: Test handling of null bytes in log output
+
+services:
+  test-container:
+    type: container
+    image: alpine
+    setup-commands:
+      - command: 'printf "Setup log with null byte: \000 embedded"'
+    entrypoint: ["/bin/sh", "-c"]
+    command: ['printf "Container log with null byte: \000 embedded"; sleep infinity']
+    log-stdout: true
+    log-stderr: true
+
+flow:
+  - name: Flow with Null Bytes
+    container: test-container
+    commands:
+      - type: console
+        command: 'printf "Flow stdout with null byte: \000 embedded" && printf "Flow stderr with null byte: \000 embedded" >&2'
+        shell: /bin/sh
+        log-stdout: true
+        log-stderr: true


### PR DESCRIPTION
If there were null bytes in the stdout or stderr, it came to the following database error:

```plain
psycopg.errors.UntranslatableCharacter: unsupported Unicode escape sequence
DETAIL: \u0000 cannot be converted to text.
CONTEXT: JSON data, line 1: ...........('127.0.0.1', 53764) unrecognised: \u0000...
unnamed portal parameter $1 = '...'
```

With this PR null bytes from stdout/stderr are cleaned when added to the internal log structure.