### PR TITLE
(feat): Reboot machine after certain intervals

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -46,6 +46,10 @@ cluster:
     jobs_processing: "random"
     update_os_packages: True
     shutdown_on_job_no: suspend
+    # Force a reboot after the machine has been running for this many seconds. Only triggers when no
+    # measurement is active. If the job queue is never empty the reboot will be deferred indefinitely.
+    # Set to False or 0 to disable. Example: 86400 = 24 hours.
+    reboot_after_seconds: False
     # These two parameters have only effect in cluster mode. When using CLI they will be set via flags --docker-prune and --full-docker-prune only
     docker_prune: False
     full_docker_prune: True

--- a/cron/client.py
+++ b/cron/client.py
@@ -63,6 +63,19 @@ def set_status(status_code, data=None, run_id=None):
     )
     DB().query(query=query, params=params)
 
+def reboot_if_uptime_exceeded(reboot_after_s):
+
+    if not reboot_after_s:
+        return
+
+    with open('/proc/uptime', encoding='UTF-8') as f:
+        uptime_seconds = float(f.read().split()[0])
+
+    if uptime_seconds > reboot_after_s:
+        print(f"Uptime {uptime_seconds:.0f}s exceeds reboot_after_seconds {reboot_after_s}s. Rebooting...")
+        subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
+        subprocess.check_output(['sudo', 'systemctl', 'reboot'], encoding='UTF-8', errors='replace')
+
 def do_maintenance():
     config = GlobalConfig().config # pylint: disable=redefined-outer-name
 
@@ -304,12 +317,16 @@ if __name__ == '__main__':
 
             else:
                 set_status('job_no')
-                if config['cluster']['client']['shutdown_on_job_no']:
-                    subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
-                    time.sleep(60) # sleep for 60 before going to suspend to allow logins to cluster when systems are fresh rebooted for maintenance
-                    subprocess.check_output(['sudo', 'systemctl', config['cluster']['client']['shutdown_on_job_no']], encoding='UTF-8', errors='replace')
 
                 if not args.testing:
+                    if reboot_after_seconds:= config['cluster']['client'].get('reboot_after_seconds'): # 0 will also resolve to false, which is what we want
+                        reboot_if_uptime_exceeded(reboot_after_seconds)
+
+                    if config['cluster']['client']['shutdown_on_job_no']:
+                        subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
+                        time.sleep(60) # sleep for 60 before going to suspend to allow logins to cluster when systems are fresh rebooted for maintenance
+                        subprocess.check_output(['sudo', 'systemctl', config['cluster']['client']['shutdown_on_job_no']], encoding='UTF-8', errors='replace')
+
                     time.sleep(config['cluster']['client']['sleep_time_no_job'])
 
             if args.testing:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds automatic machine reboot functionality that triggers after the machine has been running for a specified duration, but only when no measurement is active.

## Changes

**config.yml.example**
- Added `reboot_after_seconds` configuration parameter to the `cluster` section with default value `False`
- Includes documentation explaining that reboots only occur during idle periods (no active measurements)

**cron/client.py**
- Added `reboot_if_uptime_exceeded(reboot_after_s)` helper function that:
  - Reads system uptime from `/proc/uptime`
  - Triggers `systemctl reboot` (after syncing) when uptime exceeds the configured threshold
- Integrated uptime check into the main client loop's `job_no` path (skipped when running with `--testing` flag)
- Check runs before existing `shutdown_on_job_no` behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->