### PR TITLE
Added NOT NULL to all columns where it made sense

### DIFF
--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -634,7 +634,7 @@ LEFT JOIN carbondb_projects as p ON cd.project = p.id;
 
 CREATE TABLE hog_simplified_measurements (
     id SERIAL PRIMARY KEY,
-    user_id integer NOT NULL REFERENCES users(id) ON DELETE SET NULL ON UPDATE CASCADE,
+    user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE,
     machine_uuid UUID NOT NULL,
     timestamp BIGINT NOT NULL,
     timezone TEXT CHECK (char_length(timezone) <= 50),


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added `NOT NULL` constraints to 40+ columns across multiple tables to enforce data integrity in the database schema.

**Critical Issues Found:**
- **Missing migration file**: Only `structure.sql` updated, no `ALTER TABLE` statements for existing databases
- **Conflicting constraint**: `hog_simplified_measurements.user_id` has `NOT NULL` with `ON DELETE SET NULL` (line 637)

**Concerns:**
- Existing databases with NULL values in these columns will fail when migration is applied
- No data validation or backfill strategy provided for tables like `machines.description`, `runs.uri`, `notes.note`, `warnings.message`, etc.
- Foreign key syntax reformatted in `hog_top_processes` table (line 662)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->