### PR TITLE
Replacing kaniko with martizih/kaniko:slim

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -91,7 +91,7 @@ machine:
 
 measurement:
   full_docker_prune_whitelist:
-    - gcr.io/kaniko-project/executor
+    - martizih/kaniko:slim
   metric_providers:
   # Please select the needed providers according to the working ones on your system
   # More info https://docs.green-coding.io/docs/measuring/metric-providers

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -962,7 +962,7 @@ class ScenarioRunner:
             print('Skipping downloading dependencies due to --skip-download-dependencies')
             return
 
-        subprocess.run(['docker', 'pull', 'gcr.io/kaniko-project/executor:latest'], check=True)
+        subprocess.run(['docker', 'pull', 'martizih/kaniko:slim'], check=True)
 
     def _get_build_info(self, service):
         if isinstance(service['build'], str):
@@ -1041,7 +1041,7 @@ class ScenarioRunner:
                     docker_build_command.append('--mount')
                     docker_build_command.append(f"type=bind,source={relation['mount_path']},target=/tmp/relations/{relation_key},readonly") # relation_key already checked in schema_checker
 
-                docker_build_command.append('gcr.io/kaniko-project/executor:latest')
+                docker_build_command.append('martizih/kaniko:slim')
 
                 # from here args for kaniko directly
                 docker_build_command.extend(

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -26,7 +26,7 @@ docker rmi -f nginx
 docker rmi -f green-metrics-tool-test-test-green-coding-gunicorn
 docker rmi -f green-metrics-tool-green-coding-gunicorn
 docker rmi -f redis:alpine
-docker rmi -f gcr.io/kaniko-project/executor:latest
+docker rmi -f martizih/kaniko:slim
 docker rmi -f postgres:18
 docker volume rm green-metrics-tool_green-coding-redis-data
 docker volume rm green-metrics-tool_green-coding-shared-sockets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR replaces the Kaniko executor Docker image from the official GCR-hosted version (`gcr.io/kaniko-project/executor`) with a slim third-party alternative (`martizih/kaniko:slim`) across the codebase.

## Changes
- **config.yml.example**: Updated the Docker prune whitelist to exclude `martizih/kaniko:slim` instead of `gcr.io/kaniko-project/executor`
- **lib/scenario_runner.py**: Replaced the Kaniko executor image in Docker pull and build commands from `gcr.io/kaniko-project/executor:latest` to `martizih/kaniko:slim`
- **uninstall.sh**: Updated the Docker image removal step to target `martizih/kaniko:slim` instead of `gcr.io/kaniko-project/executor:latest`

## Impact
This change switches the container image used for building Docker images within the scenario runner, likely to reduce image size and improve build performance with the "slim" variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->