### PR TITLE
Sending usage scenario variables as empty or null will include all combinations

### DIFF
--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -135,9 +135,12 @@
                                 </select>
                             </div>
                             <div class="inline fields">
-                                <label>Usage Scenario Variables:</label>
-                                    <input type="text" name="usage_scenario_variables" value="" placeholder='Type either only key, only value or as KV-Pairs with double quotes if string e.g. __GMT_VAR_NAME__="Cat"' class="ui input large">
+                                <label style="min-width: 15em;">Usage Scenario Variables:<br>
+                                    <i class="info circle icon"></i> <small>Leave empty to include all</small>
+                                </label>
+                                <input type="text" name="usage_scenario_variables" value="" placeholder='Type either only key, only value or as KV-Pairs with double quotes if string e.g. __GMT_VAR_NAME__="Cat"' class="ui input large">
                             </div>
+
                             <div class="inline fields">
                                 <label>Metrics to show:</label>
                                 <div class="field">


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR enhances the timeline query feature to allow viewing all usage scenario variable combinations when no specific filter is provided.

**Key changes:**
- Makes `usage_scenario_variables` filter conditional in `get_timeline_query()` - only applies when explicitly provided
- Adds JSON validation for `usage_scenario_variables` using `orjson.loads()` before query execution
- Updates the frontend with a helpful hint: "Leave empty to include all"

Previously, empty/null `usage_scenario_variables` defaulted to `{}`, which would only match runs with exactly empty variables. Now, leaving it empty returns all runs regardless of their usage scenario variables, giving users more flexibility when exploring timeline data.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->