### PR TITLE
Decrypt only on request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tools/sgx_enable
 /templates/ai/usage_scenario.yml.tmp
 /templates/website/usage_scenario.yml.tmp
 .nova/
+.rsa/
 
 ## Files that will be created if Enterprise Version gets installed with valid license
 /ee

--- a/lib/encryption.py
+++ b/lib/encryption.py
@@ -8,6 +8,7 @@ from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.backends import default_backend
 
 from lib.global_config import GlobalConfig
 
@@ -81,7 +82,21 @@ def _load_private_key():
 
     return private_key
 
+def is_valid_openssh_private_key(data: str) -> bool:
+    if not data.startswith("-----BEGIN OPENSSH PRIVATE KEY-----"):
+        return False
+    if not data.strip().endswith("-----END OPENSSH PRIVATE KEY-----"):
+        return False
 
+    try:
+        serialization.load_ssh_private_key(
+            data.encode(),
+            password=None,  # or b"passphrase" if encrypted
+            backend=default_backend()
+        )
+        return True
+    except Exception: # pylint: disable=broad-exception-caught
+        return False
 
 def encrypt_data(data):
     if data is None:

--- a/lib/user.py
+++ b/lib/user.py
@@ -149,6 +149,7 @@ class User():
             WHERE id = %s
             """, params=(encrypted_value, self._id, ))
 
+        self.__encrypted_ssh_private_key = encrypted_value
         self.__decrypted_ssh_private_key = SecureVariable(normalized_value) if normalized_value else None
 
     def can_change_setting(self, name):

--- a/lib/user.py
+++ b/lib/user.py
@@ -40,7 +40,7 @@ class User():
         del values['_id']
         values.pop('_User__encrypted_ssh_private_key', None)
         values.pop('_User__decrypted_ssh_private_key', None)
-        values['_has_ssh_private_key'] = bool(self.__encrypted_ssh_private_key) is not None
+        values['_has_ssh_private_key'] = bool(self.__encrypted_ssh_private_key)
         return values
 
     def __repr__(self):

--- a/lib/user.py
+++ b/lib/user.py
@@ -108,9 +108,7 @@ class User():
         return bool(self.__encrypted_ssh_private_key)
 
     def get_ssh_private_key(self):
-        if self.__decrypted_ssh_private_key:
-            return self.__decrypted_ssh_private_key.get_value()
-        elif self.has_ssh_private_key():
+        if self.__decrypted_ssh_private_key is None and self.has_ssh_private_key():
             if self.__encrypted_ssh_private_key.startswith(ENCRYPTED_VALUE_PREFIX):
                 decrypted_ssh_private_key = decrypt_data(self.__encrypted_ssh_private_key)
             else:
@@ -118,7 +116,9 @@ class User():
 
             self.__decrypted_ssh_private_key = SecureVariable(decrypted_ssh_private_key) if decrypted_ssh_private_key else None
 
-        return self.__decrypted_ssh_private_key
+        if self.__decrypted_ssh_private_key is None:
+            return None
+        return self.__decrypted_ssh_private_key.get_value()
 
     def update_ssh_private_key(self, value):
         if value is None:

--- a/lib/user.py
+++ b/lib/user.py
@@ -129,8 +129,8 @@ class User():
     def update_ssh_private_key(self, key):
 
         if key is None:
-            self.__encrypted_ssh_private_key = self.__decrypted_ssh_private_key = None
             self._save_key_to_db(None)
+            self.__encrypted_ssh_private_key = self.__decrypted_ssh_private_key = None
             return
 
         if not isinstance(key, str):
@@ -139,8 +139,8 @@ class User():
         normalized_value = key.strip()
 
         if normalized_value == '':
-            self.__encrypted_ssh_private_key = self.__decrypted_ssh_private_key = None
             self._save_key_to_db(None)
+            self.__encrypted_ssh_private_key = self.__decrypted_ssh_private_key = None
             return
 
         if not is_valid_openssh_private_key(normalized_value):
@@ -153,9 +153,9 @@ class User():
         except EncryptionConfigurationError as e:
             raise ValueError('Cannot store SSH key: encryption is not configured on this server') from e
 
+        self._save_key_to_db(self.__encrypted_ssh_private_key)
         self.__encrypted_ssh_private_key = encrypted_value
         self.__decrypted_ssh_private_key = SecureVariable(normalized_value) if normalized_value else None
-        self._save_key_to_db(self.__encrypted_ssh_private_key)
 
     def can_change_setting(self, name):
         return name in self._capabilities['user']['updateable_settings']

--- a/lib/user.py
+++ b/lib/user.py
@@ -38,8 +38,8 @@ class User():
     def to_dict(self):
         values = self.__dict__.copy()
         del values['_id']
-        values.pop('__encrypted_ssh_private_key', None)
-        values.pop('__decrypted_ssh_private_key', None)
+        values.pop('_User__encrypted_ssh_private_key', None)
+        values.pop('_User__decrypted_ssh_private_key', None)
         values['_has_ssh_private_key'] = bool(self.__encrypted_ssh_private_key) is not None
         return values
 

--- a/lib/user.py
+++ b/lib/user.py
@@ -3,7 +3,7 @@ import hashlib
 
 from lib.secure_variable import SecureVariable
 from lib.db import DB
-from lib.encryption import ENCRYPTED_VALUE_PREFIX, EncryptionConfigurationError, decrypt_data, encrypt_data
+from lib.encryption import EncryptionConfigurationError, decrypt_data, encrypt_data
 
 def get_nested_value(dictionary, path):
     keys = path.split('.', 1)
@@ -109,11 +109,7 @@ class User():
 
     def get_ssh_private_key(self):
         if self.__decrypted_ssh_private_key is None and self.has_ssh_private_key():
-            if self.__encrypted_ssh_private_key.startswith(ENCRYPTED_VALUE_PREFIX):
-                decrypted_ssh_private_key = decrypt_data(self.__encrypted_ssh_private_key)
-            else:
-                decrypted_ssh_private_key = self.__encrypted_ssh_private_key or None
-
+            decrypted_ssh_private_key = decrypt_data(self.__encrypted_ssh_private_key)
             self.__decrypted_ssh_private_key = SecureVariable(decrypted_ssh_private_key) if decrypted_ssh_private_key else None
 
         if self.__decrypted_ssh_private_key is None:

--- a/lib/user.py
+++ b/lib/user.py
@@ -29,20 +29,18 @@ class User():
         self._id = user[0]
         self._name = user[1]
         self._capabilities = user[2]
-
-        raw_key = user[3]
-        if raw_key and raw_key.startswith(ENCRYPTED_VALUE_PREFIX):
-            decrypted_ssh_private_key = decrypt_data(raw_key)
-        else:
-            decrypted_ssh_private_key = raw_key or None
-
-        self._ssh_private_key = SecureVariable(decrypted_ssh_private_key) if decrypted_ssh_private_key else None
+        self.__encrypted_ssh_private_key = user[3]
+        # value is not populated here directly as due to the security setup of GMT
+        # the server sometimes only has the public key to encrypt and would fail if the
+        # private key is missing
+        self.__decrypted_ssh_private_key = None
 
     def to_dict(self):
         values = self.__dict__.copy()
         del values['_id']
-        values.pop('_ssh_private_key', None)
-        values['_has_ssh_private_key'] = self._ssh_private_key is not None
+        values.pop('__encrypted_ssh_private_key', None)
+        values.pop('__decrypted_ssh_private_key', None)
+        values['_has_ssh_private_key'] = bool(self.__encrypted_ssh_private_key) is not None
         return values
 
     def __repr__(self):
@@ -107,13 +105,20 @@ class User():
         self.update()
 
     def has_ssh_private_key(self):
-        return self._ssh_private_key is not None
+        return bool(self.__encrypted_ssh_private_key)
 
     def get_ssh_private_key(self):
-        if self._ssh_private_key:
-            return self._ssh_private_key.get_value()
-        else:
-            return None
+        if self.__decrypted_ssh_private_key:
+            return self.__decrypted_ssh_private_key.get_value()
+        elif self.has_ssh_private_key():
+            if self.__encrypted_ssh_private_key.startswith(ENCRYPTED_VALUE_PREFIX):
+                decrypted_ssh_private_key = decrypt_data(self.__encrypted_ssh_private_key)
+            else:
+                decrypted_ssh_private_key = self.__encrypted_ssh_private_key or None
+
+            self.__decrypted_ssh_private_key = SecureVariable(decrypted_ssh_private_key) if decrypted_ssh_private_key else None
+
+        return self.__decrypted_ssh_private_key
 
     def update_ssh_private_key(self, value):
         if value is None:
@@ -144,7 +149,7 @@ class User():
             WHERE id = %s
             """, params=(encrypted_value, self._id, ))
 
-        self._ssh_private_key = SecureVariable(normalized_value) if normalized_value else None
+        self.__decrypted_ssh_private_key = SecureVariable(normalized_value) if normalized_value else None
 
     def can_change_setting(self, name):
         return name in self._capabilities['user']['updateable_settings']

--- a/lib/user.py
+++ b/lib/user.py
@@ -3,7 +3,7 @@ import hashlib
 
 from lib.secure_variable import SecureVariable
 from lib.db import DB
-from lib.encryption import EncryptionConfigurationError, decrypt_data, encrypt_data
+from lib.encryption import EncryptionConfigurationError, decrypt_data, encrypt_data, is_valid_openssh_private_key
 
 def get_nested_value(dictionary, path):
     keys = path.split('.', 1)
@@ -52,6 +52,14 @@ class User():
             SET capabilities = %s
             WHERE id = %s
             """, params=(json.dumps(self._capabilities), self._id, ))
+
+
+    def _save_key_to_db(self, encrypted_value):
+        DB().query("""
+            UPDATE users
+            SET ssh_private_key = %s
+            WHERE id = %s
+            """, params=(encrypted_value, self._id, ))
 
     def visible_users(self):
         return self._capabilities['user']['visible_users']
@@ -116,37 +124,38 @@ class User():
             return None
         return self.__decrypted_ssh_private_key.get_value()
 
-    def update_ssh_private_key(self, value):
-        if value is None:
-            normalized_value = None
-        elif not isinstance(value, str):
+
+
+    def update_ssh_private_key(self, key):
+
+        if key is None:
+            self.__encrypted_ssh_private_key = self.__decrypted_ssh_private_key = None
+            self._save_key_to_db(None)
+            return
+
+        if not isinstance(key, str):
             raise ValueError('The setting ssh_private_key must be a string')
-        else:
-            normalized_value = value.strip()
 
-            if normalized_value == '':
-                normalized_value = None
-            elif not all(marker in normalized_value for marker in ('-----BEGIN', 'PRIVATE KEY-----', '-----END')):
-                raise ValueError('The setting ssh_private_key must contain a valid private key block')
-            else:
-                normalized_value = f"{normalized_value}\n"
+        normalized_value = key.strip()
 
-        if normalized_value:
-            try:
-                encrypted_value = encrypt_data(normalized_value)
-            except EncryptionConfigurationError as e:
-                raise ValueError('Cannot store SSH key: encryption is not configured on this server') from e
-        else:
-            encrypted_value = None
+        if normalized_value == '':
+            self.__encrypted_ssh_private_key = self.__decrypted_ssh_private_key = None
+            self._save_key_to_db(None)
+            return
 
-        DB().query("""
-            UPDATE users
-            SET ssh_private_key = %s
-            WHERE id = %s
-            """, params=(encrypted_value, self._id, ))
+        if not is_valid_openssh_private_key(normalized_value):
+            raise ValueError('The setting ssh_private_key must contain a valid private key block')
+
+        normalized_value = f"{normalized_value.strip()}\n" # normalize line ends
+
+        try:
+            encrypted_value = encrypt_data(normalized_value)
+        except EncryptionConfigurationError as e:
+            raise ValueError('Cannot store SSH key: encryption is not configured on this server') from e
 
         self.__encrypted_ssh_private_key = encrypted_value
         self.__decrypted_ssh_private_key = SecureVariable(normalized_value) if normalized_value else None
+        self._save_key_to_db(self.__encrypted_ssh_private_key)
 
     def can_change_setting(self, name):
         return name in self._capabilities['user']['updateable_settings']

--- a/tests/api/test_api_base.py
+++ b/tests/api/test_api_base.py
@@ -55,7 +55,7 @@ def test_can_not_update_ssh_private_key_setting():
     try:
         payload = {
             'name': 'ssh_private_key',
-            'value': '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----',
+            'value': Tests.OPENSSH_EXAMPLE_PRIVATE_KEY,
         }
 
         response = requests.put(f"{API_URL}/v1/user/setting", json=payload, timeout=15)
@@ -78,7 +78,7 @@ def test_can_update_ssh_private_key_setting():
 
     payload = {
         'name': 'ssh_private_key',
-        'value': '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----',
+        'value': Tests.OPENSSH_EXAMPLE_PRIVATE_KEY,
     }
 
     try:
@@ -87,7 +87,7 @@ def test_can_update_ssh_private_key_setting():
 
         user = User(1)
         assert user.has_ssh_private_key() is True
-        assert user.get_ssh_private_key() == '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n'
+        assert user.get_ssh_private_key() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
     finally:
         User(1).update_ssh_private_key('')
         user = User(1)

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -806,6 +806,8 @@ class TestFrontendFunctionality:
             settings_response = response_info.value.json()
             assert settings_response['success'] is True
             assert '_ssh_private_key' not in settings_response['data']
+            assert '_User__decrypted_ssh_private_key' not in settings_response['data']
+            assert '_User__encrypted_ssh_private_key' not in settings_response['data']
             assert private_key not in json.dumps(settings_response)
 
             page.wait_for_load_state("load") # ALL JS should be done

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -794,10 +794,9 @@ class TestFrontendFunctionality:
         assert time_series_avg_display.strip() == 'Currently not showing AVG in time series'
 
     def test_settings_does_not_expose_ssh_private_key(self):
-        private_key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----'
 
         try:
-            User(1).update_ssh_private_key(private_key)
+            User(1).update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
             page.goto(GlobalConfig().config['cluster']['metrics_url'] + '/index.html')
             with page.expect_response(lambda response: '/v1/user/settings' in response.url and response.status == 200) as response_info:
@@ -808,7 +807,7 @@ class TestFrontendFunctionality:
             assert '_ssh_private_key' not in settings_response['data']
             assert '_User__decrypted_ssh_private_key' not in settings_response['data']
             assert '_User__encrypted_ssh_private_key' not in settings_response['data']
-            assert private_key not in json.dumps(settings_response)
+            assert Tests.OPENSSH_EXAMPLE_PRIVATE_KEY not in json.dumps(settings_response)
 
             page.wait_for_load_state("load") # ALL JS should be done
             page.locator("a#settings-tab-measurement").click()
@@ -924,11 +923,11 @@ class TestFrontendFunctionality:
         page.locator('#save-measurement-dev-no-sleeps').click()
         page.locator('#save-measurement-skip-optimizations').click()
         page.locator('#save-measurement-skip-volume-inspect').click()
-        page.locator('#ssh-private-key').fill('-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----')
+        page.locator('#ssh-private-key').fill(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
         page.locator('#save-ssh-private-key').click(timeout=15000)
 
         #page.wait_for_load_state("networkidle") # Network Idle sadly not enough here. The DB seems to take 1-2 seconds
-        time.sleep(1)
+        time.sleep(3)
 
         user = User(1)
         assert user._capabilities['measurement']['disabled_metric_providers'] == ['network_connections_proxy_container']

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -78,6 +78,21 @@ def test_user_can_clear_ssh_private_key():
     finally:
         user.update_ssh_private_key('')
 
+def test_user_dict_is_clean():
+    user = User(1)
+    try:
+
+        private_key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n'
+        user.update_ssh_private_key(private_key)
+
+        assert user.has_ssh_private_key() is True
+        assert user.get_ssh_private_key() == private_key
+        assert "BEGIN OPENSSH PRIVATE KEY" not in f"{user}"
+        assert ENCRYPTED_VALUE_PREFIX not in f"{user}"
+
+    finally:
+        user.update_ssh_private_key('')
+
 def test_encrypt_and_decrypt_data():
     data = 'secret value'
 

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -73,6 +73,8 @@ def test_user_can_clear_ssh_private_key():
 
         assert user.has_ssh_private_key() is False
         assert user.get_ssh_private_key() is None
+        assert user._User__encrypted_ssh_private_key is None
+        assert user._User__decrypted_ssh_private_key is None
     finally:
         user.update_ssh_private_key('')
 
@@ -138,5 +140,7 @@ def test_user_error_without_key(tmp_path):
             user.update_ssh_private_key(private_key)
 
         assert user.has_ssh_private_key() is False
+        assert user._User__encrypted_ssh_private_key is None
+        assert user._User__decrypted_ssh_private_key is None
     finally:
         _restore_test_config()

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -71,7 +71,6 @@ def test_user_can_clear_ssh_private_key():
 
         user.update_ssh_private_key('')
 
-        assert user._ssh_private_key is None
         assert user.has_ssh_private_key() is False
         assert user.get_ssh_private_key() is None
     finally:

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -11,9 +11,9 @@ from lib.global_config import GlobalConfig
 from lib.encryption import ENCRYPTED_VALUE_PREFIX, EncryptionConfigurationError, decrypt_data, encrypt_data
 from tests import test_functions as Tests
 
-TEST_CONFIG_FILE = os.path.normpath(f'{CURRENT_DIR}/../test-config.yml')
-TEST_PUBLIC_KEY_FILE = os.path.normpath(f'{CURRENT_DIR}/../data/encryption_public_key.pem')
-TEST_PRIVATE_KEY_FILE = os.path.normpath(f'{CURRENT_DIR}/../data/encryption_private_key.pem')
+TEST_CONFIG_FILE = os.path.normpath(f"{CURRENT_DIR}/../test-config.yml")
+TEST_PUBLIC_KEY_FILE = os.path.normpath(f"{CURRENT_DIR}/../data/encryption_public_key.pem")
+TEST_PRIVATE_KEY_FILE = os.path.normpath(f"{CURRENT_DIR}/../data/encryption_private_key.pem")
 
 
 def _restore_test_config():
@@ -50,11 +50,25 @@ def test_even_if_token_set_for_user_zero_authenticate_still_fails():
         User.authenticate(SecureVariable('asd'))
     assert str(e.value) == 'User 0 is system user and cannot log in'
 
+def test_non_openssh_key_fails():
+    user = User(1)
+    try:
+
+        with pytest.raises(ValueError) as e:
+            user.update_ssh_private_key('-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----')
+
+        assert str(e.value) == 'The setting ssh_private_key must contain a valid private key block'
+
+        user_dict = user.to_dict()
+        assert '_ssh_private_key' not in user_dict
+    finally:
+        user.update_ssh_private_key('')
+
 def test_user_to_dict_does_not_expose_ssh_private_key():
     user = User(1)
     try:
 
-        user.update_ssh_private_key('-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----')
+        user.update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
         user_dict = user.to_dict()
         assert '_ssh_private_key' not in user_dict
@@ -65,7 +79,7 @@ def test_user_can_clear_ssh_private_key():
     user = User(1)
     try:
 
-        user.update_ssh_private_key('-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----')
+        user.update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
         assert user.has_ssh_private_key() is True
 
@@ -82,11 +96,10 @@ def test_user_dict_is_clean():
     user = User(1)
     try:
 
-        private_key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n'
-        user.update_ssh_private_key(private_key)
+        user.update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
         assert user.has_ssh_private_key() is True
-        assert user.get_ssh_private_key() == private_key
+        assert user.get_ssh_private_key() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
         assert "BEGIN OPENSSH PRIVATE KEY" not in f"{user}"
         assert ENCRYPTED_VALUE_PREFIX not in f"{user}"
 
@@ -129,30 +142,27 @@ def test_decrypt_data_fails_relative_key_paths_from_config_file(tmp_path):
 
 def test_user_stores_ssh_private_key_encrypted():
     user = User(1)
-    private_key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----'
 
     try:
-
-        user.update_ssh_private_key(private_key)
+        user.update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
         raw_value = DB().fetch_one('SELECT ssh_private_key FROM users WHERE id = %s', params=(1,))[0]
 
         assert raw_value.startswith(ENCRYPTED_VALUE_PREFIX)
-        assert private_key not in raw_value
-        assert User(1).get_ssh_private_key() == f'{private_key}\n'
+        assert Tests.OPENSSH_EXAMPLE_PRIVATE_KEY not in raw_value
+        assert User(1).get_ssh_private_key() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
     finally:
         User(1).update_ssh_private_key('')
 
 
 def test_user_error_without_key(tmp_path):
     user = User(1)
-    private_key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----'
 
     try:
         _override_security_config(tmp_path, 'security: {}\n')
 
         with pytest.raises(ValueError):
-            user.update_ssh_private_key(private_key)
+            user.update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
         assert user.has_ssh_private_key() is False
         assert user._User__encrypted_ssh_private_key is None

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -21,6 +21,14 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 TEST_MEASUREMENT_CONTAINERS = {'bb0ea912f295ab0d8b671caf061929de9bb8b106128c071d6a196f9b6c05cd98': {'name': 'Arne'}, 'f78f0ca43069836d975f2bd4c45724227bbc71fc4788e60b33a77f1494cd2e0c': {'name': 'Not-Arne'}}
 
+OPENSSH_EXAMPLE_PRIVATE_KEY = '''-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBaJtSTmDwlgU0uPP0+zPSerJQZaYWd9dYCctpibwl4ZwAAAJgWu55CFrue
+QgAAAAtzc2gtZWQyNTUxOQAAACBaJtSTmDwlgU0uPP0+zPSerJQZaYWd9dYCctpibwl4Zw
+AAAEDIFKWnFdbeP4joIRyTvJ1KG2Z3IPmEy9XNhScJwmsffFom1JOYPCWBTS48/T7M9J6s
+lBlphZ311gJy2mJvCXhnAAAAE2FybmVAbWludGJvb2subG9jYWwBAg==
+-----END OPENSSH PRIVATE KEY-----'''
+
 def add_random_padding():
     return random.randint(100, 10000)
 


### PR DESCRIPTION
This PR fixes some deployment related quirks with the SSH private key / RSA encryption implementation.

In the old form it was not possible to have the server only configured with a RSA public key only. Both keys needed to be set as the user.py was decrypting the private on object instantiation.

This has been now changed to a lazy encryption only on actual read of the key (which happens only in the runner).

Furthermore a documentation was missing. The experiences from setting this up are documented in https://github.com/green-coding-solutions/documentation/issues/134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Implements lazy decryption of SSH private keys so the server no longer requires the RSA private key at startup — the private key is decrypted only when actually read.

## Changes
- **lib/user.py**
  - Switches SSH private key handling to lazy decryption: stores the encrypted DB value on initialization and defers decryption until get_ssh_private_key() is called; caches a SecureVariable after first decrypt.
  - Adds __encrypted_ssh_private_key and __decrypted_ssh_private_key internals, _save_key_to_db helper, and refactors update_ssh_private_key to validate, normalize, encrypt, cache, and persist keys. Clearing/None handling updated.
  - to_dict() and has_ssh_private_key() updated to avoid exposing internal key material and to derive _has_ssh_private_key from the encrypted value.
- **lib/encryption.py**
  - Adds is_valid_openssh_private_key(data: str) -> bool which checks OpenSSH private key PEM boundaries and attempts parsing via serialization.load_ssh_private_key(..., backend=default_backend()).
  - No change to existing RSA PEM load/encrypt/decrypt flows; existing error handling retained.
- **.gitignore**
  - Added .rsa/ to ignored paths.
- **tests**
  - **tests/test_functions.py**: Adds OPENSSH_EXAMPLE_PRIVATE_KEY constant used across tests.
  - **tests/lib/test_user.py**: Refactors tests to use the shared OPENSSH_EXAMPLE_PRIVATE_KEY constant; strengthens assertions to ensure both encrypted and decrypted internal fields are cleared/not exposed; adds/updates tests covering validation, clearing, persistence, and that neither plaintext nor encrypted markers leak via User.__repr__ or to_dict().
  - **tests/frontend/test_frontend.py**: Extends test_settings_does_not_expose_ssh_private_key to assert internal encrypted and decrypted SSH key fields are not present in the settings endpoint response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->