### PR TITLE
(feat): Git API does not flake anymore on 403 Rate Limiting, but only sends warning to admin

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -67,7 +67,7 @@ def check_repo(repo_url, branch='main'):
         )
 
     if response.status_code == 404:
-        raise RuntimeError(f"Could not find repository {repo_url} and branch {branch}. Is the repo publicly accessible, not empty and does the branch {branch} exist?") from exc
+        raise RuntimeError(f"Could not find repository {repo_url} and branch {branch}. Is the repo publicly accessible, not empty and does the branch {branch} exist?")
 
     if response.status_code != 200:
         # We do not fail here, but only do a warning, bc often times the SSH or token which might be supplied in the URL is too restrictive then and cannot be used to query the commits also

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -52,13 +52,37 @@ def check_repo(repo_url, branch='main'):
         error_helpers.log_error(f"Request to {git_api} API failed",url=url,exception=str(exc))
         raise RuntimeError(f"Could not find repository {repo_url} and branch {branch}. Is the repo publicly accessible, not empty and does the branch {branch} exist?") from exc
 
-    # We do not fail here, but only do a warning, bc often times the SSH or token which might be supplied in the URL is too restrictive then and cannot be used to query the commits also
-    # However we do check the commits endpoint bc this tells us if the repo is non empty or not
+    message = _extract_api_message(response)
+
+    # ---- Rate limit detection (works even on 403) ----
+    if response.status_code == 403 and isinstance(message, str) and message.startswith("API rate limit exceeded"):
+        error_helpers.log_error(f"{git_api} rate limit exceeded while accessing {repo_url}. Skipping repo validation - Consider authenticating future requests.")
+        return
+
+    # ---- Status-based handling ----
+    if response.status_code == 403:
+        raise PermissionError(
+            f"Access denied (403) for repository {repo_url}. "
+            f"Repo may be private or credentials are insufficient."
+        )
+
+    if response.status_code == 404:
+        raise RuntimeError(f"Could not find repository {repo_url} and branch {branch}. Is the repo publicly accessible, not empty and does the branch {branch} exist?") from exc
+
     if response.status_code != 200:
+        # We do not fail here, but only do a warning, bc often times the SSH or token which might be supplied in the URL is too restrictive then and cannot be used to query the commits also
+        # However we do check the commits endpoint bc this tells us if the repo is non empty or not
         if git_api in ('gitlab', 'github'):
             raise RuntimeError(f"Repository returned bad status code ({response.status_code}). Is the repo ({repo_url}) publicly accessible, not empty and does the branch {branch} exist?")
         else:
             error_helpers.log_error(f"Connect to {git_api} API was possible, but return code was not 200",url=url,status_code=response.status_code,status_text=response.text)
+
+def _extract_api_message(response):
+    try:
+        data = response.json()
+        return data.get("message", "") if isinstance(data, dict) else ""
+    except Exception: # pylint: disable=broad-exception-caught
+        return response.text or ""
 
 def get_repo_last_marker(repo_url, marker, branch=None):
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Modified `lib/utils.py` to improve Git API error handling in the `check_repo` function:

- Added `_extract_api_message()` helper to safely extract message fields from JSON API responses
- Detects GitHub/GitLab rate-limit 403 responses (messages starting with "API rate limit exceeded") and logs them as warnings instead of failing, preventing test flakes
- 403 responses without rate-limit messages now raise `PermissionError` to indicate access denial (e.g., private repo or insufficient credentials)
- 404 responses now raise `RuntimeError` to indicate repository/branch not found
- Maintains existing warning/logging behavior for non-200 responses from non-GitHub/GitLab APIs

Lines changed: +26/-2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->