### PR TITLE
Playwright headful

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -588,8 +588,8 @@ class ScenarioRunner:
             def include_gmt_helper(loader: Loader, node):
                 nodes = loader.get_constructed_nodes(node)
 
-                if not re.fullmatch(r'gmt-playwright(?:-with-cache)?\.yml', nodes[0]):
-                    raise ValueError(f"You tried include unallowed files with !include-gmt-helper function. Included files must conform to regex gmt-playwright(?:-with-cache)?\\.yml but actually is {nodes[0]}")
+                if not re.fullmatch(r'gmt-playwright(?:-headful)?(?:-with-cache)?\.yml', nodes[0]):
+                    raise ValueError(f"You tried include unallowed files with !include-gmt-helper function. Included files must conform to regex gmt-playwright(?:-headful)?(?:-with-cache)?\\.yml but actually is {nodes[0]}")
 
                 filename = runner_join_paths(f"{GMT_ROOT_DIR}/templates/partials/", nodes[0], force_path_as_root=True, force_path_in_repo=False)
 
@@ -628,7 +628,7 @@ class ScenarioRunner:
                 usage_scenario_file=usage_scenario_file,
             )
 
-            if re.search(r'!include-gmt-helper gmt-playwright(?:-with-cache)?\.yml', usage_scenario):
+            if re.search(r'!include-gmt-helper gmt-playwright(?:-headful)?(?:-with-cache)?\.yml', usage_scenario):
                 self.__include_playwright_ipc = True
 
             # We can use load here as the Loader extends SafeLoader

--- a/templates/partials/gmt-playwright-headful-with-cache.yml
+++ b/templates/partials/gmt-playwright-headful-with-cache.yml
@@ -10,6 +10,10 @@ services:
             - command: cd /tmp/gmt-utils && npm init -y && npm install playwright@1.59.1
               shell: bash
         # playwright-ipc.js will be mounted into container via lib/scenario_runner.py to not conflict with include directory restrictions
+        volumes:
+          - /tmp/.X11-unix:/tmp/.X11-unix
+        environment:
+           DISPLAY: ":0"
 
     squid:
         image: greencoding/squid_reverse_proxy:v5

--- a/templates/partials/gmt-playwright-headful-with-cache.yml
+++ b/templates/partials/gmt-playwright-headful-with-cache.yml
@@ -1,0 +1,37 @@
+services:
+    gmt-playwright-nodejs:
+        image: mcr.microsoft.com/playwright:v1.59.1-noble
+#        volumes:
+#            - /tmp/.X11-unix:/tmp/.X11-unix # for debugging in non-headless mode
+#        environment:
+#            DISPLAY: ":0" # for debugging in non-headless mode
+        setup-commands:
+            # install playwright libraries in writeable directory
+            - command: cd /tmp/gmt-utils && npm init -y && npm install playwright@1.59.1
+              shell: bash
+        # playwright-ipc.js will be mounted into container via lib/scenario_runner.py to not conflict with include directory restrictions
+
+    squid:
+        image: greencoding/squid_reverse_proxy:v5
+        healthcheck:
+            test: ["CMD", "curl", "-fs", "--proxy", "http://squid:3128", "https://www.google.com", "--insecure"]
+            interval: "1h" # effectively turns repeated healthchecks during runtime off
+            start_period: "60s"
+            start_interval: "1s"
+# activate for debugging
+#        ports:
+#           - 3128:3128
+
+flow-prepend:
+  - name: Starting browser IPC
+    container: gmt-playwright-nodejs
+    hidden: true
+    commands:
+      - type: console
+        command: node /tmp/gmt-utils/gmt-playwright-ipc.js --headless false --browser firefox --proxy http://squid:3128
+        note: Starting browser in background process with IPC
+        detach: true
+      - type: console
+        command: timeout 10 bash -c 'until [ -p "/tmp/playwright-ipc-ready" ]; do sleep 1; done && echo "Browser ready!"'
+        shell: bash
+        note: Waiting for website stepper loop to start by monitoring rendezvous file endpoint

--- a/templates/partials/gmt-playwright-headful.yml
+++ b/templates/partials/gmt-playwright-headful.yml
@@ -1,0 +1,26 @@
+services:
+    gmt-playwright-nodejs:
+        image: mcr.microsoft.com/playwright:v1.59.1-noble
+#        volumes:
+#            - /tmp/.X11-unix:/tmp/.X11-unix # for debugging in non-headless mode
+#        environment:
+#            DISPLAY: ":0" # for debugging in non-headless mode
+        setup-commands:
+            # install playwright libraries in writeable directory
+            - command: cd /tmp/gmt-utils && npm init -y && npm install playwright@1.59.1
+              shell: bash
+        # playwright-ipc.js will be mounted into container via lib/scenario_runner.py to not conflict with include directory restrictions
+
+flow-prepend:
+  - name: Starting browser IPC
+    container: gmt-playwright-nodejs
+    hidden: true
+    commands:
+      - type: console
+        command: node /tmp/gmt-utils/gmt-playwright-ipc.js --headless false --browser firefox
+        note: Starting browser in background process with IPC
+        detach: true
+      - type: console
+        command: timeout 10 bash -c 'until [ -p "/tmp/playwright-ipc-ready" ]; do sleep 1; done && echo "Browser ready!"'
+        shell: bash
+        note: Waiting for website stepper loop to start by monitoring rendezvous file endpoint

--- a/templates/partials/gmt-playwright-headful.yml
+++ b/templates/partials/gmt-playwright-headful.yml
@@ -10,6 +10,10 @@ services:
             - command: cd /tmp/gmt-utils && npm init -y && npm install playwright@1.59.1
               shell: bash
         # playwright-ipc.js will be mounted into container via lib/scenario_runner.py to not conflict with include directory restrictions
+        volumes:
+          - /tmp/.X11-unix:/tmp/.X11-unix
+        environment:
+           DISPLAY: ":0"
 
 flow-prepend:
   - name: Starting browser IPC


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

**lib/scenario_runner.py**
- Extended `_load_yml_file` pattern matching to recognize the optional `-headful` suffix in Playwright template filenames (e.g., `gmt-playwright-headful.yml`)
- Updated runner detection logic to set `self.__include_playwright_ipc` for headful Playwright includes

**New Templates**
- `templates/partials/gmt-playwright-headful.yml`: Defines a Playwright service configured for headful mode with X11 socket mounting (`/tmp/.X11-unix`) and display settings (`DISPLAY=":0"`). Includes a startup flow that launches the Playwright IPC process and waits for a readiness signal before proceeding.
- `templates/partials/gmt-playwright-headful-with-cache.yml`: Similar to above but adds an HTTP proxy service (squid) for caching, enabling Playwright to run in headful mode behind a reverse proxy with healthchecks.

Both templates include setup commands to install Playwright dependencies into a writable `/tmp/gmt-utils` directory during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1679)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->