### PR TITLE
Bugfix variable scope

### DIFF
--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -107,9 +107,6 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
     csv_buffer = StringIO()
 
     machine_power_baseline = None
-    machine_power_current_phase = None
-    machine_energy_current_phase = None
-
     runtime_phase_idx = None
 
     for idx, phase in enumerate(phases[0]):
@@ -117,14 +114,16 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
             runtime_phase_idx = idx
             continue
 
+        # reset all phase specific values
         phase_warnings = set()
-        network_bytes_total = [] # reset; # we use array here and sum later, because checking for 0 alone not enough
-
-        cpu_utilization_containers = {} # reset
+        network_bytes_total = [] # we use array here and sum later, because checking for 0 alone not enough
+        cpu_utilization_containers = {}
         cpu_utilization_machine = None
         network_io_carbon_in_ug = None
-        sci_phase_data = {} # reset
-        sci_phase_data_custom = {} # reset
+        sci_phase_data = {}
+        sci_phase_data_custom = {}
+        machine_power_current_phase = None
+        machine_energy_current_phase = None
 
         select_query = """
             WITH lag_table as (


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR implements support for custom metrics across the green-metrics-tool, allowing users to define and track custom measurements alongside built-in metrics. The changes span frontend UI components, backend metric processing, configuration validation, and the scenario execution pipeline.

## Key Changes

**Frontend (JavaScript)**
- Enhanced `getPretty()` in `main.js` to handle metrics starting with `custom_`, returning custom display names, human-readable titles (title-cased underscore-delimited), and context-specific explanations (with special handling for `*_sci_global` suffixed metrics).
- Refactored `metric-boxes.js` to introduce a reusable `createCard()` helper function and added a dedicated container for custom metric cards within phase tabs. Updated `updateKeyMetric()` to dynamically inject custom metric cards with appropriate icon/color formatting based on metric type.

**Backend Configuration & Schema**
- Updated `schema_checker.py` to replace the legacy top-level `sci` mapping with a new `custom_metrics` schema, allowing users to define custom metrics with required `unit` and optional `regex` and `sci` boolean fields.
- Added `normalize_timestamp()` utility in `utils.py` to standardize timestamp formats (10–19 chars, left-padded and truncated to 16 chars).

**Metric Processing Pipeline**
- Modified `build_and_store_phase_stats()` in `phase_stats.py` to accept an optional `sci_metrics` parameter and shifted from global to phase-scoped carbon aggregation. The function now computes per-phase `<metric>_sci_global` outputs for custom metrics ending in `_sci_global`.
- Extensively refactored `scenario_runner.py` to:
  - Load `sci` config directly instead of parsing stdout.
  - Parse and validate `custom_metrics` from usage scenarios, applying default regex patterns and storing metric definitions in-memory.
  - Extract custom metric data via regex matching during stdout processing, normalizing timestamps and aggregating results.
  - Pass collected custom metrics to `build_and_store_phase_stats()` for SCI-related processing.
  - Store custom metric data via a new `_store_custom_metrics` post-processing step.
  - Remove legacy SCI stdout reading logic and related container/service plumbing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes a variable-scope bug by moving phase-specific accumulators (`network_bytes_total`, `sci_phase_data`, `cpu_utilization_containers`, etc.) inside the per-phase loop so they reset on every iteration rather than accumulating across all phases. One pre-existing issue remains in the touched file: the guard `if runtime_phase_idx:` at line 345 is falsy when `[RUNTIME]` is the first phase (`idx=0`), silently skipping `reconstruct_runtime_phase` and leaving runtime phase stats empty.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/phase_stats.py`, line 345-346 ([link](https://github.com/green-coding-solutions/green-metrics-tool/blob/ce034ca69b91e8fbaefcf238f2db4cec84fcc521/lib/phase_stats.py#L345-L346)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Falsy check on zero-indexed `runtime_phase_idx`**

   `runtime_phase_idx` is an `int` set via `enumerate`, so it can be `0` if `[RUNTIME]` is the first phase in the list. When that happens, `if runtime_phase_idx:` evaluates to `False` and `reconstruct_runtime_phase` is silently skipped, leaving the `[RUNTIME]` phase stats unbuilt. The sentinel value for "not found" is already `None` (line 110), so the guard should test for that explicitly.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["(fix): Variables should be per phase and..."](https://github.com/green-coding-solutions/green-metrics-tool/commit/ce034ca69b91e8fbaefcf238f2db4cec84fcc521) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27984519)</sub>

<!-- /greptile_comment -->