### PR TITLE
Makes the get_private_key return a secure variable per default.

### DIFF
--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -5,7 +5,6 @@
 import sys
 import faulthandler
 
-from lib.secure_variable import SecureVariable
 faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to stderr
 
 import os
@@ -45,7 +44,7 @@ class RunJob(Job):
             filename=self._filename,
             branch=self._branch,
             commit_hash=self._commit_hash,
-            ssh_private_key=SecureVariable(user.get_ssh_private_key()) if user.has_ssh_private_key() else None,
+            ssh_private_key=user.get_ssh_private_key(),
             allow_unsafe=False, # cluster runs should never allow this. All should go through individual user permissions,
             skip_unsafe=user._capabilities['measurement']['skip_unsafe'],
             dev_no_system_checks=user._capabilities['measurement']['dev_no_system_checks'],

--- a/lib/user.py
+++ b/lib/user.py
@@ -120,9 +120,7 @@ class User():
             decrypted_ssh_private_key = decrypt_data(self.__encrypted_ssh_private_key)
             self.__decrypted_ssh_private_key = SecureVariable(decrypted_ssh_private_key) if decrypted_ssh_private_key else None
 
-        if self.__decrypted_ssh_private_key is None:
-            return None
-        return self.__decrypted_ssh_private_key.get_value()
+        return self.__decrypted_ssh_private_key
 
 
 

--- a/tests/api/test_api_base.py
+++ b/tests/api/test_api_base.py
@@ -7,6 +7,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.user import User
 from lib.global_config import GlobalConfig
+from lib.secure_variable import SecureVariable
 from tests import test_functions as Tests
 from tests.test_functions import delete_jobs_from_DB # pylint: disable=unused-import
 
@@ -87,7 +88,8 @@ def test_can_update_ssh_private_key_setting():
 
         user = User(1)
         assert user.has_ssh_private_key() is True
-        assert user.get_ssh_private_key() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
+        assert isinstance(user.get_ssh_private_key(), SecureVariable)
+        assert user.get_ssh_private_key().get_value() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
     finally:
         User(1).update_ssh_private_key('')
         user = User(1)

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -99,7 +99,8 @@ def test_user_dict_is_clean():
         user.update_ssh_private_key(Tests.OPENSSH_EXAMPLE_PRIVATE_KEY)
 
         assert user.has_ssh_private_key() is True
-        assert user.get_ssh_private_key() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
+        assert isinstance(user.get_ssh_private_key(), SecureVariable)
+        assert user.get_ssh_private_key().get_value() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
         assert "BEGIN OPENSSH PRIVATE KEY" not in f"{user}"
         assert ENCRYPTED_VALUE_PREFIX not in f"{user}"
 
@@ -150,7 +151,9 @@ def test_user_stores_ssh_private_key_encrypted():
 
         assert raw_value.startswith(ENCRYPTED_VALUE_PREFIX)
         assert Tests.OPENSSH_EXAMPLE_PRIVATE_KEY not in raw_value
-        assert User(1).get_ssh_private_key() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
+        ssh_private_key = User(1).get_ssh_private_key()
+        assert isinstance(ssh_private_key, SecureVariable)
+        assert ssh_private_key.get_value() == f"{Tests.OPENSSH_EXAMPLE_PRIVATE_KEY}\n"
     finally:
         User(1).update_ssh_private_key('')
 


### PR DESCRIPTION
Makes it a little more secure as the default is a `SecureVariable` like this we avoid leaking it in the future per accident

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Refactors `User.get_ssh_private_key()` to return a `SecureVariable` wrapper by default rather than an unwrapped string, ensuring SSH private keys are handled as secure values throughout the codebase and reducing the risk of accidental leakage in logs or error messages.

## Changes

**lib/user.py**
- Modified `get_ssh_private_key()` to return `SecureVariable | None` instead of extracting and returning the raw string value
- Removed the `.get_value()` call that previously unwrapped the SecureVariable

**lib/job/run.py**
- Simplified `RunJob._process()` to pass the `SecureVariable` directly from `user.get_ssh_private_key()` to `ScenarioRunner`
- Removed prior conditional logic and explicit SecureVariable wrapping that handled None cases
- Removed unused `SecureVariable` import

**tests/api/test_api_base.py**
- Updated `test_can_update_ssh_private_key_setting` to expect `SecureVariable` return type
- Added verification of wrapped value using `.get_value()`
- Added explicit `SecureVariable` import

**tests/lib/test_user.py**
- Updated two SSH key tests to verify returned objects are `SecureVariable` instances
- Changed assertions to validate decrypted content via `.get_value()` instead of direct string comparison
- Maintained existing checks for encrypted storage and string representation security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->