### PR TITLE
Added running systemd services to hardwareinfo

### DIFF
--- a/lib/hardware_info_root_original.py
+++ b/lib/hardware_info_root_original.py
@@ -95,6 +95,7 @@ root_info_list = [
     [rdr, 'CPU Scheduling', '/sys/kernel/debug/sched'],
     [rpwr, 'Hardware Details', 'lshw', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [cf, 'RAPL Energy Filtering', read_rapl_energy_filtering],
+    [rpwr, 'Systemd Services', 'sudo systemctl --all list-unit-files', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
 ]
 
 def get_root_list():


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added systemd service collection to hardware info gathering. The implementation has several issues:

- Double `sudo` invocation (script already runs with sudo privileges)
- Incorrect command syntax (`--all` flag position)
- Mismatch between PR intent (running services) and actual command (`list-unit-files` shows all unit files regardless of running state)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->