### PR TITLE
Checks test path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def setup_and_cleanup_test():
 #     pass
 
 
-def pytest_sessionstart(_):
+def pytest_sessionstart(session):  # pylint: disable=unused-argument
     tests_dir = Path(__file__).parent.resolve()
     cwd = Path.cwd().resolve()
 


### PR DESCRIPTION
When developing I sometimes call 
```
~/code/green-metrics-tool$ pytest .
```
as I am hopping around in dirs. This will initially look like it is working till it will fail because paths will fail. This PR adds a check that we are calling `pytest` from the `test` folder. 

Probably not an error @ArneTR makes :)