### PR TITLE
Compare Dropdown will not reflow when being shown

### DIFF
--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -684,14 +684,22 @@ a {
 /* Compare Mode Buttons */
 #compare-button {
     margin-right: 0px;
+    margin-bottom: 5px;
+    font-size:15px;
 }
 
 #compare-force-mode-dropdown {
   visibility: hidden;
 }
 
+#compare-force-mode-dropdown span {
+    font-size: 1em;
+    color: rgba(0,0,0,0.5);
+    white-space: nowrap;
+}
+
 #compare-force-mode {
-    font-size: 0.8em;
+    font-size: 1em;
     padding: 1px 4px;
     border: 1px solid #ccc;
     border-radius: 3px;

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -587,10 +587,6 @@ a,
     font-family: monospace;
 }
 
-#unselect-button, #compare-force-mode {
-    display: none;
-    margin-top: 10px;
-}
 
 .wide.card {
     width: 400px !important;
@@ -683,4 +679,20 @@ a {
         margin-top: 1em !important;
         margin-bottom: 1em !important;
     }
+}
+
+/* Compare Mode Buttons */
+#compare-button {
+    margin-right: 0px;
+}
+
+#compare-force-mode-dropdown {
+  visibility: hidden;
+}
+
+#compare-force-mode {
+    font-size: 0.8em;
+    padding: 1px 4px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
 }

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -692,7 +692,7 @@ a {
   visibility: hidden;
 }
 
-#compare-force-mode-dropdown span {
+#compare-force-mode-dropdown label {
     font-size: 1em;
     color: rgba(0,0,0,0.5);
     white-space: nowrap;

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -28,12 +28,11 @@ const updateCompareCount = () => {
     const checkedCount = document.querySelectorAll('input[type=checkbox]:checked').length;
     countButton.textContent = `Compare: ${checkedCount} Run(s)`;
     if (checkedCount === 0) {
-        document.querySelector('.ui.accordion.compare-force-mode').style.display = 'none';
-        document.querySelector('#unselect-button').style.display = 'none';
-
+        document.querySelector('#compare-force-mode-dropdown').style.visibility = 'hidden';
+        document.querySelector('#unselect-button').classList.add('hidden');
     } else {
-        document.querySelector('#unselect-button').style.display = 'block';
-        document.querySelector('.ui.accordion.compare-force-mode').style.display = 'block';
+        document.querySelector('#compare-force-mode-dropdown').style.visibility = 'visible';
+        document.querySelector('#unselect-button').classList.remove('hidden');
     }
 }
 

--- a/frontend/runs.html
+++ b/frontend/runs.html
@@ -149,20 +149,18 @@
                     <th>
                         <span id="runs-and-repos-table-title">Runs</span> (<i class="icon code github"></i> / <i class="icon code gitlab"></i> / <i class="icon code folder"></i> etc.)+
                         <div class="float-right">
-                            <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 2px;">
-                                <button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare: 0 Run(s)</button>
-                                <div id="compare-force-mode-dropdown">
-                                    <span style="font-size: 0.75em; color: rgba(0,0,0,0.5); white-space: nowrap;">Mode</span>
-                                    <select id="compare-force-mode">
-                                        <option value="">Auto</option>
-                                        <option value="branches">Branches</option>
-                                        <option value="commit_hashes">Commits</option>
-                                        <option value="machine_ids">Machines</option>
-                                        <option value="usage_scenarios">Usage Scenarios</option>
-                                        <option value="usage_scenario_variables">Variables</option>
-                                        <option value="repos">Repos</option>
-                                    </select>
-                                </div>
+                            <button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare: 0 Run(s)</button>
+                            <div id="compare-force-mode-dropdown">
+                                <span>Mode</span>
+                                <select id="compare-force-mode">
+                                    <option value="">Auto</option>
+                                    <option value="branches">Branches</option>
+                                    <option value="commit_hashes">Commits</option>
+                                    <option value="machine_ids">Machines</option>
+                                    <option value="usage_scenarios">Usage Scenarios</option>
+                                    <option value="usage_scenario_variables">Variables</option>
+                                    <option value="repos">Repos</option>
+                                </select>
                             </div>
                         </div>
                         <div class="float-right">

--- a/frontend/runs.html
+++ b/frontend/runs.html
@@ -151,7 +151,7 @@
                         <div class="float-right">
                             <button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare: 0 Run(s)</button>
                             <div id="compare-force-mode-dropdown">
-                                <span>Mode</span>
+                                <label for="compare-force-mode">Mode</label>
                                 <select id="compare-force-mode">
                                     <option value="">Auto</option>
                                     <option value="branches">Branches</option>

--- a/frontend/runs.html
+++ b/frontend/runs.html
@@ -149,24 +149,24 @@
                     <th>
                         <span id="runs-and-repos-table-title">Runs</span> (<i class="icon code github"></i> / <i class="icon code gitlab"></i> / <i class="icon code folder"></i> etc.)+
                         <div class="float-right">
-                            <button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare: 0 Run(s)</button>
-                            <div class="ui accordion compare-force-mode" style="width: 100%;">
-                                <div class="title">
-                                    <i class="dropdown icon"></i> Compare Mode
-                                </div>
-                                <div class="content">
-                                    <select id="compare-force-mode" style="width: 160px; height: 40px; margin-top: 5px;">
+                            <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 2px;">
+                                <button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare: 0 Run(s)</button>
+                                <div id="compare-force-mode-dropdown">
+                                    <span style="font-size: 0.75em; color: rgba(0,0,0,0.5); white-space: nowrap;">Mode</span>
+                                    <select id="compare-force-mode">
                                         <option value="">Auto</option>
                                         <option value="branches">Branches</option>
                                         <option value="commit_hashes">Commits</option>
                                         <option value="machine_ids">Machines</option>
                                         <option value="usage_scenarios">Usage Scenarios</option>
-                                        <option value="usage_scenario_variables">Usage Scenario Variables</option>
+                                        <option value="usage_scenario_variables">Variables</option>
                                         <option value="repos">Repos</option>
                                     </select>
                                 </div>
                             </div>
-                            <button id="unselect-button" class="ui mini button red right " style="display:none">Unselect all</button>
+                        </div>
+                        <div class="float-right">
+                            <button id="unselect-button" class="ui small button red hidden">Unselect all</button>
                         </div>
                         <button id="sort-button" class="ui small button purple float-right"><i class="text icon"></i><span>Sort name</span></button>
                     </th>

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -667,8 +667,6 @@ class TestFrontendFunctionality:
         elements[3].click()
         elements[5].click()
 
-        page.locator('.ui.accordion.compare-force-mode .title').click() # open accordion
-
         page.locator('#compare-force-mode').select_option("Machines")
 
         with context.expect_page() as new_page_info:
@@ -702,9 +700,7 @@ class TestFrontendFunctionality:
         for element in elements:
             element.click()
 
-        page.locator('.ui.accordion.compare-force-mode .title').click() # open accordion
-        page.locator('#compare-force-mode').select_option("Usage Scenario Variables")
-
+        page.locator('#compare-force-mode').select_option('Variables')
 
         with context.expect_page() as new_page_info:
             page.locator('#compare-button').click()


### PR DESCRIPTION
<img width="627" height="169" alt="Screenshot 2026-05-15 at 2 25 04 PM" src="https://github.com/user-attachments/assets/5deb8579-9896-46c7-bf66-ecd4f20eb8c1" />
<img width="457" height="154" alt="Screenshot 2026-05-15 at 2 24 59 PM" src="https://github.com/user-attachments/assets/d618b2fe-5e10-4456-9bb5-a7d62ff6fd45" />

[skip ci]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes the compare dropdown to prevent layout reflow when being shown by simplifying the UI control structure and switching from `display`-based visibility to `visibility` properties.

## Changes

**CSS (`frontend/css/green-coding.css`)**
- Removed default `display: none` rules that hid the `#unselect-button` and `#compare-force-mode` elements
- Added new "Compare Mode Buttons" styling with proper layout and margins for `#compare-button`
- Changed `#compare-force-mode-dropdown` to use `visibility: hidden` instead of `display: none`, preventing layout reflow
- Added visible styling for `#compare-force-mode` with font size, padding, border, and border radius

**JavaScript (`frontend/js/helpers/runs.js`)**
- Updated `updateCompareCount` to toggle `#compare-force-mode-dropdown` using `visibility` property instead of managing accordion visibility
- Changed `#unselect-button` visibility to use the `hidden` class instead of inline `style.display` manipulation

**HTML (`frontend/runs.html`)**
- Replaced the accordion-based "Compare Mode" control with a simpler, compact layout
- Restructured the compare button and mode selector into a right-aligned container
- Updated the mode selector to use a plain `<select id="compare-force-mode">` with options for branches, commits, machines, scenarios, and repos
- Adjusted button IDs and classes to align with the new visibility management approach

## Impact

The changes use `visibility: hidden` instead of `display: none` to hide elements, which maintains the element's space in the document flow and prevents expensive layout recalculation (reflow) when showing/hiding the compare dropdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1682)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->