### PR TITLE
Add debug outputs to investigate failing multi arch image test case

### DIFF
--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -16,7 +16,7 @@ inputs:
   test-path:
     description: 'Specific test path to run'
     required: false
-    default: 'test_runner.py::test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails_github_actions' # Only for debugging
+    default: ''
   github-token:
     description: 'pass in your secrets.GITHUB_TOKEN'
     required: true

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -10,9 +10,13 @@ inputs:
     required: false
     default: '.'
   tests-command:
-    description: 'The command to run the tests'
+    description: 'Base pytest command'
     required: false
-    default: 'pytest test_runner.py::test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails_github_actions -vv -s'
+    default: 'pytest -vv --durations=0'
+  test-path:
+    description: 'Specific test path to run'
+    required: false
+    default: ''
   github-token:
     description: 'pass in your secrets.GITHUB_TOKEN'
     required: true
@@ -126,7 +130,7 @@ runs:
       working-directory: ${{ inputs.gmt-directory }}/tests
       run: |
         source ../venv/bin/activate
-        python3 -m ${{ inputs.tests-command }} -rA | tee /tmp/test-results.txt
+        python3 -m ${{ inputs.tests-command }} ${{ inputs.test-path }} -rA | tee /tmp/test-results.txt
 
     - name: Display Results
       shell: bash

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Sets the branch to checkout for the ee repo'
     required: false
     default: ''
+  enable-ssh:
+    description: 'Enable SSH connection for debugging purposes'
+    required: false
+    default: 'false'
 
 
 runs:
@@ -105,8 +109,12 @@ runs:
       run: |
         source ../venv/bin/activate && ./start-test-containers.sh -d
 
-    # - name: Setup upterm session
-    #   uses: lhotari/action-upterm@v1
+    # for debugging purposes you can setup a ssh connection by setting 'inputs.enable-ssh' to true
+    - name: Setup upterm session
+      if: ${{ inputs.enable-ssh == 'true' }}
+      uses: owenthereal/action-upterm@v1
+      with:
+        limit-access-to-actor: true # Restrict to the user who triggered the workflow
 
     - name: Disable swap
       shell: bash

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -16,7 +16,7 @@ inputs:
   test-path:
     description: 'Specific test path to run'
     required: false
-    default: ''
+    default: 'test_runner.py::test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails_github_actions' # Only for debugging
   github-token:
     description: 'pass in your secrets.GITHUB_TOKEN'
     required: true

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -12,7 +12,7 @@ inputs:
   tests-command:
     description: 'The command to run the tests'
     required: false
-    default: 'pytest -vv --durations=0'
+    default: 'pytest test_runner.py::test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails_github_actions -vv -s'
   github-token:
     description: 'pass in your secrets.GITHUB_TOKEN'
     required: true

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '.'
   tests-command:
-    description: 'Base pytest command'
+    description: 'The command to run the tests'
     required: false
     default: 'pytest -vv --durations=0'
   test-path:

--- a/.github/workflows/tests-vm-main.yml
+++ b/.github/workflows/tests-vm-main.yml
@@ -9,8 +9,8 @@ on:
         description: 'Enable SSH connection for debugging purposes'
         required: false
         type: boolean
-      tests-command:
-        description: 'Custom pytest command to run the tests'
+      test-path:
+        description: 'Specific test path to run'
         required: false
         type: string
 
@@ -55,7 +55,7 @@ jobs:
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          enable-ssh: ${{ inputs.enable-ssh }}
-         tests-command: ${{ inputs.tests-command }}
+         test-path: ${{ inputs.test-path }}
 
       - name: Eco CI Energy Estimation - Get Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@main

--- a/.github/workflows/tests-vm-main.yml
+++ b/.github/workflows/tests-vm-main.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      enable-ssh:
+        description: 'Enable SSH connection for debugging purposes'
+        required: false
+        type: boolean
+      tests-command:
+        description: 'Custom pytest command to run the tests'
+        required: false
+        type: string
 
 jobs:
   run-tests-main:
@@ -45,6 +54,8 @@ jobs:
         uses: ./.github/actions/gmt-pytest
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
+         enable-ssh: ${{ inputs.enable-ssh }}
+         tests-command: ${{ inputs.tests-command }}
 
       - name: Eco CI Energy Estimation - Get Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@main

--- a/.github/workflows/tests-vm-pr.yml
+++ b/.github/workflows/tests-vm-pr.yml
@@ -42,7 +42,7 @@ jobs:
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          enable-ssh: ${{ inputs.enable-ssh }}
-         test-path: ${{ inputs.test-path || 'test_runner.py::test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails_github_actions' }} # run only one test for debugging purposes
+         test-path: ${{ inputs.test-path }}
 
       - name: Eco CI Energy Estimation - Get Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@main

--- a/.github/workflows/tests-vm-pr.yml
+++ b/.github/workflows/tests-vm-pr.yml
@@ -2,6 +2,16 @@ name: Pull Request Tests
 run-name: PR check
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      enable-ssh:
+        description: 'Enable SSH connection for debugging purposes'
+        required: false
+        type: boolean
+      tests-command:
+        description: 'Custom pytest command to run the tests'
+        required: false
+        type: string
 
 jobs:
   run-tests:
@@ -31,6 +41,8 @@ jobs:
         uses: ./.github/actions/gmt-pytest
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
+         enable-ssh: ${{ inputs.enable-ssh }}
+         tests-command: ${{ inputs.tests-command }}
 
       - name: Eco CI Energy Estimation - Get Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@main

--- a/.github/workflows/tests-vm-pr.yml
+++ b/.github/workflows/tests-vm-pr.yml
@@ -8,8 +8,8 @@ on:
         description: 'Enable SSH connection for debugging purposes'
         required: false
         type: boolean
-      tests-command:
-        description: 'Custom pytest command to run the tests'
+      test-path:
+        description: 'Specific test path to run'
         required: false
         type: string
 
@@ -42,7 +42,7 @@ jobs:
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          enable-ssh: ${{ inputs.enable-ssh }}
-         tests-command: ${{ inputs.tests-command }}
+         test-path: ${{ inputs.test-path }}
 
       - name: Eco CI Energy Estimation - Get Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@main

--- a/.github/workflows/tests-vm-pr.yml
+++ b/.github/workflows/tests-vm-pr.yml
@@ -42,7 +42,7 @@ jobs:
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          enable-ssh: ${{ inputs.enable-ssh }}
-         test-path: ${{ inputs.test-path }}
+         test-path: ${{ inputs.test-path || 'test_runner.py::test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails_github_actions' }} # run only one test for debugging purposes
 
       - name: Eco CI Energy Estimation - Get Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@main

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -538,11 +538,6 @@ def can_emulate_arm64_images():
     return container_compatibility.get_platform_compatibility_status('linux/arm64') == container_compatibility.CompatibilityStatus.EMULATED
 
 def _print_architecture_debug_info(target_platform):
-    """Print debug information for architecture compatibility testing in GitHub Actions.
-
-    Args:
-        target_platform: The platform being tested (e.g., 'linux/arm64', 'linux/amd64')
-    """
     print("\n=== DEBUG: CI Environment Detected ===")
 
     # Debug: Docker buildx inspect
@@ -617,6 +612,7 @@ def test_docker_run_multi_arch_image_with_arm64_digest_on_amd64_host_fails():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/docker_run_multiarch_image_arm64_digest.yml',
                           skip_system_checks=True, dev_no_sleeps=True, dev_no_save=True)
 
+    # Add debug outputs in CI pipeline to investigate https://github.com/green-coding-solutions/green-metrics-tool/issues/1360
     if os.getenv('GITHUB_ACTIONS'):
         _print_architecture_debug_info('linux/arm64')
 
@@ -636,6 +632,7 @@ def test_docker_run_multi_arch_image_with_amd64_digest_on_arm64_host_fails():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/docker_run_multiarch_image_amd64_digest.yml',
                           skip_system_checks=True, dev_no_sleeps=True, dev_no_save=True)
 
+    # Add debug outputs in CI pipeline to investigate https://github.com/green-coding-solutions/green-metrics-tool/issues/1360
     if os.getenv('GITHUB_ACTIONS'):
         _print_architecture_debug_info('linux/amd64')
 


### PR DESCRIPTION
Add debug outputs to investigate issue #1360 

In addition to that it also introduces two new optional input variables for the CI pipeline:
- `test-path` -> let us specify a specific test that should be executed in the pipeline instead of all
- `enable-ssh` -> let us enable a ssh connection for debugging purposes

I also added the ability to run the PR workflow manually (`workflow_dispatch`).