### PR TITLE
Hardening the subit by making the file also unwriteable by group

### DIFF
--- a/metric_providers/cpu/energy/rapl/msr/component/Makefile
+++ b/metric_providers/cpu/energy/rapl/msr/component/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lm -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@

--- a/metric_providers/cpu/throttling/msr/component/Makefile
+++ b/metric_providers/cpu/throttling/msr/component/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lm -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@

--- a/metric_providers/memory/energy/rapl/msr/component/Makefile
+++ b/metric_providers/memory/energy/rapl/msr/component/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lm -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/container/Makefile
+++ b/metric_providers/network/io/cgroup/container/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lc -lcurl -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h $(GMT_LIB_DIR)/gmt-container-lib.o $(GMT_LIB_DIR)/gmt-container-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-container-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@

--- a/metric_providers/network/io/cgroup/system/Makefile
+++ b/metric_providers/network/io/cgroup/system/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lcurl -lc -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h $(GMT_LIB_DIR)/gmt-container-lib.o $(GMT_LIB_DIR)/gmt-container-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-container-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/ac/mcp/machine/Makefile
+++ b/metric_providers/psu/energy/ac/mcp/machine/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lm -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@

--- a/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
+++ b/metric_providers/psu/energy/dc/rapl/msr/machine/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -O3 -Wall -Werror -lm -I$(GMT_LIB_DIR)
 
 metric-provider-binary: source.c $(GMT_LIB_DIR)/gmt-lib.o $(GMT_LIB_DIR)/gmt-lib.h
 	gcc $(GMT_LIB_DIR)/gmt-lib.o $< $(CFLAGS) -o $@
-	sudo chown root $@
+	sudo chown root:root $@
 	sudo chmod u+s $@


### PR DESCRIPTION
Technically not needed as the subit already pops when the file is modified anyway.

But there is no need to have the file group writeable, so locking it down

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens several setuid metric-provider build targets by changing the post-build ownership step from `sudo chown root $@` to `sudo chown root:root $@`, ensuring the resulting binaries are owned by group `root` rather than inheriting a potentially writable group.

This fits into the codebase’s pattern of compiling small metric-provider binaries and then setting ownership/permissions (including setuid) so they can access privileged system interfaces at runtime.

Issues found:
- Several Makefiles now lack a trailing newline, producing `\ No newline at end of file` diffs and potentially tripping strict text-file checks.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->