### PR TITLE
Naming metric providers with simple underscore names

### DIFF
--- a/.devcontainer/codespace-setup.sh
+++ b/.devcontainer/codespace-setup.sh
@@ -22,7 +22,7 @@ sed -i "s#${CODESPACE_NAME}-9143.app.github.dev#localhost#" /workspaces/green-me
 sed -i "s#${CODESPACE_NAME}-9142.app.github.dev#localhost#" /workspaces/green-metrics-tool/docker/nginx/api.conf
 
 # activate XGBoost provider with sane values for GitHub Codespaces
-sed -i 's/common:/common:\n      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:\n        CPUChips: 1\n        HW_CPUFreq: 2800\n        CPUCores: 32\n        CPUThreads: 64\n        TDP: 270\n        HW_MemAmountGB: 256\n        VHost_Ratio: 0.03125\n/' /workspaces/green-metrics-tool/config.yml
+sed -i 's/common:/common:\n      psu_energy_ac_xgboost_machine:\n        CPUChips: 1\n        HW_CPUFreq: 2800\n        CPUCores: 32\n        CPUThreads: 64\n        TDP: 270\n        HW_MemAmountGB: 256\n        VHost_Ratio: 0.03125\n/' /workspaces/green-metrics-tool/config.yml
 
 
 git clone https://github.com/green-coding-solutions/example-applications.git --depth=1 --single-branch /workspaces/green-metrics-tool/example-applications || true

--- a/config.yml.example
+++ b/config.yml.example
@@ -102,90 +102,90 @@ measurement:
     #--- Architecture - Linux Only
     linux:
     #--- Always-On - We recommend these providers to be always enabled
-      cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
+      cpu_utilization_procfs_system:
         sampling_rate: 99
     #--- CGroupV2 - Turn these on if you have CGroupsV2 working on your machine
-      cpu.utilization.cgroup.container.provider.CpuUtilizationCgroupContainerProvider:
+      cpu_utilization_cgroup_container:
         sampling_rate: 99
-      memory.used.cgroup.container.provider.MemoryUsedCgroupContainerProvider:
+      memory_used_cgroup_container:
         sampling_rate: 99
-      network.io.cgroup.container.provider.NetworkIoCgroupContainerProvider:
+      network_io_cgroup_container:
         sampling_rate: 99
-      disk.io.cgroup.container.provider.DiskIoCgroupContainerProvider:
+      disk_io_cgroup_container:
         sampling_rate: 99
     #--- RAPL - Only enable these if you have RAPL enabled on your machine
-#      cpu.energy.rapl.msr.component.provider.CpuEnergyRaplMsrComponentProvider:
+#      cpu_energy_rapl_msr_component:
 #        sampling_rate: 99
-#      memory.energy.rapl.msr.component.provider.MemoryEnergyRaplMsrComponentProvider:
+#      memory_energy_rapl_msr_component:
 #        sampling_rate: 99
     #--- Machine Energy - These providers need special hardware / lab equipment to work
-#      psu.energy.ac.gude.machine.provider.PsuEnergyAcGudeMachineProvider:
+#      psu_energy_ac_gude_machine:
 #        sampling_rate: 99
-#      psu.energy.ac.powerspy2.machine.provider.PsuEnergyAcPowerspy2MachineProvider:
+#      psu_energy_ac_powerspy2_machine:
 #        sampling_rate: 250
-#      psu.energy.ac.mcp.machine.provider.PsuEnergyAcMcpMachineProvider:
+#      psu_energy_ac_mcp_machine:
 #        sampling_rate: 99
-#      psu.energy.ac.ipmi.machine.provider.PsuEnergyAcIpmiMachineProvider:
+#      psu_energy_ac_ipmi_machine:
 #        sampling_rate: 99
-#      psu.energy.dc.rapl.msr.machine.provider.PsuEnergyDcRaplMsrMachineProvider:
+#      psu_energy_dc_rapl_msr_machine:
 #        sampling_rate: 99
     #--- GPU - Only enable these if you have GPUs with power measurement enabled in your machine
-#      gpu.energy.nvidia.nvml.component.provider.GpuEnergyNvidiaNvmlComponentProvider:
+#      gpu_energy_nvidia_nvml_component:
 #        sampling_rate: 99
     #--- Sensors - these providers need the lm-sensors package installed
-#      lmsensors.temperature.component.provider.LmsensorsTemperatureComponentProvider:
+#      lmsensors_temperature_component:
 #        sampling_rate: 99
       # Please change these values according to the names in '$ sensors'
 #        chips: ['thinkpad-isa-0000', 'coretemp-isa-0000']
 #        features: ['CPU', 'Package id 0', 'Core 0', 'Core 1', 'Core 2', 'Core 3']
-#      lmsensors.fan.component.provider.LmsensorsFanComponentProvider:
+#      lmsensors_fan_component:
 #        sampling_rate: 99
       # Please change these values according to the names in '$ sensors'
 #        chips: ['thinkpad-isa-0000']
 #        features: ['fan1', 'fan2']
     #--- Debug - These providers should only be needed for debugging and introspection purposes
-#      cpu.throttling.msr.component.provider.CpuThrottlingMsrComponentProvider:
+#      cpu_throttling_msr_component:
 #        sampling_rate: 99
-#      cpu.frequency.sysfs.core.provider.CpuFrequencySysfsCoreProvider:
+#      cpu_frequency_sysfs_core:
 #        sampling_rate: 99
-#      cpu.time.cgroup.container.provider.CpuTimeCgroupContainerProvider:
+#      cpu_time_cgroup_container:
 #        sampling_rate: 99
-#      cpu.time.cgroup.system.provider.CpuTimeCgroupSystemProvider:
+#      cpu_time_cgroup_system:
 #        sampling_rate: 99
-#      cpu.time.procfs.system.provider.CpuTimeProcfsSystemProvider:
+#      cpu_time_procfs_system:
 #        sampling_rate: 99
-#      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
+#      disk_io_procfs_system:
 #        sampling_rate: 99
-#      network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
+#      network_io_procfs_system:
 #        sampling_rate: 99
 #        remove_virtual_interfaces: True
-#      disk.used.statvfs.system.provider.DiskUsedStatvfsSystemProvider:
+#      disk_used_statvfs_system:
 #        sampling_rate: 99
-#      memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
+#      memory_used_procfs_system:
 #        sampling_rate: 99
     #--- Cgroup system monitoring - These providers can be used to monitor background processes
-#      cpu.utilization.cgroup.system.provider.CpuUtilizationCgroupSystemProvider:
+#      cpu_utilization_cgroup_system:
 #        sampling_rate: 99
 #        cgroups:
 #            "org.gnome.Shell@wayland.service":
 #                name: "Window Manager incl. X11"
 #            "session-2.scope":
 #                name: "GNOME Desktop"
-#      memory.used.cgroup.system.provider.MemoryUsedCgroupSystemProvider:
+#      memory_used_cgroup_system:
 #        sampling_rate: 99
 #        cgroups:
 #            "org.gnome.Shell@wayland.service":
 #                name: "Window Manager incl. X11"
 #            "session-2.scope":
 #                name: "GNOME Desktop"
-#      disk.io.cgroup.system.provider.DiskIoCgroupSystemProvider:
+#      disk_io_cgroup_system:
 #        sampling_rate: 99
 #        cgroups:
 #            "org.gnome.Shell@wayland.service":
 #                name: "Window Manager incl. X11"
 #            "session-2.scope":
 #                name: "GNOME Desktop"
-#      network.io.cgroup.system.provider.NetworkIoCgroupSystemProvider:
+#      network_io_cgroup_system:
 #        sampling_rate: 99
 #        cgroups:
 #            "org.gnome.Shell@wayland.service":
@@ -196,20 +196,21 @@ measurement:
     #--- Architecture - MacOS
     macos:
     #--- MacOS: On Mac you only need this provider. Please remove all others!
-      powermetrics.provider.PowermetricsProvider:
+      powermetrics:
         sampling_rate: 499 # If you set this value too low powermetrics will not be able to accommodate the timing. We recommend no lower than 199 ms
-      cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
+      cpu_utilization_mach_system:
         sampling_rate: 99
     #--- Architecture - Common
     common:
-#      network.connections.proxy.container.provider.NetworkConnectionsProxyContainerProvider:
+#      network_connections_proxy_container:
 ##        host_ip: 192.168.1.2 # This only needs to be enabled if automatic detection fails
+
     #--- Model based - These providers estimate rather than measure. Helpful where measuring is not possible, like in VMs
-#      psu.energy.ac.sdia.machine.provider.PsuEnergyAcSdiaMachineProvider:
+#      psu_energy_ac_sdia_machine:
       #-- This is a default configuration. Please change this to your system!
 #        CPUChips: 1
 #        TDP: 65
-#      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
+#      psu_energy_ac_xgboost_machine:
       #-- This is a default configuration. Please change this to your system!
 #        CPUChips: 1
 #        HW_CPUFreq: 3200
@@ -223,7 +224,7 @@ measurement:
 #        VHost_Ratio: 1
 #
 ###### DEBUG
-#      network.connections.tcpdump.system.provider.NetworkConnectionsTcpdumpSystemProvider:
+#      network_connections_tcpdump_system:
 #        split_ports: True
 #--- END
 

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -103,8 +103,8 @@
                                     <td>
                                         <select id="measurement-disabled-metric-providers" multiple="" class="ui multiple search selection dropdown" data-setting="measurement.disabled_metric_providers">
                                             <option value="">Select Metrics Provider</option>
-                                            <option value="NetworkConnectionsProxyContainerProvider">NetworkConnectionsProxyContainerProvider</option>
-                                            <option value="NetworkConnectionsTcpdumpSystemProvider">NetworkConnectionsTcpdumpSystemProvider</option>
+                                            <option value="network_connections_proxy_container">network_connections_proxy_container</option>
+                                            <option value="network_connections_tcpdump_system">network_connections_tcpdump_system</option>
                                         </select>
                                     </td>
                                     <td><button id="save-measurement-disabled-metric-providers" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -914,8 +914,8 @@ class ScenarioRunner:
         self._initialize_folder(self._metrics_folder) # should be cleared for a new run, bc we otherwise do not understand which files are new
 
         for metric_provider in metric_providers: # will iterate over keys
-            module_path, class_name = metric_provider.rsplit('.', 1)
-            module_path = f"metric_providers.{module_path}"
+            module_path = f"metric_providers.{metric_provider.replace('_', '.')}.provider"
+            class_name = "".join([token.capitalize() for token in metric_provider.split('_')]) + "Provider"
             conf = metric_providers[metric_provider] or {}
 
             if class_name in self._disabled_metric_providers:

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -918,8 +918,8 @@ class ScenarioRunner:
             class_name = "".join([token.capitalize() for token in metric_provider.split('_')]) + "Provider"
             conf = metric_providers[metric_provider] or {}
 
-            if class_name in self._disabled_metric_providers:
-                print(TerminalColors.WARNING, arrows(f"Not importing {class_name} as disabled per user settings"), TerminalColors.ENDC)
+            if metric_provider in self._disabled_metric_providers:
+                print(TerminalColors.WARNING, arrows(f"Not importing {metric_provider} as disabled per user settings"), TerminalColors.ENDC)
                 continue
 
             print(f"Importing {class_name} from {module_path}")

--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -47,7 +47,7 @@ def check_docker_host_env(*_, **__):
 
 def check_one_energy_and_scope_machine_provider(*_, **__):
     metric_providers = utils.get_metric_providers(GlobalConfig().config).keys()
-    energy_machine_providers = [provider for provider in metric_providers if ".energy" in provider and ".machine" in provider]
+    energy_machine_providers = [provider for provider in metric_providers if "_energy_" in provider and "_machine" in provider]
     return len(energy_machine_providers) <= 1
 
 def check_tmpfs_mount(*_, **__):

--- a/lib/user.py
+++ b/lib/user.py
@@ -74,7 +74,7 @@ class User():
                 value = int(value)
             case 'measurement.disabled_metric_providers':
                 value = set(value)
-                allowed_values = {'NetworkConnectionsTcpdumpSystemProvider', 'NetworkConnectionsProxyContainerProvider'} # set
+                allowed_values = {'network_connections_tcpdump_system', 'network_connections_proxy_container'} # set
                 if not value.issubset(allowed_values):
                     raise ValueError(f'The setting {name} must be in {allowed_values} but is {value}')
                 value = list(value) # transform back, as it is not json serializable. But we need the unique transform of set beforehand

--- a/metric_providers/lmsensors/README.md
+++ b/metric_providers/lmsensors/README.md
@@ -39,7 +39,7 @@ Your config could be:
 
 ```
 lmsensors_temperature_component:
-    resolution: 99
+    sampling_rate: 99
     chips: ['coretemp-isa-0000']
     features: ['Package id 0', 'Core 0', 'Core 1', 'Core 2', 'Core 3']
 ```

--- a/metric_providers/lmsensors/README.md
+++ b/metric_providers/lmsensors/README.md
@@ -38,8 +38,8 @@ Core 3:        +29.0°C  (high = +100.0°C, crit = +100.0°C)
 Your config could be:
 
 ```
-lmsensors.temperature.provider.LmSenorsTempProvider:
-    resolution: 100
+lmsensors_temperature_component:
+    resolution: 99
     chips: ['coretemp-isa-0000']
     features: ['Package id 0', 'Core 0', 'Core 1', 'Core 2', 'Core 3']
 ```

--- a/metric_providers/lmsensors/abstract_provider.py
+++ b/metric_providers/lmsensors/abstract_provider.py
@@ -27,7 +27,7 @@ class LmsensorsProvider(BaseMetricProvider):
         if __name__ == '__main__':
             # If you run this on the command line you will need to set this in the config
             # This is separate so it is always clear what config is used.
-            self._provider_config_path = 'lmsensors.abstract_provider.LmsensorsProvider'
+            self._provider_config_path = None
 
 
         super().__init__(

--- a/metric_providers/lmsensors/fan/component/provider.py
+++ b/metric_providers/lmsensors/fan/component/provider.py
@@ -2,7 +2,7 @@ from metric_providers.lmsensors.abstract_provider import LmsensorsProvider
 
 class LmsensorsFanComponentProvider(LmsensorsProvider):
     def __init__(self, sampling_rate, folder, *, skip_check=False, **_):
-        self._provider_config_path = 'lmsensors.fan.component.provider.LmsensorsFanComponentProvider'
+        self._provider_config_path = 'lmsensors_fan_component'
         super().__init__(
             metric_name='lmsensors_fan_component',
             sampling_rate=sampling_rate,

--- a/metric_providers/lmsensors/temperature/component/provider.py
+++ b/metric_providers/lmsensors/temperature/component/provider.py
@@ -2,7 +2,7 @@ from metric_providers.lmsensors.abstract_provider import LmsensorsProvider
 
 class LmsensorsTemperatureComponentProvider(LmsensorsProvider):
     def __init__(self, sampling_rate, folder, *, skip_check=False, **_):
-        self._provider_config_path = 'lmsensors.temperature.component.provider.LmsensorsTemperatureComponentProvider'
+        self._provider_config_path = 'lmsensors_temperature_component'
         super().__init__(
             metric_name='lmsensors_temperature_component',
             sampling_rate=sampling_rate,

--- a/metric_providers/psu/energy/ac/sdia/machine/provider.py
+++ b/metric_providers/psu/energy/ac/sdia/machine/provider.py
@@ -44,7 +44,7 @@ class PsuEnergyAcSdiaMachineProvider(BaseMetricProvider):
 
         config = GlobalConfig().config
         file_path = os.path.dirname(os.path.abspath(__file__))
-        provider_name = file_path[file_path.find("metric_providers") + len("metric_providers") + 1:].replace("/", ".") + ".provider." + self.__class__.__name__
+        provider_name = file_path[file_path.find("metric_providers") + len("metric_providers") + 1:].replace("/", "_")
         provider_config = config['measurement']['metric_providers']['common'][provider_name]
 
         if not provider_config['CPUChips']:

--- a/metric_providers/psu/energy/ac/xgboost/machine/provider.py
+++ b/metric_providers/psu/energy/ac/xgboost/machine/provider.py
@@ -46,8 +46,9 @@ class PsuEnergyAcXgboostMachineProvider(BaseMetricProvider):
         # as there is no metric_provider_executable to check
         super().check_system(check_command=None, check_parallel_provider=False)
         config = GlobalConfig().config
-        if 'cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider' not in config['measurement']['metric_providers']['linux']:
-            raise MetricProviderConfigurationError(f"{self._metric_name} provider could not be started.\nPlease activate the CpuUtilizationProcfsSystemProvider in the config.yml\n \
+
+        if 'cpu_utilization_procfs_system' not in config['measurement']['metric_providers']['linux']:
+            raise MetricProviderConfigurationError(f"{self._metric_name} provider could not be started.\nPlease activate the cpu_utilization_procfs_system in the config.yml\n \
                 This is required to run PsuEnergyAcXgboostMachineProvider")
 
     def _read_metrics(self):

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -787,7 +787,7 @@ class TestFrontendFunctionality:
 
 
         page.locator('#measurement-system-check-threshold').fill('2')
-        page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "NetworkConnectionsProxyContainerProvider");')
+        page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "network_connections_proxy_container");')
         page.locator('#measurement-flow-process-duration').fill('456')
         page.locator('#measurement-total-duration').fill('123')
         page.locator('#measurement-phase-padding').click()
@@ -820,7 +820,7 @@ class TestFrontendFunctionality:
         time.sleep(1)
 
         user = User(1)
-        assert user._capabilities['measurement']['disabled_metric_providers'] == ['NetworkConnectionsProxyContainerProvider']
+        assert user._capabilities['measurement']['disabled_metric_providers'] == ['network_connections_proxy_container']
         assert user._capabilities['measurement']['flow_process_duration'] == 456
         assert user._capabilities['measurement']['total_duration'] == 123
         assert user._capabilities['measurement']['phase_padding'] is False

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -77,13 +77,13 @@ def test_db_rows_are_written_and_presented():
     assert(data is not None and data != [])
 
     config = GlobalConfig().config # will be pre-loaded with test-config.yml due to conftest.py
-    metric_providers = utils.get_metric_providers_names(config)
+    metric_providers = list(utils.get_metric_providers(config).keys())
 
     # The network connection proxy provider writes to a different table so we need to remove it here
-    if 'NetworkConnectionsProxyContainerProvider' in metric_providers:
-        metric_providers.remove('NetworkConnectionsProxyContainerProvider')
+    if 'network_connections_proxy_container' in metric_providers:
+        metric_providers.remove('network_connections_proxy_container')
 
-    if 'PowermetricsProvider' in metric_providers:
+    if 'powermetrics' in metric_providers:
         # The problem here is that the powermetrics provider splits up the output of powermetrics and acts like
         # there are loads of providers. This makes a lot easier in showing and processing the data but is
         # not std behavior. That is also why we need to patch the imported check down below.
@@ -98,12 +98,13 @@ def test_db_rows_are_written_and_presented():
             'ane_energy_powermetrics_component',
         ]
 
-        metric_providers.extend([utils.get_pascal_case(i) + 'Provider' for i in pm_additional_list])
+        metric_providers.extend(pm_additional_list)
 
     do_check = True
 
     for d in data:
-        d_provider = utils.get_pascal_case(d[0]) + 'Provider'
+        d_class_name = utils.get_pascal_case(d[0]) + 'Provider'
+        d_provider = d[0]
         d_count = d[1]
         ## Assert the provider in DB matches one of the metric providers in config
         assert d_provider in metric_providers
@@ -112,21 +113,21 @@ def test_db_rows_are_written_and_presented():
         assert d_count > 0
 
         if do_check:
-            if 'PowermetricsProvider' in metric_providers:
+            if 'powermetrics' in metric_providers:
                 ## Assert the information printed to std.out matches what's in the db
                 match = re.search(r"Imported \S* (\d+) \S* metrics from  PowermetricsProvider", run_stdout, re.MULTILINE)
                 assert match is not None
                 do_check = False
             else:
                 ## Assert the information printed to std.out matches what's in the db
-                match = re.search(rf"Imported \S* (\d+) \S* metrics from\s*{d_provider}", run_stdout)
+                match = re.search(rf"Imported \S* (\d+) \S* metrics from\s*{d_class_name}", run_stdout)
                 assert match is not None
                 assert int(match.group(1)) == d_count
 
             ## Assert that all the providers in the config are represented
             metric_providers.remove(d_provider)
 
-    if not 'PowermetricsProvider' in metric_providers:
+    if 'powermetrics' not in metric_providers:
         assert len(metric_providers) == 0
 
 def test_run_contains_warnings():

--- a/tests/test-config-alternate-host-reserved-cpus.yml
+++ b/tests/test-config-alternate-host-reserved-cpus.yml
@@ -25,7 +25,7 @@ machine:
 measurement:
   metric_providers:
     common:
-      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
+      psu_energy_ac_xgboost_machine:
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test-config-extra-network-and-duplicate-psu-providers.yml
+++ b/tests/test-config-extra-network-and-duplicate-psu-providers.yml
@@ -20,27 +20,27 @@ machine:
 measurement:
   metric_providers:
     linux:
-      cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
+      cpu_utilization_procfs_system:
         sampling_rate: 99
-#      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
+#      disk_io_procfs_system:
 #        sampling_rate: 99
-      network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
+      network_io_procfs_system:
         sampling_rate: 99
         remove_virtual_interfaces: True
-      disk.used.statvfs.system.provider.DiskUsedStatvfsSystemProvider:
+      disk_used_statvfs_system:
         sampling_rate: 99
-      memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
+      memory_used_procfs_system:
         sampling_rate: 99
     macos:
-      cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
+      cpu_utilization_mach_system:
         sampling_rate: 99
     common:
-      network.connections.proxy.container.provider.NetworkConnectionsProxyContainerProvider:
+      network_connections_proxy_container:
 
-      psu.energy.ac.sdia.machine.provider.PsuEnergyAcSdiaMachineProvider:
+      psu_energy_ac_sdia_machine:
         CPUChips: 1
         TDP: 60
-      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
+      psu_energy_ac_xgboost_machine:
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test-config-extra-network-and-duplicate-psu-providers.yml
+++ b/tests/test-config-extra-network-and-duplicate-psu-providers.yml
@@ -16,6 +16,9 @@ machine:
   base_temperature_value: 10
   base_temperature_chip: "asd"
   base_temperature_feature: "asd"
+  host_reserved_cpus: 1
+  host_reserved_memory: 0
+
 
 measurement:
   metric_providers:

--- a/tests/test-config.yml.example
+++ b/tests/test-config.yml.example
@@ -65,28 +65,28 @@ machine:
 measurement:
   metric_providers:
     linux:
-      cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
+      cpu_utilization_procfs_system:
         sampling_rate: 99
-#      disk.io.procfs.system.provider.DiskIoProcfsSystemProvider:
+#      disk_io_procfs_system:
 #        sampling_rate: 99
-      network.io.procfs.system.provider.NetworkIoProcfsSystemProvider:
+      network_io_procfs_system:
         sampling_rate: 99
         remove_virtual_interfaces: True
-      disk.used.statvfs.system.provider.DiskUsedStatvfsSystemProvider:
+      disk_used_statvfs_system:
         sampling_rate: 99
-      memory.used.procfs.system.provider.MemoryUsedProcfsSystemProvider:
+      memory_used_procfs_system:
         sampling_rate: 99
-      cpu.utilization.cgroup.container.provider.CpuUtilizationCgroupContainerProvider:
+      cpu_utilization_cgroup_container:
         sampling_rate: 99
-      memory.used.cgroup.container.provider.MemoryUsedCgroupContainerProvider:
+      memory_used_cgroup_container:
         sampling_rate: 99
-      network.io.cgroup.container.provider.NetworkIoCgroupContainerProvider:
+      network_io_cgroup_container:
         sampling_rate: 99
     macos:
-      cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider:
+      cpu_utilization_mach_system:
         sampling_rate: 99
     common:
-      psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
+      psu_energy_ac_xgboost_machine:
         CPUChips: 1
         HW_CPUFreq: 3200
         CPUCores: 4

--- a/tests/test_config_opts.py
+++ b/tests/test_config_opts.py
@@ -61,14 +61,17 @@ def test_provider_disabling_working():
 
     GlobalConfig().override_config(config_location=f"{os.path.dirname(os.path.realpath(__file__))}/test-config-extra-network-and-duplicate-psu-providers.yml")
 
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/stress-application/usage_scenario.yml', skip_unsafe=False, dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=False, dev_no_phase_stats=True, disabled_metric_providers=['NetworkConnectionsProxyContainerProvider'], dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/stress-application/usage_scenario.yml', skip_unsafe=False, dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=False, dev_no_phase_stats=True, disabled_metric_providers=['network_connections_proxy_container'], dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
 
     with redirect_stdout(out), redirect_stderr(err):
         with Tests.RunUntilManager(runner) as context:
-            context.run_until('import_metric_providers')
+            context.run_until('initialize_run')
 
-    assert 'Not importing NetworkConnectionsProxyContainerProvider as disabled per user settings' in out.getvalue()
+    assert 'Not importing network_connections_proxy_container as disabled per user settings' in out.getvalue()
 
+    run_data = DB().fetch_one('SELECT measurement_config FROM runs WHERE id = %s', (runner._run_id,))[0]
+
+    assert list(run_data['configured_metric_providers'].keys()) == ['psu_energy_ac_sdia_machine', 'cpu_utilization_mach_system', 'psu_energy_ac_xgboost_machine'], 'Network Connections provider still in configured_metric_providers'
 
 def test_phase_padding_inactive():
     out = io.StringIO()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -822,12 +822,12 @@ def wip_test_verbose_provider_boot():
     # there is a note added when it starts "Booting {metric_provider}"
     # can check for this note in the DB and the notes are about 2s apart
     notes = DB().fetch_all(query, (run_id,'Booting%',))
-    metric_providers = utils.get_metric_providers_names(GlobalConfig().config)
+    metric_providers = utils.get_metric_providers(GlobalConfig().config).keys()
 
     #for each metric provider, assert there is an an entry in notes
-    for provider in metric_providers:
-        assert any(provider in note for _, note in notes), \
-            Tests.assertion_info(f"note: 'Booting {provider}'", f"notes: {notes}")
+    for metric_provider in metric_providers:
+        assert any(metric_provider in note for _, note in notes), \
+            Tests.assertion_info(f"note: 'Booting {metric_provider}'", f"notes: {notes}")
 
     #check that each timestamp in notes roughly 10 seconds apart
     for i in range(len(notes)-1):

--- a/tools/import_measurements.py
+++ b/tools/import_measurements.py
@@ -15,8 +15,8 @@ config = GlobalConfig().config
 
 def import_metric_provider(metric_provider):
 
-    module_path, class_name = metric_provider.rsplit('.', 1)
-    module_path = f"metric_providers.{module_path}"
+    module_path = f"metric_providers.{metric_provider.replace('_', '.')}.provider"
+    class_name = "".join([token.capitalize() for token in metric_provider.split('_')]) + "Provider"
 
     print(f"Importing {class_name} from {module_path}")
 
@@ -32,7 +32,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('run_id', type=str, help='Run-ID (UUID)')
-    parser.add_argument('metric_provider', type=str, help='Metric Provider (ex. cpu.utilization.mach.system.provider.CpuUtilizationMachSystemProvider)')
+    parser.add_argument('metric_provider', type=str, help='Metric Provider (ex. cpu_utilization_mach_system)')
     parser.add_argument('filename', type=str, help='Filename')
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Simplify metric provider naming convention from fully-qualified class names to snake_case identifiers

This PR refactors metric provider naming across the repo: dotted fully-qualified class-path keys (e.g. cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider) were replaced with short snake_case identifiers (e.g. cpu_utilization_procfs_system). Code, configs, tests, tooling, and frontend values were updated to the new scheme.

Key changes
- Configs: All example and test YAMLs (config.yml.example, tests/*.yml, etc.) converted provider keys to snake_case while leaving per-provider option fields unchanged.
- Imports/boot: lib/scenario_runner.py and tools/import_measurements.py changed to derive module paths and PascalCase provider class names from underscore-delimited provider identifiers (underscores → dots for modules; tokens → Capitalized + "Provider" for class names). Disabled-provider checks now compare the identifier string.
- System checks: lib/system_checks.py updated provider filtering to match new naming (e.g. matching "_energy_" and "_machine").
- Providers: Many providers updated to use snake_case keys for configuration lookups (examples: lmsensors providers, psu energy xgboost provider). .devcontainer/codespace-setup.sh injection and lmsensors README example updated.
- Frontend & User: frontend/settings.html and lib/user.py updated to use snake_case provider identifiers for the "disable providers" UI and validation.
- Tests: Many tests updated to assert and pass snake_case provider identifiers (tests/*).

Notable issues found
- Stale dotted key in PSU SDIA provider (P1): metric_providers/psu/energy/ac/sdia/machine/provider.py still looks up the CPU utilization provider using the old dotted key 'cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider' while configuration keys now use cpu_utilization_procfs_system. This lookup will fail and cause MetricProviderConfigurationError during system checks, disabling the SDIA PSU provider. The sibling XGBoost PSU provider already uses the correct snake_case key.
- lmsensors README example (P1): The README snippet incorrectly shows resolution: 99 instead of sampling_rate: 99 (the code expects sampling_rate); copying the snippet may cause a constructor/config error.

Other notes
- No security concerns identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames metric provider config keys from the old dot-notation class-path format (e.g. `cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider`) to simple underscore names (e.g. `cpu_utilization_procfs_system`) across config files, providers, and tooling.

- **P1**: `PsuEnergyAcSdiaMachineProvider.check_system` still uses the old dot-notation key `'cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider'` to look up the CPU utilization provider in the config, while every config file now uses `cpu_utilization_procfs_system`. This causes the check to always raise `MetricProviderConfigurationError`, breaking the SDIA provider when system checks are enabled. The XGBoost provider was correctly updated.
- **P1**: The `lmsensors` README example config uses `resolution: 99` instead of `sampling_rate: 99`, which would produce a constructor error for anyone copying the snippet.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `metric_providers/psu/energy/ac/sdia/machine/provider.py`, line 55-57 ([link](https://github.com/green-coding-solutions/green-metrics-tool/blob/71a2dc8c8de77703afb3e23efec8e514043d5459/metric_providers/psu/energy/ac/sdia/machine/provider.py#L55-L57)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale key format breaks SDIA system check**

   This line still checks for the old dot-notation key `'cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider'`, but all config files in this PR now use the underscore-style key `cpu_utilization_procfs_system`. This lookup will always fail, causing `check_system` to always raise `MetricProviderConfigurationError` even when the provider is correctly configured — effectively disabling the SDIA provider whenever system checks run.

   The sibling `PsuEnergyAcXgboostMachineProvider.check_system` was already updated to the correct key (line 50 of `xgboost/machine/provider.py`).

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Naming metric providers with simple unde..."](https://github.com/green-coding-solutions/green-metrics-tool/commit/71a2dc8c8de77703afb3e23efec8e514043d5459) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27706956)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->