### PR TITLE
Changing import of optimzations to happen earlier for efficiency reasons

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -189,6 +189,10 @@ if __name__ == '__main__':
                     #disabled_metric_providers # this is intentionally not supported as the user can just edit the config in CLI mode and using another args="+" for parsing CLI is flaky
                     #allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'] # this is intentionally not supported as the user can just enter --allow-unsafe in CLI mode and using another args="+" for parsing CLI is flaky
                     )
+    if not runner._skip_optimizations and not runner._dev_no_save and not runner._dev_no_metrics:
+        import optimization_providers.base  # We need to import this here as we need the correct config file
+        print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
+        optimization_providers.base.import_reporters()
 
     # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
     #pylint: disable=broad-except
@@ -206,9 +210,6 @@ if __name__ == '__main__':
             # In a cloud setup it however makes sense to free the measurement machine as soon as possible
             # So this code should be individually callable, separate from the runner
             if not runner._skip_optimizations and not runner._dev_no_save and not runner._dev_no_metrics:
-                import optimization_providers.base  # We need to import this here as we need the correct config file
-                print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
-                optimization_providers.base.import_reporters()
                 print(TerminalColors.HEADER, '\nRunning optimization reporters ...', TerminalColors.ENDC)
                 optimization_providers.base.run_reporters(runner._user_id, runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
 

--- a/runner.py
+++ b/runner.py
@@ -190,7 +190,9 @@ if __name__ == '__main__':
                     #allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'] # this is intentionally not supported as the user can just enter --allow-unsafe in CLI mode and using another args="+" for parsing CLI is flaky
                     )
     if not runner._skip_optimizations and not runner._dev_no_save and not runner._dev_no_metrics:
-        import optimization_providers.base  # We need to import this here as we need the correct config file
+        # We cannot import this at the top of the as we need the correct config file
+        # Config file is replaced through args.config_override sometimes
+        import optimization_providers.base
         print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
         optimization_providers.base.import_reporters()
 


### PR DESCRIPTION
Optimizations import was moved to a different location as it was happening inside of the loop.

This was apparently needed in an old implementation but is not anymore. The comment was misleading and was updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Moves `optimization_providers.base.import_reporters()` from inside the per-file loop to a one-time execution before the loop, conditioned on the same checks (`--skip-optimizations`, `--dev-no-save`, `--dev-no-metrics`). The `run_reporters()` call remains in the loop where it executes for each file. This avoids redundant imports when processing multiple scenario files in a single run.

The misleading comment explaining the prior placement has been clarified to indicate why the import still cannot occur at the top of the file: the configuration file may be overridden via command-line arguments.

**Files changed:** runner.py (+6/-3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->