### PR TITLE
Full Docker Prune whitelist implemented

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -80,6 +80,8 @@ machine:
   base_temperature_feature: False
 
 measurement:
+  full_docker_prune_whitelist:
+    - gcr.io/kaniko-project/executor
   metric_providers:
   # Please select the needed providers according to the working ones on your system
   # More info https://docs.green-coding.io/docs/measuring/metric-providers


### PR DESCRIPTION
This PR makes the --full-docker-prune flag more dynamic by allowing a whitelist of images that will not be pruned.

Helpful for cluster installations where certain images shall be retained that are not security critical but heavy in download size