### PR TITLE
Fixing tests

### DIFF
--- a/lib/post_metric_providers/calculate_co2_intensity.py
+++ b/lib/post_metric_providers/calculate_co2_intensity.py
@@ -52,7 +52,7 @@ def calculate_co2_intensity(run_id):
             if not energy_values:
                 continue
 
-            detail_name = f"{energy_metric}_{energy_detail_name}_{carbon_metric}_{carbon_detail_name}"
+            detail_name = f"{energy_detail_name}_{carbon_metric}_{carbon_detail_name}"
             derived_metric = energy_metric.replace('_energy_', '_carbon_')
             derived_metric_id = DB().fetch_one('''
                 INSERT INTO measurement_metrics (run_id, metric, detail_name, unit)

--- a/lib/post_metric_providers/calculate_co2_intensity.py
+++ b/lib/post_metric_providers/calculate_co2_intensity.py
@@ -8,8 +8,6 @@ from io import StringIO
 
 from lib.db import DB
 
-DERIVED_METRIC = 'psu_carbon_elephant_machine'
-
 def calculate_co2_intensity(run_id):
     carbon_intensity_metrics = DB().fetch_all('''
         SELECT id, metric, detail_name
@@ -55,11 +53,12 @@ def calculate_co2_intensity(run_id):
                 continue
 
             detail_name = f"{energy_metric}_{energy_detail_name}_{carbon_metric}_{carbon_detail_name}"
+            derived_metric = energy_metric.replace('_energy_', '_carbon_')
             derived_metric_id = DB().fetch_one('''
                 INSERT INTO measurement_metrics (run_id, metric, detail_name, unit)
                 VALUES (%s, %s, %s, %s)
                 RETURNING id
-            ''', params=(run_id, DERIVED_METRIC, detail_name, 'ugCO2e'))[0]
+            ''', params=(run_id, derived_metric, detail_name, 'ugCO2e'))[0]
 
             csv_buffer = StringIO()
             carbon_times = [entry[0] for entry in carbon_values]
@@ -81,4 +80,3 @@ def calculate_co2_intensity(run_id):
                 columns=('measurement_metric_id', 'value', 'time')
             )
             csv_buffer.close()
-

--- a/metric_providers/carbon/intensity/elephant/machine/provider.py
+++ b/metric_providers/carbon/intensity/elephant/machine/provider.py
@@ -150,7 +150,6 @@ class CarbonIntensityElephantMachineProvider(BaseMetricProvider):
             'region': self.region,
             'startTime': self._format_time(self._start_time),
             'endTime': self._format_time(self._end_time),
-            'update': 'true',
         }
 
         if self.provider_filter:

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -946,7 +946,7 @@ def test_phase_stats_maps_elephant_machine_carbon():
     )
 
     assert data['metric'] == 'psu_carbon_ac_sdia_machine'
-    assert data['detail_name'] == 'psu_energy_ac_sdia_machine_[MACHINE]_carbon_intensity_elephant_machine_bundesnetzagentur_de'
+    assert data['detail_name'] == '[MACHINE]_carbon_intensity_elephant_machine_bundesnetzagentur_de'
     assert data['unit'] == 'ugCO2e'
     assert data['value'] == 1200
     assert data['type'] == 'TOTAL'

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -281,7 +281,7 @@ def test_phase_embodied_and_operational_carbon():
     psu_energy_ac_mcp_machine = next(d for d in data if d['metric'] == 'psu_energy_ac_mcp_machine')
     psu_carbon_ac_mcp_machine = next(d for d in data if d['metric'] == 'psu_carbon_ac_mcp_machine')
 
-    assert psu_carbon_ac_mcp_machine['detail_name'] == 'psu_energy_ac_mcp_machine_[MACHINE]_carbon_intensity_static_machine_static'
+    assert psu_carbon_ac_mcp_machine['detail_name'] == '[MACHINE]_carbon_intensity_static_machine_static'
     assert psu_carbon_ac_mcp_machine['unit'] == 'ugCO2e'
 
     operational_carbon_expected = int(psu_energy_ac_mcp_machine['value'] * MICROJOULES_TO_KWH * carbon_intensity_value * 1_000_000)

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -270,6 +270,8 @@ def test_phase_embodied_and_operational_carbon():
     carbon_intensity_value = 436
     import_static_carbon_intensity(run_id, carbon_intensity_value)
 
+    calculate_co2_intensity(run_id)
+
     sci = {"R":0,"EL":4,"RS":1,"TE":181000}
     build_and_store_phase_stats(run_id, sci=sci)
 
@@ -279,11 +281,11 @@ def test_phase_embodied_and_operational_carbon():
     psu_energy_ac_mcp_machine = next(d for d in data if d['metric'] == 'psu_energy_ac_mcp_machine')
     psu_carbon_ac_mcp_machine = next(d for d in data if d['metric'] == 'psu_carbon_ac_mcp_machine')
 
-    assert psu_carbon_ac_mcp_machine['detail_name'] == '[MACHINE]'
-    assert psu_carbon_ac_mcp_machine['unit'] == 'ug'
+    assert psu_carbon_ac_mcp_machine['detail_name'] == 'psu_energy_ac_mcp_machine_[MACHINE]_carbon_intensity_static_machine_static'
+    assert psu_carbon_ac_mcp_machine['unit'] == 'ugCO2e'
 
     operational_carbon_expected = int(psu_energy_ac_mcp_machine['value'] * MICROJOULES_TO_KWH * carbon_intensity_value * 1_000_000)
-    assert psu_carbon_ac_mcp_machine['value'] == operational_carbon_expected
+    assert psu_carbon_ac_mcp_machine['value'] == pytest.approx(operational_carbon_expected, abs=10)
     assert psu_carbon_ac_mcp_machine['type'] == 'TOTAL'
 
     phase_time_in_years = Tests.TEST_MEASUREMENT_RUNTIME_DURATION_NON_HIDDEN_S / (60 * 60 * 24 * 365)
@@ -317,6 +319,7 @@ def test_phase_operational_carbon_uses_dynamic_intensity_without_sci_i():
         detail_name='simulation',
     )
 
+    calculate_co2_intensity(run_id)
     build_and_store_phase_stats(run_id, sci={})
 
     data = DB().fetch_one(
@@ -654,6 +657,8 @@ def test_sci_calculation_for_custom_metric():
 
     import_static_carbon_intensity(run_id, 500)
 
+    calculate_co2_intensity(run_id)
+
     # Define comprehensive SCI configuration with all required parameters
     test_sci_config = {
         'EL': 4,       # Expected lifespan (years)
@@ -854,7 +859,7 @@ def test_calculate_co2_intensity_uses_microgram_scale():
 
     derived_metric_id = DB().fetch_one(
         "SELECT id FROM measurement_metrics WHERE run_id = %s AND metric = %s AND unit = %s",
-        params=(run_id, 'psu_carbon_elephant_machine', 'ugCO2e')
+        params=(run_id, 'psu_carbon_ac_mcp_machine', 'ugCO2e')
     )[0]
 
     derived_values = DB().fetch_all(
@@ -936,11 +941,11 @@ def test_phase_stats_maps_elephant_machine_carbon():
         FROM phase_stats
         WHERE phase = %s AND metric = %s
         ''',
-        params=('007_Stress', 'psu_carbon_elephant_machine'),
+        params=('007_Stress', 'psu_carbon_ac_sdia_machine'),
         fetch_mode='dict',
     )
 
-    assert data['metric'] == 'psu_carbon_elephant_machine'
+    assert data['metric'] == 'psu_carbon_ac_sdia_machine'
     assert data['detail_name'] == 'psu_energy_ac_sdia_machine_[MACHINE]_carbon_intensity_elephant_machine_bundesnetzagentur_de'
     assert data['unit'] == 'ugCO2e'
     assert data['value'] == 1200

--- a/tests/metric_providers/test_electricitymaps_provider.py
+++ b/tests/metric_providers/test_electricitymaps_provider.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import pandas
 import pytest
 import requests
 import tempfile
@@ -214,9 +213,8 @@ def test_fallback_http_error_returns_none():
         return make_response(status_code=503)
 
     with patch('requests.get', side_effect=side_effect):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
-    assert provider._error_string != ''
+        with pytest.raises(RuntimeError, match='503'):
+            provider._read_metrics()
 
 
 # --- _read_metrics: error paths ---
@@ -224,18 +222,15 @@ def test_fallback_http_error_returns_none():
 def test_http_error_returns_none_and_logs():
     provider = profiled_provider()
     with patch('requests.get', return_value=make_response(status_code=500)):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
-    assert '500' in provider._error_string
+        with pytest.raises(RuntimeError, match='500'):
+            provider._read_metrics()
 
 
 def test_network_failure_returns_none_and_logs():
     provider = profiled_provider()
     with patch('requests.get', side_effect=requests.RequestException('timeout')):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
-
-    assert provider._error_string != ''
+        with pytest.raises(RuntimeError, match='timeout'):
+            provider._read_metrics()
 
 
 # --- _read_metrics: missing start/end times ---

--- a/tests/metric_providers/test_electricitymaps_provider.py
+++ b/tests/metric_providers/test_electricitymaps_provider.py
@@ -216,23 +216,6 @@ def test_fallback_http_error_returns_none():
         with pytest.raises(RuntimeError, match='503'):
             provider._read_metrics()
 
-
-# --- _read_metrics: error paths ---
-
-def test_http_error_returns_none_and_logs():
-    provider = profiled_provider()
-    with patch('requests.get', return_value=make_response(status_code=500)):
-        with pytest.raises(RuntimeError, match='500'):
-            provider._read_metrics()
-
-
-def test_network_failure_returns_none_and_logs():
-    provider = profiled_provider()
-    with patch('requests.get', side_effect=requests.RequestException('timeout')):
-        with pytest.raises(RuntimeError, match='timeout'):
-            provider._read_metrics()
-
-
 # --- _read_metrics: missing start/end times ---
 
 def test_read_metrics_without_profiling_raises():

--- a/tests/metric_providers/test_elephant_providers.py
+++ b/tests/metric_providers/test_elephant_providers.py
@@ -1,5 +1,4 @@
 import shutil
-import pandas
 import pytest
 import requests
 import uuid
@@ -87,9 +86,17 @@ def test_missing_provider_without_simulation_raises():
 
 def test_check_system_success():
     provider = make_provider()
-    with patch('requests.get', return_value=make_response({'status': 'healthy'})) as mock_get:
+    current_data = [{'time': FIXED_TIME, 'carbon_intensity': FIXED_VALUE, 'provider': 'test_de'}]
+
+    def side_effect(url, **_):
+        if '/health' in url:
+            return make_response({'status': 'healthy'})
+        return make_response(current_data)
+
+    with patch('requests.get', side_effect=side_effect) as mock_get:
         provider.check_system()
-    mock_get.assert_called_once_with(f'{BASE_URL}/health', timeout=10)
+
+    assert mock_get.call_args_list[0][0][0] == f'{BASE_URL}/health'
 
 
 def test_check_system_failure_raises():
@@ -117,7 +124,7 @@ def test_read_metrics_url_and_params():
     call_kwargs = mock_get.call_args
     assert call_kwargs[0][0] == f'{BASE_URL}/carbon-intensity/history'
     assert call_kwargs[1]['params']['region'] == 'DE'
-    assert call_kwargs[1]['params']['update'] == 'true'
+    assert 'update' not in call_kwargs[1]['params']
 
 
 def test_read_metrics_with_provider_filter():
@@ -191,43 +198,41 @@ def test_empty_history_with_simulation_uses_simulation_fallback():
 def test_http_error_returns_none_and_logs():
     provider = profiled_provider()
     with patch('requests.get', return_value=make_response(status_code=500)):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
-    assert '500' in provider._error_string
+        with pytest.raises(RuntimeError, match='500'):
+            provider._read_metrics()
 
 
 def test_network_failure_returns_none_and_logs():
     provider = profiled_provider()
     with patch('requests.get', side_effect=requests.RequestException('timeout')):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
-    assert provider._error_string != ''
+        with pytest.raises(RuntimeError, match='timeout'):
+            provider._read_metrics()
 
 
 def test_fallback_http_error_returns_none():
     provider = profiled_provider()
 
-    def side_effect(url, **_kwargs):
+    def side_effect(url, **_):
         if 'history' in url:
             return make_response([])
         return make_response(status_code=503)
 
     with patch('requests.get', side_effect=side_effect):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
+        with pytest.raises(RuntimeError, match='503'):
+            provider._read_metrics()
 
 
 def test_fallback_network_failure_returns_none():
     provider = profiled_provider()
 
-    def side_effect(url, **_kwargs):
+    def side_effect(url, **_):
         if 'history' in url:
             return make_response([])
         raise requests.RequestException('unreachable')
 
     with patch('requests.get', side_effect=side_effect):
-        result = provider._read_metrics()
-    assert isinstance(result, pandas.DataFrame) and result.empty
+        with pytest.raises(RuntimeError, match='unreachable'):
+            provider._read_metrics()
 
 
 # --- _read_metrics: missing start/end times ---
@@ -290,7 +295,7 @@ def _live_elephant_reachable():
 @pytest.mark.skipif(not _live_elephant_reachable(), reason='Elephant service not reachable')
 def test_live_check_system_passes():
     provider = CarbonIntensityElephantMachineProvider(
-        region='DE', provider='test', elephant=LIVE_ELEPHANT_CONFIG, folder=GMT_METRICS_DIR, skip_check=True,
+        region='DE', provider='bundesnetzagentur', elephant=LIVE_ELEPHANT_CONFIG, folder=GMT_METRICS_DIR, skip_check=True,
     )
     provider.check_system()
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -103,14 +103,13 @@ def test_db_rows_are_written_and_presented():
 
     # calculate_co2_intensity derives a carbon metric for each energy+carbon_intensity combo.
     # Add those expected derived names so the assertion below can validate them.
-    if any('carbon_intensity_' in p for p in metric_providers):
-        derived_carbon_metrics = [
-            p.replace('_energy_', '_carbon_')
-            for p in metric_providers if '_energy_' in p
-        ]
-        metric_providers.extend(derived_carbon_metrics)
-    else:
-        derived_carbon_metrics = []
+    assert any('carbon_intensity_' in p for p in metric_providers), \
+        "carbon_intensity provider must be present in test-config.yml"
+    derived_carbon_metrics = [
+        p.replace('_energy_', '_carbon_')
+        for p in metric_providers if '_energy_' in p
+    ]
+    metric_providers.extend(derived_carbon_metrics)
 
     do_check = True
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -101,6 +101,17 @@ def test_db_rows_are_written_and_presented():
 
         metric_providers.extend(pm_additional_list)
 
+    # calculate_co2_intensity derives a carbon metric for each energy+carbon_intensity combo.
+    # Add those expected derived names so the assertion below can validate them.
+    if any('carbon_intensity_' in p for p in metric_providers):
+        derived_carbon_metrics = [
+            p.replace('_energy_', '_carbon_')
+            for p in metric_providers if '_energy_' in p
+        ]
+        metric_providers.extend(derived_carbon_metrics)
+    else:
+        derived_carbon_metrics = []
+
     do_check = True
 
     for d in data:
@@ -119,7 +130,7 @@ def test_db_rows_are_written_and_presented():
                 match = re.search(r"Imported \S* (\d+) \S* metrics from  PowermetricsProvider", run_stdout, re.MULTILINE)
                 assert match is not None
                 do_check = False
-            else:
+            elif d_provider not in derived_carbon_metrics:
                 ## Assert the information printed to std.out matches what's in the db
                 match = re.search(rf"Imported \S* (\d+) \S* metrics from\s*{d_class_name}", run_stdout)
                 assert match is not None

--- a/tests/test_config_opts.py
+++ b/tests/test_config_opts.py
@@ -89,7 +89,7 @@ def test_provider_disabling_working():
 
     providers = list(run_data['configured_metric_providers'].keys())
     # or check bc in linux / macos there is a different result set of configured providers
-    assert providers == ['psu_energy_ac_sdia_machine', 'cpu_utilization_mach_system', 'psu_energy_ac_xgboost_machine'] or providers == ['disk_used_statvfs_system', 'network_io_procfs_system', 'memory_used_procfs_system', 'psu_energy_ac_sdia_machine', 'cpu_utilization_procfs_system', 'psu_energy_ac_xgboost_machine'], 'Network Connections provider still in configured_metric_providers' #pylint: disable=consider-using-in
+    assert providers == ['psu_energy_ac_sdia_machine', 'cpu_utilization_mach_system', 'psu_energy_ac_xgboost_machine'] or providers == ['disk_used_statvfs_system', 'network_io_procfs_system', 'memory_used_procfs_system', 'psu_energy_ac_sdia_machine', 'cpu_utilization_procfs_system', 'psu_energy_ac_xgboost_machine', 'carbon_intensity_static_machine'], 'Network Connections provider still in configured_metric_providers' #pylint: disable=consider-using-in
 
 def test_phase_padding_inactive():
     out = io.StringIO()


### PR DESCRIPTION
- [ ]  Still need to check if this also fixes the front end display errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Refactors CO2 intensity derivation to generate carbon metrics dynamically (replacing "_energy_" with "_carbon_"), removes a now-unused module constant, adjusts Elephant provider request parameters, and updates tests to match the new behavior and stricter error handling.

## Key changes
- lib/post_metric_providers/calculate_co2_intensity.py
  - Removed module-level DERIVED_METRIC constant.
  - Now derives metric names per energy metric by replacing "_energy_" → "_carbon_" and inserts derived metrics with unit "ugCO2e".
  - Builds derived metric detail_name as "{energy_detail_name}_{carbon_metric}_{carbon_detail_name}" and writes values via DB.copy_from.

- metric_providers/carbon/intensity/elephant/machine/provider.py
  - Removed the `update: "true"` request parameter when querying /carbon-intensity/history.
  - Error handling unchanged but tests updated to reflect parameter removal.

- Tests
  - tests/lib/test_phase_stats.py: Calls calculate_co2_intensity(run_id) before building phase stats; updated expected derived metric names/units and loosened one numerical assertion to pytest.approx.
  - tests/metric_providers/test_electricitymaps_provider.py: Removed pandas import; updated error-path tests to expect RuntimeError (status code/message) instead of returning empty DataFrame and checking _error_string.
  - tests/metric_providers/test_elephant_providers.py: Removed unused pandas import; rewrote request and error assertions to expect RuntimeError on failures and assert the absence of the `update` parameter; adjusted live test provider string.
  - tests/smoke_test.py: Adds derived carbon metric names (map _energy_ → _carbon_) to expected metric providers and skips stdout-count validation for those derived metrics.
  - tests/test_config_opts.py: Accepts additional configured provider `carbon_intensity_static_machine` in assertions.

## Testing / behavior impact
- Derived carbon metrics are now created per energy+carbon_intensity pairing and stored as microgram CO2 equivalents (ugCO2e).
- Several tests now expect RuntimeError for provider HTTP errors instead of empty DataFrames.
- Test expectations and metric-name mappings updated to reflect dynamic naming.
- Checklist: the PR contains an unchecked item to verify whether these changes also fix front-end display errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->