### PR TITLE
Acl volume loading reboot

### DIFF
--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -132,7 +132,7 @@ VALUES (
             "dev_no_sleeps": false,
             "skip_optimizations": false,
             "dev_no_container_dependency_collection": false,
-            "allow_unsafe": false,
+            "allowed_volume_mounts": [],
             "skip_unsafe": true,
             "dev_no_system_checks": false,
             "skip_volume_inspect": false,

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -43,7 +43,7 @@ class RunJob(Job):
             filename=self._filename,
             branch=self._branch,
             commit_hash=self._commit_hash,
-            allow_unsafe=user._capabilities['measurement']['allow_unsafe'],
+            allow_unsafe=False, # cluster runs should never allow this. All should go through individual user permissions,
             skip_unsafe=user._capabilities['measurement']['skip_unsafe'],
             dev_no_system_checks=user._capabilities['measurement']['dev_no_system_checks'],
             skip_volume_inspect=user._capabilities['measurement']['skip_volume_inspect'],

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -66,6 +66,7 @@ class RunJob(Job):
             dev_no_sleeps=user._capabilities['measurement']['dev_no_sleeps'],
             disabled_metric_providers=user._capabilities['measurement']['disabled_metric_providers'],
             allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'], # They are specific to the orchestrator. However currently we only have one. As soon as we support more orchestrators we will sub-class Runner with dedicated child classes (DockerRunner, PodmanRunner etc.)
+            allowed_volume_mounts=user._capabilities['measurement']['allowed_volume_mounts'],
 
 
         )

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1378,7 +1378,7 @@ class ScenarioRunner:
                             else:
                                 mount_type = 'bind'
                                 if mount_option != ',readonly':
-                                    raise RuntimeError(f"Service '{service_name}': We only allow readonly (ro) as parameter in volume mounts in unsafe mode. Volume: {volume}")
+                                    raise RuntimeError(f"Service '{service_name}': We only allow readonly (ro) as parameter in volume mounts in safe mode. Volume: {volume} - Try --allow-unsafe if you are running locally")
                                 mount_src = self._join_paths(self.__working_folder, mount_src).as_posix()
                         except FileNotFoundError as exc:
                             raise RuntimeError(f"The mount path {mount_src} could not be loaded or found at the specified path.") from exc

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1358,7 +1358,7 @@ class ScenarioRunner:
 
                             mount_string = f"{mount_src}{mount_option}"
                             if mount_string in self._allowed_volume_mounts:
-                                if '/' not in mount_src: # volume case. should exist
+                                if not Path(mount_src).is_absolute() and not mount_src.startswith(('.', '..')): # volume case. should exist
                                     mount_type = 'volume'
                                     ps = subprocess.run(
                                         ["docker", "volume", "inspect", mount_src],
@@ -1373,6 +1373,8 @@ class ScenarioRunner:
 
                                 else: # path case. Check path if on machine as -v will create folder otherwise
                                     mount_type = 'bind'
+                                    if not Path(mount_src).is_absolute():
+                                        raise ValueError(f"Mount path in allow listed volume mounts must be absolute. Value was: {mount_src}")
                                     mount_src = Path(mount_src).resolve(strict=True).as_posix()
 
                             else:

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1346,7 +1346,13 @@ class ScenarioRunner:
 
                         mount_src = vol[0]
                         mount_target = vol[1]
-                        mount_option = 'ro' if vol_len == 2 else vol[2]
+                        mount_option = '' # read-write by default. But will work only with allow list
+
+                        if vol_len == 3:
+                            if vol[2] == 'ro' or vol[2] == 'readonly':
+                                mount_option = ',readonly'
+                            else:
+                                raise ValueError(f"Service '{service_name}': We only allow readonly (ro) or no parameter (writeable) for volume mounts. Volume: {volume}")
 
                         try:
                             mount_string = f"{mount_src}:{mount_option}"
@@ -1362,26 +1368,29 @@ class ScenarioRunner:
                                     )
                                     if ps.returncode != 0:
                                         raise RuntimeError(f"Could not find volume '{mount_src}' locally from service: {service_name}. The volume must be created manually before it can be loaded. GMT does not create named volumes. - Error from Docker: {ps.stderr}")
+                                    docker_run_string.append('--mount')
+                                    docker_run_string.append(f"type=volume,source={mount_src},target={mount_target}{mount_option}")
+
 
                                 else: # path case. Check path if on machine as -v will create folder otherwise
                                     mount_src_absolute = Path(mount_src).resolve(strict=True)
-
-                                # we are using the more flexible -v option here bc it can also load named volumes with same syntax
-                                docker_run_string.append('-v')
-                                docker_run_string.append(mount_string)
+                                    docker_run_string.append('--mount')
+                                    docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target}{mount_option}")
 
 
                             else:
-                                mount_src_absolute = self._join_paths(self.__working_folder, vol[0]).as_posix()
-                                if mount_option != 'ro':
+                                if mount_option != ',readonly':
                                     raise RuntimeError(f"Service '{service_name}': We only allow ro as parameter in volume mounts in unsafe mode. Volume: {volume}")
 
-                                if ',' in mount_src_absolute: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
-                                    raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src_absolute}")
+                                mount_src_absolute = self._join_paths(self.__working_folder, vol[0]).
+
+                                if ',' in mount_src_absolute.as_posix(): # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                                    raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src_absolute.as_posix()}")
                                 if ',' in mount_target: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
                                     raise ValueError(f"Mount target path may not contain commas (,) in the name: {mount_target}")
                                 docker_run_string.append('--mount')
-                                docker_run_string.append(f"type=bind,source={mount_src_absolute},target={mount_target},{mount_option}")
+                                docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target},readonly")
+
                         except FileNotFoundError as exc:
                             raise RuntimeError(f"The volume {mount_src} could not be loaded or found at the specified path.") from exc
 

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1354,7 +1354,7 @@ class ScenarioRunner:
                             else:
                                 raise ValueError(f"Service '{service_name}': We only allow readonly (ro) or no parameter (writeable) for volume mounts. Volume: {volume}")
 
-                        mount_string = f"{mount_src}:{mount_option}"
+                        mount_string = f"{mount_src}{mount_option}"
                         if mount_string in self._allowed_volume_mounts:
                             if '/' not in mount_src: # volume case. should exist
                                 ps = subprocess.run(
@@ -1379,7 +1379,7 @@ class ScenarioRunner:
 
                         else:
                             if mount_option != ',readonly':
-                                raise RuntimeError(f"Service '{service_name}': We only allow ro as parameter in volume mounts in unsafe mode. Volume: {volume}")
+                                raise RuntimeError(f"Service '{service_name}': We only allow readonly (ro) as parameter in volume mounts in unsafe mode. Volume: {volume}")
 
                             try:
                                 mount_src_absolute = self._join_paths(self.__working_folder, vol[0])

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1354,45 +1354,45 @@ class ScenarioRunner:
                             else:
                                 raise ValueError(f"Service '{service_name}': We only allow readonly (ro) or no parameter (writeable) for volume mounts. Volume: {volume}")
 
-                        try:
-                            mount_string = f"{mount_src}:{mount_option}"
-                            if mount_string in self._allowed_volume_mounts:
-                                if '/' not in mount_src: # volume case. should exist
-                                    ps = subprocess.run(
-                                        ["docker", "volume", "inspect", mount_src],
-                                        check=False,
-                                        stdout=subprocess.DEVNULL,
-                                        stderr=subprocess.PIPE,
-                                        encoding='UTF-8',
-                                        errors='replace'
-                                    )
-                                    if ps.returncode != 0:
-                                        raise RuntimeError(f"Could not find volume '{mount_src}' locally from service: {service_name}. The volume must be created manually before it can be loaded. GMT does not create named volumes. - Error from Docker: {ps.stderr}")
-                                    docker_run_string.append('--mount')
-                                    docker_run_string.append(f"type=volume,source={mount_src},target={mount_target}{mount_option}")
-
-
-                                else: # path case. Check path if on machine as -v will create folder otherwise
-                                    mount_src_absolute = Path(mount_src).resolve(strict=True)
-                                    docker_run_string.append('--mount')
-                                    docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target}{mount_option}")
-
-
-                            else:
-                                if mount_option != ',readonly':
-                                    raise RuntimeError(f"Service '{service_name}': We only allow ro as parameter in volume mounts in unsafe mode. Volume: {volume}")
-
-                                mount_src_absolute = self._join_paths(self.__working_folder, vol[0]).
-
-                                if ',' in mount_src_absolute.as_posix(): # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
-                                    raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src_absolute.as_posix()}")
-                                if ',' in mount_target: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
-                                    raise ValueError(f"Mount target path may not contain commas (,) in the name: {mount_target}")
+                        mount_string = f"{mount_src}:{mount_option}"
+                        if mount_string in self._allowed_volume_mounts:
+                            if '/' not in mount_src: # volume case. should exist
+                                ps = subprocess.run(
+                                    ["docker", "volume", "inspect", mount_src],
+                                    check=False,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.PIPE,
+                                    encoding='UTF-8',
+                                    errors='replace'
+                                )
+                                if ps.returncode != 0:
+                                    raise RuntimeError(f"Could not find volume '{mount_src}' locally from service: {service_name}. The volume must be created manually before it can be loaded. GMT does not create named volumes. - Error from Docker: {ps.stderr}")
                                 docker_run_string.append('--mount')
-                                docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target},readonly")
+                                docker_run_string.append(f"type=volume,source={mount_src},target={mount_target}{mount_option}")
 
-                        except FileNotFoundError as exc:
-                            raise RuntimeError(f"The volume {mount_src} could not be loaded or found at the specified path.") from exc
+
+                            else: # path case. Check path if on machine as -v will create folder otherwise
+                                mount_src_absolute = Path(mount_src).resolve(strict=True)
+                                docker_run_string.append('--mount')
+                                docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target}{mount_option}")
+
+
+                        else:
+                            if mount_option != ',readonly':
+                                raise RuntimeError(f"Service '{service_name}': We only allow ro as parameter in volume mounts in unsafe mode. Volume: {volume}")
+
+                            try:
+                                mount_src_absolute = self._join_paths(self.__working_folder, vol[0])
+                            except FileNotFoundError as exc:
+                                raise RuntimeError(f"The volume {mount_src} could not be loaded or found at the specified path.") from exc
+
+                            if ',' in mount_src_absolute.as_posix(): # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                                raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src_absolute.as_posix()}")
+                            if ',' in mount_target: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                                raise ValueError(f"Mount target path may not contain commas (,) in the name: {mount_target}")
+                            docker_run_string.append('--mount')
+                            docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target},readonly") # only readonly mounts for non allow list mounts
+
 
             if service.get('init', False):
                 docker_run_string.append('--init')

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -65,7 +65,8 @@ class ScenarioRunner:
         verbose_provider_boot=False, full_docker_prune=False, commit_hash_folder=None,
         commit_hash=None,
         docker_prune=False, job_id=None, user_id=1,
-        disabled_metric_providers=None, allowed_run_args=None, phase_padding=True, usage_scenario_variables=None,
+        disabled_metric_providers=None, allowed_run_args=None, allowed_volume_mounts=None,
+        phase_padding=True, usage_scenario_variables=None,
         category_ids=None,
 
         measurement_system_check_threshold=3, measurement_pre_test_sleep=5, measurement_idle_duration=60,
@@ -156,6 +157,7 @@ class ScenarioRunner:
         self._measurement_total_duration = measurement_total_duration
         self._disabled_metric_providers = [] if disabled_metric_providers is None else disabled_metric_providers
         self._allowed_run_args = [] if allowed_run_args is None else allowed_run_args # They are specific to the orchestrator. However currently we only have one. As soon as we support more orchestrators we will sub-class Runner with dedicated child classes (DockerRunner, PodmanRunner etc.)
+        self._allowed_volume_mounts = [] if allowed_volume_mounts is None else allowed_volume_mounts
         self._measurement_system_check_threshold = measurement_system_check_threshold
         self._measurement_pre_test_sleep = measurement_pre_test_sleep
         self._measurement_idle_duration = measurement_idle_duration
@@ -1023,7 +1025,7 @@ class ScenarioRunner:
                     if ',' in relation['mount_path']:
                         raise ValueError(f"Relation mount path may not contain commas (,) in the name: {relation['mount_path']}")
                     docker_build_command.append('--mount')
-                    docker_build_command.append(f"type=bind,source={relation['mount_path']},target=/tmp/relations/{relation_key},readonly")
+                    docker_build_command.append(f"type=bind,source={relation['mount_path']},target=/tmp/relations/{relation_key},readonly") # relation_key already checked in schema_checker
 
                 docker_build_command.append('gcr.io/kaniko-project/executor:latest')
 
@@ -1321,7 +1323,7 @@ class ScenarioRunner:
             if 'volumes' in service:
                 if self._allow_unsafe:
                     for volume in service['volumes']:
-                        docker_run_string.append('-v')
+                        docker_run_string.append('-v') # since the volume can be bind or anonymous we use the more flexible -v syntax here
                         vol = volume.split(':',1) # there might be an :ro etc at the end, so only split once
                         if not Path(vol[0]).is_absolute(): # we have a bind-mount with relative path
                             path = Path(self.__working_folder, vol[0]).resolve()
@@ -1333,18 +1335,55 @@ class ScenarioRunner:
                 else: # safe volume bindings are active by default
                     for volume in service['volumes']:
                         vol = volume.split(':')
-                        # We always assume the format to be ./dir:dir:[flag] as if we allow none bind mounts people
-                        # could create volumes that would linger on our system.
-                        try:
-                            path = self._join_paths(self.__working_folder, vol[0])
-                        except FileNotFoundError as exc:
-                            raise RuntimeError(f"The volume {vol[0]} could not be loaded or found at the specified path.") from exc
-                        if len(vol) == 3:
-                            if vol[2] != 'ro':
-                                raise RuntimeError(f"Service '{service_name}': We only allow ro as parameter in volume mounts in unsafe mode")
 
-                        docker_run_string.append('--mount')
-                        docker_run_string.append(f"type=bind,source={path},target={vol[1]},readonly")
+                        vol_len = len(vol)
+                        # We always assume the format to be ./dir:dir:[flag] as when we would
+                        # allow None bind mounts then people
+                        # could create volumes that would linger on our system.
+
+                        if vol_len < 2 or vol_len > 3:
+                            raise ValueError(f"Volume mount path '{volume}' is malformed should be source:target:MOUNT_OPTION")
+
+                        mount_src = vol[0]
+                        mount_target = vol[1]
+                        mount_option = 'ro' if vol_len == 2 else vol[2]
+
+                        try:
+                            mount_string = f"{mount_src}:{mount_option}"
+                            if mount_string in self._allowed_volume_mounts:
+                                if '/' not in mount_src: # volume case. should exist
+                                    ps = subprocess.run(
+                                        ["docker", "volume", "inspect", mount_src],
+                                        check=False,
+                                        stdout=subprocess.DEVNULL,
+                                        stderr=subprocess.PIPE,
+                                        encoding='UTF-8',
+                                        errors='replace'
+                                    )
+                                    if ps.returncode != 0:
+                                        raise RuntimeError(f"Could not find volume '{mount_src}' locally from service: {service_name}. The volume must be created manually before it can be loaded. GMT does not create named volumes. - Error from Docker: {ps.stderr}")
+
+                                else: # path case. Check path if on machine as -v will create folder otherwise
+                                    mount_src_absolute = Path(mount_src).resolve(strict=True)
+
+                                # we are using the more flexible -v option here bc it can also load named volumes with same syntax
+                                docker_run_string.append('-v')
+                                docker_run_string.append(mount_string)
+
+
+                            else:
+                                mount_src_absolute = self._join_paths(self.__working_folder, vol[0]).as_posix()
+                                if mount_option != 'ro':
+                                    raise RuntimeError(f"Service '{service_name}': We only allow ro as parameter in volume mounts in unsafe mode. Volume: {volume}")
+
+                                if ',' in mount_src_absolute: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                                    raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src_absolute}")
+                                if ',' in mount_target: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                                    raise ValueError(f"Mount target path may not contain commas (,) in the name: {mount_target}")
+                                docker_run_string.append('--mount')
+                                docker_run_string.append(f"type=bind,source={mount_src_absolute},target={mount_target},{mount_option}")
+                        except FileNotFoundError as exc:
+                            raise RuntimeError(f"The volume {mount_src} could not be loaded or found at the specified path.") from exc
 
             if service.get('init', False):
                 docker_run_string.append('--init')

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1332,7 +1332,7 @@ class ScenarioRunner:
                             docker_run_string.append(f"{path.as_posix()}:{vol[1]}")
                         else:
                             docker_run_string.append(f"{volume}")
-                else: # safe volume bindings are active by default
+                else:
                     for volume in service['volumes']:
                         vol = volume.split(':')
 
@@ -1354,45 +1354,43 @@ class ScenarioRunner:
                             else:
                                 raise ValueError(f"Service '{service_name}': We only allow readonly (ro) or no parameter (writeable) for volume mounts. Volume: {volume}")
 
-                        mount_string = f"{mount_src}{mount_option}"
-                        if mount_string in self._allowed_volume_mounts:
-                            if '/' not in mount_src: # volume case. should exist
-                                ps = subprocess.run(
-                                    ["docker", "volume", "inspect", mount_src],
-                                    check=False,
-                                    stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.PIPE,
-                                    encoding='UTF-8',
-                                    errors='replace'
-                                )
-                                if ps.returncode != 0:
-                                    raise RuntimeError(f"Could not find volume '{mount_src}' locally from service: {service_name}. The volume must be created manually before it can be loaded. GMT does not create named volumes. - Error from Docker: {ps.stderr}")
-                                docker_run_string.append('--mount')
-                                docker_run_string.append(f"type=volume,source={mount_src},target={mount_target}{mount_option}")
+                        try: # Path.resolve and _join_paths can error
+
+                            mount_string = f"{mount_src}{mount_option}"
+                            if mount_string in self._allowed_volume_mounts:
+                                if '/' not in mount_src: # volume case. should exist
+                                    mount_type = 'volume'
+                                    ps = subprocess.run(
+                                        ["docker", "volume", "inspect", mount_src],
+                                        check=False,
+                                        stdout=subprocess.DEVNULL,
+                                        stderr=subprocess.PIPE,
+                                        encoding='UTF-8',
+                                        errors='replace'
+                                    )
+                                    if ps.returncode != 0:
+                                        raise RuntimeError(f"Could not find volume '{mount_src}' locally from service: {service_name}. The volume must be created manually before it can be loaded. GMT does not create named volumes. - Error from Docker: {ps.stderr}")
+
+                                else: # path case. Check path if on machine as -v will create folder otherwise
+                                    mount_type = 'bind'
+                                    mount_src = Path(mount_src).resolve(strict=True).as_posix()
+
+                            else:
+                                mount_type = 'bind'
+                                if mount_option != ',readonly':
+                                    raise RuntimeError(f"Service '{service_name}': We only allow readonly (ro) as parameter in volume mounts in unsafe mode. Volume: {volume}")
+                                mount_src = self._join_paths(self.__working_folder, mount_src).as_posix()
+                        except FileNotFoundError as exc:
+                            raise RuntimeError(f"The mount path {mount_src} could not be loaded or found at the specified path.") from exc
 
 
-                            else: # path case. Check path if on machine as -v will create folder otherwise
-                                mount_src_absolute = Path(mount_src).resolve(strict=True)
-                                docker_run_string.append('--mount')
-                                docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target}{mount_option}")
+                        if ',' in mount_src: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                            raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src}")
+                        if ',' in mount_target: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
+                            raise ValueError(f"Mount target path may not contain commas (,) in the name: {mount_target}")
 
-
-                        else:
-                            if mount_option != ',readonly':
-                                raise RuntimeError(f"Service '{service_name}': We only allow readonly (ro) as parameter in volume mounts in unsafe mode. Volume: {volume}")
-
-                            try:
-                                mount_src_absolute = self._join_paths(self.__working_folder, vol[0])
-                            except FileNotFoundError as exc:
-                                raise RuntimeError(f"The volume {mount_src} could not be loaded or found at the specified path.") from exc
-
-                            if ',' in mount_src_absolute.as_posix(): # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
-                                raise ValueError(f"Mount source path may not contain commas (,) in the name: {mount_src_absolute.as_posix()}")
-                            if ',' in mount_target: # when supplying a comma a user can repeat the ,src= directive effectively altering the source to be mounted
-                                raise ValueError(f"Mount target path may not contain commas (,) in the name: {mount_target}")
-                            docker_run_string.append('--mount')
-                            docker_run_string.append(f"type=bind,source={mount_src_absolute.as_posix()},target={mount_target},readonly") # only readonly mounts for non allow list mounts
-
+                        docker_run_string.append('--mount')
+                        docker_run_string.append(f"type={mount_type},source={mount_src},target={mount_target}{mount_option}")
 
             if service.get('init', False):
                 docker_run_string.append('--init')

--- a/migrations/2026_04_07_volume_mounts.sql
+++ b/migrations/2026_04_07_volume_mounts.sql
@@ -1,0 +1,12 @@
+UPDATE users
+SET capabilities = capabilities #- '{measurement,allow_unsafe}'
+WHERE capabilities #> '{measurement,allow_unsafe}' IS NOT NULL;
+
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{measurement,allowed_volume_mounts}',
+   '[]',
+    true
+);

--- a/tests/data/usage_scenarios/entrypoint_script.yml
+++ b/tests/data/usage_scenarios/entrypoint_script.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: ../entrypoint-application
     volumes:
-      - ../entrypoint-application/entrypoint-overwrite.sh:/tmp/entrypoint-overwrite.sh
+      - ../entrypoint-application/entrypoint-overwrite.sh:/tmp/entrypoint-overwrite.sh:ro
     entrypoint: /tmp/entrypoint-overwrite.sh # overwrite entrypoint
 
 flow:

--- a/tests/data/usage_scenarios/subdir_volume_loading/subdir/subdir2/usage_scenario_subdir2.yml
+++ b/tests/data/usage_scenarios/subdir_volume_loading/subdir/subdir2/usage_scenario_subdir2.yml
@@ -10,7 +10,7 @@ services:
     image: volume_bind_mount_rel_to_context
     container_name: test-container
     volumes:
-      - ./testfile2:/tmp/testfile2-correctly-mounted
+      - ./testfile2:/tmp/testfile2-correctly-mounted:ro
 
 flow:
   - name: Cat Subdir2 Mount

--- a/tests/data/usage_scenarios/subdir_volume_loading/subdir/usage_scenario_subdir.yml
+++ b/tests/data/usage_scenarios/subdir_volume_loading/subdir/usage_scenario_subdir.yml
@@ -10,8 +10,8 @@ services:
     image: volume_bind_mount_rel_to_context
     container_name: test-container
     volumes:
-      - ./subdir2/testfile2:/tmp/testfile2-correctly-mounted
-      - ./subdir2/subdir3/testfile3:/tmp/testfile3-correctly-mounted
+      - ./subdir2/testfile2:/tmp/testfile2-correctly-mounted:ro
+      - ./subdir2/subdir3/testfile3:/tmp/testfile3-correctly-mounted:ro
     command: sh
 
 flow:

--- a/tests/data/usage_scenarios/subdir_volume_loading/usage_scenario.yml
+++ b/tests/data/usage_scenarios/subdir_volume_loading/usage_scenario.yml
@@ -10,8 +10,8 @@ services:
     image: volume_bind_mount_rel_to_context_root
     container_name: test-container-root
     volumes:
-      - ./subdir/testfile:/tmp/testfile-correctly-mounted
-      - ./subdir/subdir2/testfile2:/tmp/testfile2-correctly-mounted
+      - ./subdir/testfile:/tmp/testfile-correctly-mounted:ro
+      - ./subdir/subdir2/testfile2:/tmp/testfile2-correctly-mounted:ro
 
   test-container:
     build:
@@ -20,9 +20,9 @@ services:
     image: volume_bind_mount_rel_to_context
     container_name: test-container
     volumes:
-      - ./subdir/testfile:/tmp/testfile-correctly-mounted
-      - ./subdir/subdir2/testfile2:/tmp/testfile2-correctly-mounted
-      - ./subdir/subdir2/subdir3/testfile3:/tmp/testfile3-correctly-mounted
+      - ./subdir/testfile:/tmp/testfile-correctly-mounted:ro
+      - ./subdir/subdir2/testfile2:/tmp/testfile2-correctly-mounted:ro
+      - ./subdir/subdir2/subdir3/testfile3:/tmp/testfile3-correctly-mounted:ro
 
 
 flow:

--- a/tests/data/usage_scenarios/volume_load_dot_path.yml
+++ b/tests/data/usage_scenarios/volume_load_dot_path.yml
@@ -10,7 +10,7 @@ services:
       context: ../stress-application
     container_name: test-container
     volumes:
-      - .:/tmp/repo_dir
+      - .:/tmp/repo_dir:ro
 
 flow:
   - name: Test

--- a/tests/data/usage_scenarios/volume_load_dot_path_ro.yml
+++ b/tests/data/usage_scenarios/volume_load_dot_path_ro.yml
@@ -10,7 +10,7 @@ services:
       context: ../stress-application
     container_name: test-container
     volumes:
-      - .:/tmp/repo_dir
+      - .:/tmp/repo_dir:ro
 
 flow:
   - name: Test

--- a/tests/data/usage_scenarios/volume_load_dot_slash_path.yml
+++ b/tests/data/usage_scenarios/volume_load_dot_slash_path.yml
@@ -10,7 +10,7 @@ services:
       context: ../stress-application
     container_name: test-container
     volumes:
-      - ./:/tmp/repo_dir:ro
+      - ./:/tmp/repo_dir
 
 flow:
   - name: Test

--- a/tests/data/usage_scenarios/volume_load_dot_slash_path.yml
+++ b/tests/data/usage_scenarios/volume_load_dot_slash_path.yml
@@ -10,7 +10,7 @@ services:
       context: ../stress-application
     container_name: test-container
     volumes:
-      - ./:/tmp/repo_dir
+      - ./:/tmp/repo_dir:ro
 
 flow:
   - name: Test

--- a/tests/data/usage_scenarios/volume_load_dot_slash_path_ro.yml
+++ b/tests/data/usage_scenarios/volume_load_dot_slash_path_ro.yml
@@ -1,5 +1,5 @@
 ---
-name: Test dot volume path
+name: Test dot slash volume path
 author: Test
 description: test
 
@@ -10,7 +10,7 @@ services:
       context: ../stress-application
     container_name: test-container
     volumes:
-      - .:/tmp/repo_dir
+      - ./:/tmp/repo_dir:ro
 
 flow:
   - name: Test

--- a/tests/data/usage_scenarios/volume_load_etc_hosts.yml
+++ b/tests/data/usage_scenarios/volume_load_etc_hosts.yml
@@ -10,7 +10,7 @@ services:
     image: gcb_stress
     container_name: test-container
     volumes:
-      - /etc/hosts:/tmp/hosts
+      - /etc/hosts:/tmp/hosts:ro
 
 flow:
   - name: Stress

--- a/tests/data/usage_scenarios/volume_load_non_bind_mounts.yml
+++ b/tests/data/usage_scenarios/volume_load_non_bind_mounts.yml
@@ -10,7 +10,7 @@ services:
     image: gcb_stress
     container_name: test-container
     volumes:
-      - test-volume:/tmp/test-volume
+      - gmt-test-volume-delete-me:/tmp/test-volume
 
 flow:
   - name: Stress

--- a/tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml
+++ b/tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml
@@ -10,7 +10,7 @@ services:
     image: gcb_stress
     container_name: test-container
     volumes:
-      - ../tmp/symlink:/tmp/hosts:ro
+      - gmt-test-volume-delete-me:/tmp/test-volume:ro
 
 flow:
   - name: Stress

--- a/tests/data/usage_scenarios/volume_load_references.yml
+++ b/tests/data/usage_scenarios/volume_load_references.yml
@@ -10,7 +10,7 @@ services:
     image: gcb_stress
     container_name: test-container
     volumes: &test-volume
-      - ../mounts/test-file:/tmp/test-file
+      - ../mounts/test-file:/tmp/test-file:ro
 
   test-container-2:
     build:

--- a/tests/data/usage_scenarios/volume_load_within_proj.yml
+++ b/tests/data/usage_scenarios/volume_load_within_proj.yml
@@ -10,7 +10,7 @@ services:
     image: gcb_stress
     container_name: test-container
     volumes:
-      - ../mounts/test-file:/tmp/test-file
+      - ../mounts/test-file:/tmp/test-file:ro
 
 flow:
   - name: Stress

--- a/tests/data/web-application/docker-compose.yml
+++ b/tests/data/web-application/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/code
+      - .:/code:ro
     ports:
       - "8000:8000"
     environment:

--- a/tests/test_volume_loading.py
+++ b/tests/test_volume_loading.py
@@ -100,7 +100,7 @@ def test_volume_not_set_as_read_only_should_fail():
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
 
 
-def test_non_existent_volume_should_fail():
+def test_volume_without_allowed_mount_interpreted_as_missing_path():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
 
     try:
@@ -110,16 +110,49 @@ def test_non_existent_volume_should_fail():
     finally:
         container_running = Tests.check_if_container_running('test-container')
 
-    expected_error = 'The volume gmt-test-volume-delete-me could not be loaded or found at the specified path.'
+    expected_error = 'The mount path gmt-test-volume-delete-me could not be loaded or found at the specified path.'
     assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+
+def test_non_existent_but_allowed_volume_should_fail():
+    # we do NOT create the volume here beforehand as we want the test to fail
+
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True, allowed_volume_mounts=['gmt-test-volume-delete-me'])
+
+    try:
+        with pytest.raises(RuntimeError) as e:
+            with Tests.RunUntilManager(runner) as context:
+                context.run_until('setup_services')
+    finally:
+        container_running = Tests.check_if_container_running('test-container')
+
+    expected_error = "Could not find volume 'gmt-test-volume-delete-me' locally from service: test-container. The volume must be created manually before it can be loaded. GMT does not create named volumes."
+    assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
+    assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+
+def test_non_existent_but_allowed_volume_should_fail_readonly():
+    # we do NOT create the volume here beforehand as we want the test to fail
+
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True, allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
+
+    try:
+        with pytest.raises(RuntimeError) as e:
+            with Tests.RunUntilManager(runner) as context:
+                context.run_until('setup_services')
+    finally:
+        container_running = Tests.check_if_container_running('test-container')
+
+    expected_error = "Could not find volume 'gmt-test-volume-delete-me' locally from service: test-container. The volume must be created manually before it can be loaded. GMT does not create named volumes."
+    assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
+    assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+
 
 def test_non_permitted_volume_should_fail():
 
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
 
         try:
             with pytest.raises(RuntimeError) as e:
@@ -128,7 +161,7 @@ def test_non_permitted_volume_should_fail():
         finally:
             container_running = Tests.check_if_container_running('test-container')
 
-        expected_error = 'The volume gmt-test-volume-delete-me could not be loaded or found at the specified path.'
+        expected_error = 'The mount path gmt-test-volume-delete-me could not be loaded or found at the specified path.'
         assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
         assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
     finally:
@@ -160,7 +193,7 @@ def test_allowed_volume_fails_bc_readonly():
         finally:
             container_running = Tests.check_if_container_running('test-container')
 
-        expected_error = 'The volume gmt-test-volume-delete-me could not be loaded or found at the specified path.'
+        expected_error = 'The mount path gmt-test-volume-delete-me could not be loaded or found at the specified path.'
         assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
         assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
     finally:
@@ -171,7 +204,7 @@ def test_allowed_volume_readonly_works():
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
+        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True, allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
 
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
@@ -284,8 +317,8 @@ def _volume_dot_path_runner(filename, allow_unsafe=False):
 
 
 @pytest.mark.parametrize('scenario_filename', [
-    'tests/data/usage_scenarios/volume_load_dot_path.yml',
-    'tests/data/usage_scenarios/volume_load_dot_slash_path.yml',
+    'tests/data/usage_scenarios/volume_load_dot_path_ro.yml',
+    'tests/data/usage_scenarios/volume_load_dot_slash_path_ro.yml',
 ])
 def test_volume_dot_path_safe(scenario_filename):
     mounted_file = os.path.basename(scenario_filename)

--- a/tests/test_volume_loading.py
+++ b/tests/test_volume_loading.py
@@ -14,7 +14,7 @@ from lib.scenario_runner import ScenarioRunner
 from lib.db import DB
 
 def test_volume_load_no_escape():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_etc_hosts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_etc_hosts.yml')
 
     try:
         with pytest.raises(ValueError) as e:
@@ -28,7 +28,7 @@ def test_volume_load_no_escape():
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
 
 def test_volume_load_escape_ok_with_allow_unsafe():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_etc_hosts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, allow_unsafe=True, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_etc_hosts.yml', allow_unsafe=True)
 
     with Tests.RunUntilManager(runner) as context:
         context.run_until('setup_services')
@@ -47,7 +47,7 @@ def test_volume_load_escape_ok_with_allow_unsafe():
     assert "File mounted" in out, Tests.assertion_info('File mounted', f"out: {out} | err: {err}")
 
 def test_load_files_from_within_gmt():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_within_proj.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_within_proj.yml')
 
     with Tests.RunUntilManager(runner) as context:
         context.run_until('setup_services')
@@ -71,7 +71,7 @@ def test_symlinks_should_fail():
 
     os.symlink('/etc/hosts', symlink_file)
 
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_symlinks_negative.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_symlinks_negative.yml')
 
     try:
         with pytest.raises(ValueError) as e:
@@ -86,7 +86,7 @@ def test_symlinks_should_fail():
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
 
 def test_volume_not_set_as_read_only_should_fail():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts.yml')
 
     try:
         with pytest.raises(RuntimeError) as e:
@@ -101,7 +101,7 @@ def test_volume_not_set_as_read_only_should_fail():
 
 
 def test_volume_without_allowed_mount_interpreted_as_missing_path():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml')
 
     try:
         with pytest.raises(RuntimeError) as e:
@@ -117,7 +117,7 @@ def test_volume_without_allowed_mount_interpreted_as_missing_path():
 def test_non_existent_but_allowed_volume_should_fail():
     # we do NOT create the volume here beforehand as we want the test to fail
 
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True, allowed_volume_mounts=['gmt-test-volume-delete-me'])
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', allowed_volume_mounts=['gmt-test-volume-delete-me'])
 
     try:
         with pytest.raises(RuntimeError) as e:
@@ -133,7 +133,7 @@ def test_non_existent_but_allowed_volume_should_fail():
 def test_non_existent_but_allowed_volume_should_fail_readonly():
     # we do NOT create the volume here beforehand as we want the test to fail
 
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True, allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
 
     try:
         with pytest.raises(RuntimeError) as e:
@@ -152,7 +152,7 @@ def test_non_permitted_volume_should_fail():
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+        runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml')
 
         try:
             with pytest.raises(RuntimeError) as e:
@@ -172,7 +172,7 @@ def test_allowed_volume_rw_should_work():
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, allowed_volume_mounts=['gmt-test-volume-delete-me'])
+        runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', allowed_volume_mounts=['gmt-test-volume-delete-me'])
 
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
@@ -184,7 +184,7 @@ def test_allowed_volume_fails_bc_readonly():
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+        runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml')
 
         try:
             with pytest.raises(RuntimeError) as e:
@@ -204,7 +204,7 @@ def test_allowed_volume_readonly_works():
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True, allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
+        runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
 
         with Tests.RunUntilManager(runner) as context:
             context.run_until('setup_services')
@@ -214,7 +214,7 @@ def test_allowed_volume_readonly_works():
 
 
 def test_load_volume_references():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_references.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_references.yml')
 
     with Tests.RunUntilManager(runner) as context:
         context.run_until('setup_services')
@@ -259,7 +259,7 @@ def test_volume_loading_subdirectories_root():
     assert expect_mounted_testfile_3 in run_stdout, Tests.assertion_info(expect_mounted_testfile_3, f"expected output not in {run_stdout}")
 
 def test_volume_loading_subdirectories_subdir():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename="tests/data/usage_scenarios/subdir_volume_loading/subdir/usage_scenario_subdir.yml", dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner("tests/data/usage_scenarios/subdir_volume_loading/subdir/usage_scenario_subdir.yml")
 
     out = io.StringIO()
     err = io.StringIO()
@@ -276,7 +276,7 @@ def test_volume_loading_subdirectories_subdir():
     assert expect_mounted_testfile_3 in run_stdout, Tests.assertion_info(expect_mounted_testfile_3, f"expected output not in {run_stdout}")
 
 def test_volume_loading_subdirectories_subdir2():
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename="tests/data/usage_scenarios/subdir_volume_loading/subdir/subdir2/usage_scenario_subdir2.yml", dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner("tests/data/usage_scenarios/subdir_volume_loading/subdir/subdir2/usage_scenario_subdir2.yml")
 
     out = io.StringIO()
     err = io.StringIO()
@@ -299,7 +299,7 @@ def test_volume_loading_subdirectories_subdir2():
     assert expect_copied_testfile_4 in run_stdout, Tests.assertion_info(expect_copied_testfile_4, f"expected output not in {run_stdout}")
 
 
-def _volume_dot_path_runner(filename, allow_unsafe=False):
+def _volume_dot_path_runner(filename, allowed_volume_mounts=None, allow_unsafe=False):
     return ScenarioRunner(
         uri=GMT_DIR,
         uri_type='folder',
@@ -308,11 +308,13 @@ def _volume_dot_path_runner(filename, allow_unsafe=False):
         dev_no_metrics=True,
         dev_no_phase_stats=True,
         dev_no_sleeps=True,
-        dev_cache_build=False,
+        dev_no_save=True,
+        dev_cache_build=True,
         allow_unsafe=allow_unsafe,
         dev_no_container_dependency_collection=True,
         skip_download_dependencies=True,
         skip_optimizations=True,
+        allowed_volume_mounts=allowed_volume_mounts,
     )
 
 
@@ -409,7 +411,7 @@ def test_volume_inspect():
     )
     assert ps.returncode == 1, 'docker volume of 2g89huiwecjuShjg_Sdnufewiuasd seems to be present on file system. Cannot execute test safely'
 
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/stress_with_named_volume.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, allow_unsafe=True, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = _volume_dot_path_runner('tests/data/usage_scenarios/stress_with_named_volume.yml')
 
 
     try:

--- a/tests/test_volume_loading.py
+++ b/tests/test_volume_loading.py
@@ -85,7 +85,7 @@ def test_symlinks_should_fail():
     assert str(e.value).startswith(expected_error), Tests.assertion_info(expected_error, str(e.value))
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
 
-def test_non_bind_mounts_should_fail():
+def test_volume_not_set_as_read_only_should_fail():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
 
     try:
@@ -95,9 +95,90 @@ def test_non_bind_mounts_should_fail():
     finally:
         container_running = Tests.check_if_container_running('test-container')
 
-    expected_error = 'The volume test-volume could not be loaded or found at the specified path.'
+    expected_error = 'We only allow readonly (ro) as parameter in volume mounts in unsafe mode. Volume: gmt-test-volume-delete-me:/tmp/test-volume'
     assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+
+
+def test_non_existent_volume_should_fail():
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+
+    try:
+        with pytest.raises(RuntimeError) as e:
+            with Tests.RunUntilManager(runner) as context:
+                context.run_until('setup_services')
+    finally:
+        container_running = Tests.check_if_container_running('test-container')
+
+    expected_error = 'The volume gmt-test-volume-delete-me could not be loaded or found at the specified path.'
+    assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
+    assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+
+def test_non_permitted_volume_should_fail():
+
+    subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
+
+    try:
+        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+
+        try:
+            with pytest.raises(RuntimeError) as e:
+                with Tests.RunUntilManager(runner) as context:
+                    context.run_until('setup_services')
+        finally:
+            container_running = Tests.check_if_container_running('test-container')
+
+        expected_error = 'The volume gmt-test-volume-delete-me could not be loaded or found at the specified path.'
+        assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
+        assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+    finally:
+        subprocess.check_output(['docker', 'volume', 'rm', 'gmt-test-volume-delete-me'])
+
+def test_allowed_volume_rw_should_work():
+
+    subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
+
+    try:
+        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, allowed_volume_mounts=['gmt-test-volume-delete-me'])
+
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+    finally:
+        subprocess.check_output(['docker', 'volume', 'rm', 'gmt-test-volume-delete-me'])
+
+def test_allowed_volume_fails_bc_readonly():
+
+    subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
+
+    try:
+        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False)
+
+        try:
+            with pytest.raises(RuntimeError) as e:
+                with Tests.RunUntilManager(runner) as context:
+                    context.run_until('setup_services')
+        finally:
+            container_running = Tests.check_if_container_running('test-container')
+
+        expected_error = 'The volume gmt-test-volume-delete-me could not be loaded or found at the specified path.'
+        assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
+        assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
+    finally:
+        subprocess.check_output(['docker', 'volume', 'rm', 'gmt-test-volume-delete-me'])
+
+def test_allowed_volume_readonly_works():
+
+    subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
+
+    try:
+        runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, allowed_volume_mounts=['gmt-test-volume-delete-me,readonly'])
+
+        with Tests.RunUntilManager(runner) as context:
+            context.run_until('setup_services')
+    finally:
+        subprocess.check_output(['docker', 'volume', 'rm', 'gmt-test-volume-delete-me'])
+
+
 
 def test_load_volume_references():
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/volume_load_references.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)

--- a/tests/test_volume_loading.py
+++ b/tests/test_volume_loading.py
@@ -95,7 +95,7 @@ def test_volume_not_set_as_read_only_should_fail():
     finally:
         container_running = Tests.check_if_container_running('test-container')
 
-    expected_error = 'We only allow readonly (ro) as parameter in volume mounts in unsafe mode. Volume: gmt-test-volume-delete-me:/tmp/test-volume'
+    expected_error = 'We only allow readonly (ro) as parameter in volume mounts in safe mode. Volume: gmt-test-volume-delete-me:/tmp/test-volume - Try --allow-unsafe if you are running locally'
     assert expected_error in str(e.value), Tests.assertion_info(expected_error, str(e.value))
     assert container_running is False, Tests.assertion_info('test-container stopped', 'test-container was still running!')
 

--- a/tests/test_volume_loading.py
+++ b/tests/test_volume_loading.py
@@ -184,7 +184,7 @@ def test_allowed_volume_fails_bc_readonly():
     subprocess.check_output(['docker', 'volume', 'create', 'gmt-test-volume-delete-me'])
 
     try:
-        runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml')
+        runner = _volume_dot_path_runner('tests/data/usage_scenarios/volume_load_non_bind_mounts_readonly.yml', allowed_volume_mounts=['gmt-test-volume-delete-me'])
 
         try:
             with pytest.raises(RuntimeError) as e:


### PR DESCRIPTION
This is a rework of https://github.com/green-coding-solutions/green-metrics-tool/pull/1523 as it was not possible to merge rebase the branch anymore without too many conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Reimplements PR #1523 on a fresh branch. Replaces the boolean user capability `allow_unsafe` with a fine-grained per-user allowlist `allowed_volume_mounts` that controls which named Docker volumes or bind mounts may be used read-write; all other mounts are enforced read-only.

## Key Changes

**Database & Seed**
- Migration (migrations/2026_04_07_volume_mounts.sql) removes `measurement.allow_unsafe` and adds `measurement.allowed_volume_mounts` initialized to an empty JSON array.
- Seed in docker/structure.sql updated to remove `allow_unsafe` and seed `allowed_volume_mounts: []`.

**Runtime / Policy Enforcement**
- lib/scenario_runner.py
  - Adds `allowed_volume_mounts` parameter to ScenarioRunner.__init__ (defaults to []) and stores it as internal state.
  - Reworks safe-mode volume handling to build typed Docker `--mount` entries based on the allowlist rather than always forcing bind+readonly:
    - Validates simple spec format (source:target[:ro|readonly]) and rejects malformed specs.
    - Distinguishes named volumes (no `/` in source) vs bind mounts (contains `/`).
    - For allowlisted mounts:
      - Named volumes: verify existence via `docker volume inspect`.
      - Bind mounts: require absolute paths and resolve them strictly (Path.resolve(strict=True)).
      - Preserve requested readonly option if present.
    - For non-allowlisted mounts: force bind-mount behavior, require readonly, and resolve sources relative to the repo working folder.
    - Rejects comma characters in resolved mount source/target to prevent comma-injection into `--mount` parameters.
  - Docker mount args now use typed `type=...,source=...,target=...[,:ro]` instead of the previous hard-coded bind/readonly construction.

- lib/job/run.py
  - Always constructs ScenarioRunner with `allow_unsafe=False` and forwards the user's `allowed_volume_mounts` into ScenarioRunner.

**Tests**
- Many test scenario YAMLs updated to make host→container mounts read-only (`:ro`) where appropriate.
- tests/test_volume_loading.py:
  - Centralized runner helper `_volume_dot_path_runner(filename, allowed_volume_mounts=None, allow_unsafe=False)` and forwards allowlist into ScenarioRunner; changed runner flags (`dev_no_save=True`, `dev_cache_build=True`).
  - Renamed `test_non_bind_mounts_should_fail` → `test_volume_not_set_as_read_only_should_fail`.
  - Added tests covering missing-path interpretation, non-existent-but-allowed named volumes, non-permitted named volumes, and allowed-volume success/failure (rw/ro) cases. Tests manage Docker named volumes with `docker volume create/rm`.
  - Greptile noted one test duplication (`test_allowed_volume_fails_bc_readonly`) that did not pass `allowed_volume_mounts` and therefore duplicated another scenario; tests adjusted accordingly.

**Other**
- New readonly/mount-path test scenarios added (e.g., volume_load_non_bind_mounts_readonly.yml, volume_load_dot_path_ro.yml, volume_load_dot_slash_path_ro.yml).
- Commit messages indicate tightened validation (only absolute allowlist paths) and test fixes.

## Impact/Risk
- Migration changes user capability shape; existing users are default-restricted by seeding empty allowlists.
- Runtime now depends on Docker volume inspection and strict path resolution; safe defaults enforce read-only for non-allowlisted mounts.
- Greptile reported no unresolved security issues; added defenses include strict path resolution and comma-injection checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `allow_unsafe` capability with a fine-grained `allowed_volume_mounts` allowlist that controls which named volumes/bind mounts can be used in read-write mode, while enforcing read-only for everything else. The migration, seed SQL, `ScenarioRunner`, and `RunJob` are updated consistently.

- `test_allowed_volume_fails_bc_readonly` (line 182) passes no `allowed_volume_mounts`, making it an inadvertent duplicate of `test_non_permitted_volume_should_fail` (line 150) rather than testing the intended scenario where a volume is allowlisted only for RW but the YAML spec requests `:ro`.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The new allowlist mechanism correctly validates named volumes via `docker volume inspect` and restricts bind mounts to paths within the repo using `_join_paths`. The `allow_unsafe=False` enforcement in `lib/job/run.py` removes a trust escalation path. Comma injection into `--mount` parameters is guarded both at volume-name parse time and with explicit `','` checks on `mount_src`/`mount_target` before constructing the Docker command.
</details>

<sub>Reviews (2): Last reviewed commit: ["Speeding up volume tests by skipping bui..."](https://github.com/green-coding-solutions/green-metrics-tool/commit/4ad1d7fa73ae2dbba87c9c2411fa5377897a9efd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27578203)</sub>

<!-- /greptile_comment -->