### PR TITLE
add missing disk type NVME for containers

### DIFF
--- a/metric_providers/disk/io/cgroup/container/source.c
+++ b/metric_providers/disk/io/cgroup/container/source.c
@@ -57,6 +57,7 @@ static disk_io_t get_disk_cgroup(char* path, char* container_name) {
         // 180    USB devices
         // 202    Xen virtual block devices
         // 254    Device-mapper (e.g., LVM, cryptsetup)
+        // 259    Block extended (NVMe devices, dynamically assigned)
 
         if (
             major_number == 1 || // 1    Memory devices (e.g., /dev/mem, /dev/null)
@@ -68,7 +69,8 @@ static disk_io_t get_disk_cgroup(char* path, char* container_name) {
         ) {
             continue;
         }
-        if (minor_number % 16 != 0) {
+        // NVMe devices (major 259) use a different minor numbering scheme, so skip the % 16 check for them
+        if (major_number != 259 && minor_number % 16 != 0) {
             fprintf(stderr, "Partion inside a docker container found. This should not happen: %u:%u rbytes=%llu wbytes=%llu\n", major_number, minor_number, rbytes, wbytes);
             exit(1);
         }


### PR DESCRIPTION
I've used GMT mostly on a Mac, where it is pretty limited, but now I've added a dual boot with Ubuntu/Linux so I can use GMT with Linux.

I tried running it with projects I tried before on your cluster, and got this error, originating from this file:

Partion inside a docker container found. This should not happen: 259:5 rbytes=247291904 wbytes=495616

With some research I found out that this 259 is a legit 'storage type' for NVMe's, so GMT shouldn't crash on that, and include the NVMe data in the metrics. For the rest, I don't know an awful lot about this, but I did realize that you can only run into this issue if you run this hardware, so I figured I add this patch, which did solve the run failure.