### PR TITLE
Adds the CarbonIntensityLevel provider

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -259,6 +259,10 @@ measurement:
 #        # The number 334 is for Germany 2025 (https://app.electricitymaps.com/zone/DE/all/yearly)
 #        value: 342
 #        sampling_rate: 99
+#      carbon_intensity_level_electricitymaps_machine:
+#        region: 'DE'
+#        token: 'XXXX'
+#        sampling_rate: 99 # Remove if you don't want value padding
 ###### DEBUG
 #      network_connections_tcpdump_system:
 #        split_ports: True

--- a/frontend/js/helpers/config.js.example
+++ b/frontend/js/helpers/config.js.example
@@ -646,5 +646,10 @@ METRIC_MAPPINGS = {
         "clean_name": "Grid Intensity",
         "source": "Elephant",
         "explanation": "The Grid intensity as reported by Elephant"
+    },
+    "carbon_intensity_level_electricitymaps_machine": {
+        "clean_name": "Grid Intensity Level",
+        "source": "Electricity Maps",
+        "explanation": "Carbon intensity level as reported by Electricity Maps (1=low, 2=medium, 3=high, 4=very high)"
     }
 } // PLEASE DO NOT REMOVE THIS COMMENT -- END METRIC_MAPPINGS

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -235,6 +235,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
                 'carbon_intensity_elephant_machine',
                 'carbon_intensity_electricity_maps_machine',
                 'carbon_intensity_static_machine',
+                'carbon_intensity_level_electricitymaps_machine',
             ):
                 csv_buffer.write(generate_csv_line(phase['hidden'], run_id, metric, detail_name, f"{idx:03}_{phase['name']}", value_avg, 'MEAN', max_value, min_value, sampling_rate_avg, sampling_rate_max, sampling_rate_95p, unit))
 

--- a/metric_providers/carbon/intensity/level/electricitymaps/machine/provider.py
+++ b/metric_providers/carbon/intensity/level/electricitymaps/machine/provider.py
@@ -103,11 +103,18 @@ class CarbonIntensityLevelElectricitymapsMachineProvider(BaseMetricProvider):
         if not isinstance(payload, dict):
             raise RuntimeError(f"Unexpected Electricity Maps carbon intensity level response: {payload}\n")
 
-        raw_level = payload.get('data', [{}])[0].get('level')
-        if raw_level is None:
-            raise RuntimeError(f"carbonIntensityLevel key missing from Electricity Maps response: {payload}\n")
+        data = payload.get('data')
+        if not data or not isinstance(data, list) or len(data) == 0:
+            raise RuntimeError(f"'data' array missing or empty in Electricity Maps response: {payload}\n")
 
-        level_value = LEVEL_MAP.get(str(raw_level).lower().strip(), 0)
+        raw_level = data[0].get('level')
+        if raw_level is None:
+            raise RuntimeError(f"'level' key missing from Electricity Maps response: {payload}\n")
+
+        level_key = str(raw_level).lower().strip()
+        if level_key not in LEVEL_MAP:
+            raise RuntimeError(f"Unknown carbon intensity level '{raw_level}' from Electricity Maps\n")
+        level_value = LEVEL_MAP[level_key]
 
         start_us = int(self._start_time.timestamp() * 1_000_000)
         end_us = int(self._end_time.timestamp() * 1_000_000)

--- a/metric_providers/carbon/intensity/level/electricitymaps/machine/provider.py
+++ b/metric_providers/carbon/intensity/level/electricitymaps/machine/provider.py
@@ -1,0 +1,135 @@
+import os
+from datetime import datetime, timezone
+
+import pandas
+import requests
+
+from metric_providers.base import BaseMetricProvider, MetricProviderConfigurationError
+from metric_providers.carbon.intensity.helpers import expand_to_sampling_rate
+
+
+API_LATEST_URL = "https://api.electricitymaps.com/v4/carbon-intensity-level/latest"
+
+LEVEL_MAP = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "very_high": 4,
+}
+
+
+class CarbonIntensityLevelElectricitymapsMachineProvider(BaseMetricProvider):
+    def __init__(self, region, token, folder, sampling_rate=-1, skip_check=False):
+
+        self.region = region
+        self.token = token
+        self._folder = folder
+        self._start_time = None
+        self._end_time = None
+
+        if not self.region:
+            raise MetricProviderConfigurationError(
+                'Please set the region config option for CarbonIntensityLevelElectricitymapsMachineProvider in the config.yml')
+
+        if not self.token:
+            raise MetricProviderConfigurationError(
+                'Please set the token config option for CarbonIntensityLevelElectricitymapsMachineProvider in the config.yml')
+
+        super().__init__(
+            metric_name='carbon_intensity_level_electricitymaps_machine',
+            metrics={'time': int, 'value': int, 'provider': str},
+            sampling_rate=sampling_rate,
+            unit='level',
+            current_dir=os.path.dirname(os.path.abspath(__file__)),
+            skip_check=skip_check,
+            folder=folder,
+        )
+
+    def check_system(self, check_command="default", check_error_message=None, check_parallel_provider=True):
+        super().check_system(check_command=None, check_parallel_provider=False)
+
+        try:
+            with requests.get(
+                API_LATEST_URL,
+                params={'zone': self.region},
+                headers={'auth-token': self.token},
+                timeout=10,
+            ) as response:
+                if response.status_code in (401, 403):
+                    raise MetricProviderConfigurationError(
+                        'Electricity Maps token was rejected. Please verify the token in the config.yml'
+                    )
+                if response.status_code != 200:
+                    raise MetricProviderConfigurationError(
+                        f"Electricity Maps carbon intensity level health check failed with status {response.status_code}: {response.text}"
+                    )
+        except requests.RequestException as exc:
+            raise MetricProviderConfigurationError(f"Electricity Maps base URL {API_LATEST_URL} could not be reached: {exc}") from exc
+
+    def get_stderr(self):
+        return None
+
+    def start_profiling(self, _=None):
+        self._start_time = datetime.now(timezone.utc)
+        self._has_started = True
+
+    def stop_profiling(self):
+        self._end_time = datetime.now(timezone.utc)
+        self._has_started = False
+
+    def _read_metrics(self):
+        if self._start_time is None or self._end_time is None:
+            raise RuntimeError(
+                f"{self._metric_name} provider did not record start/end times. Did start_profiling and stop_profiling run?")
+
+        response = None
+        try:
+            response = requests.get(
+                API_LATEST_URL,
+                params={'zone': self.region},
+                headers={'auth-token': self.token},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Failed to query Electricity Maps carbon intensity level service: {exc}") from exc
+        finally:
+            if response is not None:
+                response.close()
+
+        if response.status_code != 200:
+            raise RuntimeError(f"Electricity Maps carbon intensity level request failed with status {response.status_code}: {response.text}\n")
+
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected Electricity Maps carbon intensity level response: {payload}\n")
+
+        raw_level = payload.get('data', [{}])[0].get('level')
+        if raw_level is None:
+            raise RuntimeError(f"carbonIntensityLevel key missing from Electricity Maps response: {payload}\n")
+
+        level_value = LEVEL_MAP.get(str(raw_level).lower().strip(), 0)
+
+        start_us = int(self._start_time.timestamp() * 1_000_000)
+        end_us = int(self._end_time.timestamp() * 1_000_000)
+
+        if end_us <= start_us:
+            end_us = start_us + 1
+
+        records = [
+            {'time': start_us, 'value': level_value, 'provider': 'electricity_maps'},
+            {'time': end_us, 'value': level_value, 'provider': 'electricity_maps'},
+        ]
+
+        df = pandas.DataFrame.from_records(records)
+        df['value'] = df['value'].astype('int64')
+        df = expand_to_sampling_rate(self, df)
+
+        return df
+
+    def _parse_metrics(self, df):
+        df['detail_name'] = df['provider']
+        df = df.drop(columns=['provider'])
+        return df
+
+    def _add_and_validate_sampling_rate_and_jitter(self, df):
+        return df


### PR DESCRIPTION
ElectricityMaps has a "Carbon Intensity Level" API Endpoint now.

This providers adds checking this level.

One caveat: It does not support history. Runs over 2 hours lenght might thus have incorrect results. 

However since we use it for website testing mostly it will work nicely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds a new provider that integrates the ElectricityMaps "Carbon Intensity Level" API endpoint to measure grid carbon intensity. The provider maps API-returned level strings (low/medium/high/very_high) to numeric values (1–4) for use in carbon intensity calculations.

## Key Changes
- **New Provider Class**: `CarbonIntensityLevelElectricitymapsMachineProvider` that queries the Electricity Maps endpoint for current carbon intensity levels and returns timestamped measurements.
- **Configuration**: Added configuration templates in `config.yml.example` and `frontend/js/helpers/config.js.example` with required parameters (region, token) and sampling rate settings.
- **Integration**: Modified `lib/phase_stats.py` to handle the new metric alongside existing carbon intensity providers.

## Implementation Details
The provider:
- Validates configuration parameters (region, token) at initialization
- Performs system health checks via the Electricity Maps "latest" endpoint
- Records UTC timestamps during profiling periods
- Fetches current carbon intensity level and maps it to numeric values (defaults to 0 for unrecognized levels)
- Returns a DataFrame with two samples (start/end) containing time, value, and provider columns
- Expands measurements to the configured sampling rate

## Limitations
- Does not support historical data
- Results may be inaccurate for measurement runs longer than 2 hours
- Primarily intended for website testing use cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->