### PR TITLE
Fix GitHub Codespaces permission error when accessing mounted files

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -323,6 +323,11 @@ class ScenarioRunner:
 
             if problematic_symlink := utils.find_outside_symlinks(self._repo_folder):
                 raise RuntimeError(f"Repository contained outside symlink: {problematic_symlink}\nGMT cannot handle this in URL or Cluster mode due to security concerns. Please change or remove the symlink or run GMT locally.")
+
+            # Fix permissions to allow access from different users inside Docker containers
+            # In some environments like GitHub Codespaces, directories may be created without
+            # execute permission for 'other', preventing container users from traversing them
+            subprocess.run(['chmod', '-R', 'o+X', self._repo_folder], check=True)
         else:
             if self._original_branch is not None:
                 # we never want to checkout a local directory to a different branch as this might also be the GMT directory itself and might confuse the tool


### PR DESCRIPTION
In GitHub Codespaces I got a permission denied error:

```sh
time="2025-11-21T07:31:41Z" level=error msg="stat /tmp/repo/k6/WarmUpSzenario.js: permission denied"
```

To reproduce the issue run the following in a GitHub Codespace:

```sh
python3 runner.py --name "KADAI - Standard Usage Scenario" --uri "https://gitlab.com/envite-consulting/sustainable-software-architecture/kadai/kadai-resource-efficiency" --filename "usage_scenario.yml" --skip-system-checks --skip-unsafe --dev-no-sleeps
```

And to investigate the issue:

```sh
git clone https://gitlab.com/envite-consulting/sustainable-software-architecture/kadai/kadai-resource-efficiency
docker compose -f kadai-resource-efficiency/docker/compose.yml up -d
docker exec k6 stat /tmp/repo/k6/WarmUpSzenario.js
```

Executing `ls -la /tmp/green-metrics-tool/repo`:

```sh
drwxr-xrw-+ 10 codespace codespace 4096 Nov 21 07:42 .
```

In GitHub Codespaces the tmp folder misses the execution permission for others.