### PR TITLE
Cache frontend

### DIFF
--- a/docker/nginx/api.conf.example
+++ b/docker/nginx/api.conf.example
@@ -3,8 +3,8 @@ server {
 #__DEFAULT__    listen [::]:9142;
 #__DEFAULT__    listen 9142;
 
-#__SSL__    listen [::]:443 ssl;
-#__SSL__    listen 443 ssl;
+#__SSL__    listen [::]:443 ssl http2;
+#__SSL__    listen 443 ssl http2;
 #__SSL__    ssl_certificate /etc/ssl/production.crt;
 #__SSL__    ssl_certificate_key /etc/ssl/production.key;
 

--- a/docker/nginx/frontend.conf.example
+++ b/docker/nginx/frontend.conf.example
@@ -6,13 +6,32 @@ server {
 #__SSL__    listen [::]:443 ssl;
 #__SSL__    listen 443 ssl;
 #__SSL__    ssl_certificate /etc/ssl/production.crt;
-#__SSL__    ssl_certificate_key /etc/ssl/production.key;
+    #__SSL__    ssl_certificate_key /etc/ssl/production.key;
 
     server_name __METRICS_URL__;
+
+    etag on;
 
     location / {
         root   /var/www/green-metrics-tool/frontend;
         index  index.html index.htm;
+        try_files $uri $uri/ =404;
+    }
+
+    location ~* \.html$ {
+        root   /var/www/green-metrics-tool/frontend;
+        add_header Cache-Control "public, max-age=0, must-revalidate" always;
+    }
+
+    location ~* \.(css|js)$ {
+        root   /var/www/green-metrics-tool/frontend;
+        add_header Cache-Control "public, max-age=0, must-revalidate" always;
+    }
+
+    location ~* \.(png|jpg|jpeg|gif|ico|svg|webp)$ {
+        root   /var/www/green-metrics-tool/frontend;
+        add_header Cache-Control "public, max-age=604800 must-revalidate" always;
+        expires 7d;
     }
 
     #error_page  404              /404.html;

--- a/docker/nginx/frontend.conf.example
+++ b/docker/nginx/frontend.conf.example
@@ -30,7 +30,7 @@ server {
 
     location ~* \.(png|jpg|jpeg|gif|ico|svg|webp)$ {
         root   /var/www/green-metrics-tool/frontend;
-        add_header Cache-Control "public, max-age=604800 must-revalidate" always;
+        add_header Cache-Control "public, max-age=604800, must-revalidate" always;
         expires 7d;
     }
 

--- a/docker/nginx/frontend.conf.example
+++ b/docker/nginx/frontend.conf.example
@@ -3,8 +3,8 @@ server {
 #__DEFAULT__    listen [::]:9142;
 #__DEFAULT__    listen 9142;
 
-#__SSL__    listen [::]:443 ssl;
-#__SSL__    listen 443 ssl;
+#__SSL__    listen [::]:443 ssl  http2;
+#__SSL__    listen 443 ssl  http2;
 #__SSL__    ssl_certificate /etc/ssl/production.crt;
     #__SSL__    ssl_certificate_key /etc/ssl/production.key;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Nginx Configuration Updates for Frontend Caching & HTTP/2

**Changes made:**

- **HTTP/2 Support**: Updated SSL listen directives in both `api.conf.example` and `frontend.conf.example` to enable HTTP/2 protocol on port 443 for IPv4 and IPv6.

- **Frontend Cache Optimization** (`frontend.conf.example`):
  - Enabled ETag generation for efficient cache validation
  - Uncommented SSL certificate key configuration
  - Added `try_files` routing for root path to return 404 for non-existent resources
  - Implemented cache policies for different asset types via new `location` blocks:
    - HTML: `Cache-Control` header for dynamic content
    - CSS/JS: `Cache-Control` header for longer caching
    - Images: `Cache-Control` header with 7-day expiration directive

These changes enforce stricter caching behavior for static assets while maintaining proper cache revalidation through ETags and appropriate HTTP headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->