### PR TITLE
Fix encoding of repo paths in URLs in frontend

### DIFF
--- a/frontend/js/ci-index.js
+++ b/frontend/js/ci-index.js
@@ -58,12 +58,13 @@ function getRepoLink(repo, source) {
 
 // Function to generate the repository URI
 function getRepoUri(repo, source) {
+    const repo_encoded = repo.split('/').map(encodeURIComponent).join('/');
     if (source.startsWith('github')) {
-        return `https://www.github.com/${encodeURIComponent(repo)}`;
+        return `https://www.github.com/${repo_encoded}`;
     } else if (source.startsWith('gitlab')) {
-        return `https://www.gitlab.com/${encodeURIComponent(repo)}`;
+        return `https://www.gitlab.com/${repo_encoded}`;
     } else if (source.startsWith('bitbucket')) {
-        return `https://bitbucket.com/${encodeURIComponent(repo)}`;
+        return `https://bitbucket.com/${repo_encoded}`;
     }
 }
 

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -194,12 +194,13 @@ const displayRunDetailsTable = (measurements, repo) => {
         let run_link = '';
 
         const run_id_esc = encodeURIComponent(run_id)
+        const repo_encoded = repo.split('/').map(encodeURIComponent).join('/');
 
         if(source == 'github') {
-            run_link = `https://github.com/${encodeURIComponent(repo)}/actions/runs/${run_id_esc}`;
+            run_link = `https://github.com/${repo_encoded}/actions/runs/${run_id_esc}`;
         }
         else if (source == 'gitlab') {
-            run_link = `https://gitlab.com/${encodeURIComponent(repo)}/-/pipelines/${run_id_esc}`
+            run_link = `https://gitlab.com/${repo_encoded}/-/pipelines/${run_id_esc}`;
         }
 
         const run_link_node = `<a href="${run_link}" target="_blank">${run_id_esc}</a>`
@@ -366,11 +367,12 @@ const populateRunInfos = async (repo, branch, source, workflow_name, workflow_id
     document.querySelector('#ci-data-workflow').innerText =  escapeString(workflow_name);
 
     let repo_link = ''
+    const repo_encoded = repo.split('/').map(encodeURIComponent).join('/');
     if(source == 'github') {
-        repo_link = `https://github.com/${encodeURIComponent(repo)}`;
+        repo_link = `https://github.com/${repo_encoded}`;
     }
     else if(source == 'gitlab') {
-        repo_link = `https://gitlab.com/${encodeURIComponent(repo)}`;
+        repo_link = `https://gitlab.com/${repo_encoded}`;
     }
 
     const repo_link_node = `<a href="${repo_link}" target="_blank">${escapeString(repo)}</a>`

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -222,6 +222,7 @@ const loadCharts = async () => {
             triggerOn: 'click',
             formatter: function (params, ticket, callback) {
                 if(series[params.seriesName]?.notes == null) return; // no notes for the MovingAverage
+                const repository_uri_encoded = repository_uri.split('/').map(encodeURIComponent).join('/');
                 return `<strong>${escapeString(series[params.seriesName].notes[params.dataIndex].run_name)}</strong><br>
                         run_id: <a href="/stats.html?id=${series[params.seriesName].notes[params.dataIndex].run_id}"  target="_blank">${series[params.seriesName].notes[params.dataIndex].run_id}</a><br>
                         date: ${series[params.seriesName].notes[params.dataIndex].created_at}<br>
@@ -229,7 +230,7 @@ const loadCharts = async () => {
                         phase: ${escapeString(series[params.seriesName].notes[params.dataIndex].phase)}<br>
                         value: ${numberFormatter.format(series[params.seriesName].values[params.dataIndex].value)}<br>
                         commit_timestamp: ${series[params.seriesName].notes[params.dataIndex].commit_timestamp}<br>
-                        commit_hash: <a href="${encodeURIComponent(repository_uri)}/commit/${series[params.seriesName].notes[params.dataIndex].commit_hash}" target="_blank">${escapeString(series[params.seriesName].notes[params.dataIndex].commit_hash)}</a><br>
+                        commit_hash: <a href="${repository_uri_encoded}/commit/${series[params.seriesName].notes[params.dataIndex].commit_hash}" target="_blank">${escapeString(series[params.seriesName].notes[params.dataIndex].commit_hash)}</a><br>
                         gmt_hash: <a href="https://github.com/green-coding-solutions/green-metrics-tool/commit/${series[params.seriesName].notes[params.dataIndex].gmt_hash}" target="_blank">${escapeString(series[params.seriesName].notes[params.dataIndex].gmt_hash)}</a><br>
 
                         <br>


### PR DESCRIPTION
Repo slashes encoded as %2F break GitHub/GitLab URLs. This PR fixes this by encoding path segments individually.