### PR TITLE
Fixes tests under Mac

### DIFF
--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -17,6 +17,7 @@ from lib.db import DB
 from lib.user import User
 from lib.terminal_colors import TerminalColors
 from lib.scenario_runner import ScenarioRunner
+from lib import host_platform
 import optimization_providers.base
 
 
@@ -94,6 +95,21 @@ class RunJob(Job):
                 )
 
         finally:
-            shutil.rmtree(runner._tmp_folder) # we see no sane reason for keeping tmp files on the cluster after a run
+            # we see no sane reason for keeping tmp files on the cluster after a run.
+            # On macOS, however, we wipe contents in place rather than removing
+            # _tmp_folder itself, so the directory's inode (and the inodes of subdirs
+            # like repo/) stay stable across runs. Docker Desktop on macOS caches
+            # inode<->path mappings in its virtiofs layer; deleting and recreating a
+            # bind-mount source between runs causes subsequent containers to see a
+            # stale/empty view until Docker Desktop is restarted.
+            if host_platform.is_macos():
+                if runner._tmp_folder.exists():
+                    for child in runner._tmp_folder.iterdir():
+                        if child.is_symlink() or not child.is_dir():
+                            child.unlink()
+                        else:
+                            shutil.rmtree(child, ignore_errors=False)
+            else:
+                shutil.rmtree(runner._tmp_folder)
             self._run_id = runner._run_id # might not be set yet due to error
             user.deduct_measurement_quota(self._machine_id, int(runner._last_measurement_duration/1_000_000)) # duration in runner is in microseconds. We need seconds

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -102,14 +102,12 @@ class RunJob(Job):
             # inode<->path mappings in its virtiofs layer; deleting and recreating a
             # bind-mount source between runs causes subsequent containers to see a
             # stale/empty view until Docker Desktop is restarted.
-            if host_platform.is_macos():
-                if runner._tmp_folder.exists():
-                    for child in runner._tmp_folder.iterdir():
-                        if child.is_symlink() or not child.is_dir():
-                            child.unlink()
-                        else:
-                            shutil.rmtree(child, ignore_errors=False)
-            else:
-                shutil.rmtree(runner._tmp_folder)
+            if runner._tmp_folder.exists():
+                for child in runner._tmp_folder.iterdir():
+                    if child.is_symlink() or not child.is_dir():
+                        child.unlink()
+                    else:
+                        shutil.rmtree(child, ignore_errors=False)
+
             self._run_id = runner._run_id # might not be set yet due to error
             user.deduct_measurement_quota(self._machine_id, int(runner._last_measurement_duration/1_000_000)) # duration in runner is in microseconds. We need seconds

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -8,7 +8,6 @@ import faulthandler
 faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to stderr
 
 import os
-import shutil
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -17,7 +16,6 @@ from lib.db import DB
 from lib.user import User
 from lib.terminal_colors import TerminalColors
 from lib.scenario_runner import ScenarioRunner
-from lib import host_platform
 import optimization_providers.base
 
 
@@ -96,18 +94,10 @@ class RunJob(Job):
 
         finally:
             # we see no sane reason for keeping tmp files on the cluster after a run.
-            # On macOS, however, we wipe contents in place rather than removing
-            # _tmp_folder itself, so the directory's inode (and the inodes of subdirs
-            # like repo/) stay stable across runs. Docker Desktop on macOS caches
-            # inode<->path mappings in its virtiofs layer; deleting and recreating a
-            # bind-mount source between runs causes subsequent containers to see a
-            # stale/empty view until Docker Desktop is restarted.
-            if runner._tmp_folder.exists():
-                for child in runner._tmp_folder.iterdir():
-                    if child.is_symlink() or not child.is_dir():
-                        child.unlink()
-                    else:
-                        shutil.rmtree(child, ignore_errors=False)
+            # We empty the folder in place rather than removing it (see
+            # ScenarioRunner._initialize_folder) so the directory inode stays stable
+            # for Docker Desktop's virtiofs cache on macOS.
+            runner._initialize_folder(runner._tmp_folder)
 
             self._run_id = runner._run_id # might not be set yet due to error
             user.deduct_measurement_quota(self._machine_id, int(runner._last_measurement_duration/1_000_000)) # duration in runner is in microseconds. We need seconds

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -274,20 +274,17 @@ class ScenarioRunner:
             time.sleep(sleep_time)
 
     def _initialize_folder(self, path: Path):
-        if host_platform.is_macos():
-            # Wipe contents in place rather than rmtree+mkdir so the directory's inode
-            # stays stable across runs. Docker Desktop on macOS caches inode<->path
-            # mappings in its virtiofs layer; if a bind-mount source is deleted and
-            # recreated between runs, subsequent containers can see a stale/empty
-            # view of the directory until Docker Desktop is restarted.
-            for child in path.iterdir():
-                if child.is_symlink() or not child.is_dir():
-                    child.unlink()
-                else:
-                    shutil.rmtree(child, ignore_errors=False)
-            return
-        shutil.rmtree(path, ignore_errors=False)
-        path.mkdir(parents=False, exist_ok=False)
+        # Wipe contents in place rather than rmtree+mkdir so the directory's inode
+        # stays stable across runs. Docker Desktop on macOS caches inode<->path
+        # mappings in its virtiofs layer; if a bind-mount source is deleted and
+        # recreated between runs, subsequent containers can see a stale/empty
+        # view of the directory until Docker Desktop is restarted.
+        for child in path.iterdir():
+            if child.is_symlink() or not child.is_dir():
+                child.unlink()
+            else:
+                shutil.rmtree(child, ignore_errors=False)
+
 
     def _ensure_ssh_private_key_file(self):
         if self._ssh_private_key is None:
@@ -1268,10 +1265,7 @@ class ScenarioRunner:
         # maybe create a switch here later to keep this artifact if we have a use case ...
         # On macOS we wipe contents in place to keep the inode stable: this dir is bind-mounted
         # into kaniko as /output, and Docker Desktop's virtiofs caches inode<->path mappings.
-        if host_platform.is_macos():
-            self._initialize_folder(self._build_dir)
-        else:
-            shutil.rmtree(self._build_dir)
+        self._initialize_folder(self._build_dir)
 
     def _save_image_and_volume_sizes(self):
 

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -274,11 +274,18 @@ class ScenarioRunner:
             time.sleep(sleep_time)
 
     def _initialize_folder(self, path: Path):
-        # Wipe contents in place rather than rmtree+mkdir so the directory's inode
-        # stays stable across runs. Docker Desktop on macOS caches inode<->path
-        # mappings in its virtiofs layer; if a bind-mount source is deleted and
-        # recreated between runs, subsequent containers can see a stale/empty
-        # view of the directory until Docker Desktop is restarted.
+        # Ensures the folder exists and is empty for a new run. When it already exists
+        # we wipe its contents in place rather than rmtree+mkdir so the directory's
+        # inode (and the inodes of subdirs like repo/) stays stable across runs.
+        # Docker Desktop on macOS caches inode<->path mappings in its virtiofs layer;
+        # if a bind-mount source is deleted and recreated between runs, subsequent
+        # containers can see a stale/empty view of the directory until Docker Desktop
+        # is restarted. The mkdir only runs when the folder is missing, where there is
+        # no existing inode to preserve.
+        if not path.exists():
+            path.mkdir(parents=False, exist_ok=False)
+            return
+
         for child in path.iterdir():
             if child.is_symlink() or not child.is_dir():
                 child.unlink()

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -274,6 +274,18 @@ class ScenarioRunner:
             time.sleep(sleep_time)
 
     def _initialize_folder(self, path: Path):
+        if host_platform.is_macos():
+            # Wipe contents in place rather than rmtree+mkdir so the directory's inode
+            # stays stable across runs. Docker Desktop on macOS caches inode<->path
+            # mappings in its virtiofs layer; if a bind-mount source is deleted and
+            # recreated between runs, subsequent containers can see a stale/empty
+            # view of the directory until Docker Desktop is restarted.
+            for child in path.iterdir():
+                if child.is_symlink() or not child.is_dir():
+                    child.unlink()
+                else:
+                    shutil.rmtree(child, ignore_errors=False)
+            return
         shutil.rmtree(path, ignore_errors=False)
         path.mkdir(parents=False, exist_ok=False)
 
@@ -1254,7 +1266,12 @@ class ScenarioRunner:
 
         # Delete the directory /tmp/gmt_docker_images as we do not want to keep the tar and the loaded image
         # maybe create a switch here later to keep this artifact if we have a use case ...
-        shutil.rmtree(self._build_dir)
+        # On macOS we wipe contents in place to keep the inode stable: this dir is bind-mounted
+        # into kaniko as /output, and Docker Desktop's virtiofs caches inode<->path mappings.
+        if host_platform.is_macos():
+            self._initialize_folder(self._build_dir)
+        else:
+            shutil.rmtree(self._build_dir)
 
     def _save_image_and_volume_sizes(self):
 

--- a/runner.py
+++ b/runner.py
@@ -245,7 +245,17 @@ if __name__ == '__main__':
                 optimization_providers.base.run_reporters(runner._user_id, runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
 
             if args.file_cleanup:
-                shutil.rmtree(runner._tmp_folder)
+                # Wipe contents in place rather than removing _tmp_folder itself, so the
+                # directory's inode (and the inodes of subdirs like repo/) stay stable
+                # across runs. Docker Desktop on macOS caches inode<->path mappings in
+                # its virtiofs layer; deleting and recreating a bind-mount source
+                # between runs causes subsequent containers to see a stale/empty view.
+                if runner._tmp_folder.exists():
+                    for child in runner._tmp_folder.iterdir():
+                        if child.is_symlink() or not child.is_dir():
+                            child.unlink()
+                        else:
+                            shutil.rmtree(child, ignore_errors=False)
 
             if not runner._dev_no_save:
                 print(TerminalColors.OKGREEN,'\n\n####################################################################################')

--- a/runner.py
+++ b/runner.py
@@ -8,7 +8,6 @@ faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to st
 from lib.venv_checker import check_venv
 check_venv() # this check must even run before __main__ as imports might not get resolved
 
-import shutil
 import os
 import re
 import subprocess
@@ -245,17 +244,10 @@ if __name__ == '__main__':
                 optimization_providers.base.run_reporters(runner._user_id, runner._run_id, runner._tmp_folder, runner.get_optimizations_ignore())
 
             if args.file_cleanup:
-                # Wipe contents in place rather than removing _tmp_folder itself, so the
-                # directory's inode (and the inodes of subdirs like repo/) stay stable
-                # across runs. Docker Desktop on macOS caches inode<->path mappings in
-                # its virtiofs layer; deleting and recreating a bind-mount source
-                # between runs causes subsequent containers to see a stale/empty view.
-                if runner._tmp_folder.exists():
-                    for child in runner._tmp_folder.iterdir():
-                        if child.is_symlink() or not child.is_dir():
-                            child.unlink()
-                        else:
-                            shutil.rmtree(child, ignore_errors=False)
+                # Empty the folder in place rather than removing it (see
+                # ScenarioRunner._initialize_folder) so the directory inode stays stable
+                # for Docker Desktop's virtiofs cache on macOS.
+                runner._initialize_folder(runner._tmp_folder)
 
             if not runner._dev_no_save:
                 print(TerminalColors.OKGREEN,'\n\n####################################################################################')

--- a/tests/cron/test_client.py
+++ b/tests/cron/test_client.py
@@ -40,4 +40,4 @@ def test_simple_cluster_run():
         Tests.assertion_info('MEASUREMENT SUCCESSFULLY COMPLETED', ps.stdout)
 
     # also check that the tmp folder was deleted locally
-    assert not tmp_folder.exists(), '/tmp/green-metrics-tool was still present after cluster run. It should have been deleted though'
+    assert tmp_folder.exists() and not any(tmp_folder.iterdir()), '/tmp/green-metrics-tool was not emptied after run although --file-cleanup was set'

--- a/tests/test_config_opts.py
+++ b/tests/test_config_opts.py
@@ -89,7 +89,7 @@ def test_provider_disabling_working():
 
     providers = list(run_data['configured_metric_providers'].keys())
     # or check bc in linux / macos there is a different result set of configured providers
-    assert providers == ['psu_energy_ac_sdia_machine', 'cpu_utilization_mach_system', 'psu_energy_ac_xgboost_machine'] or providers == ['disk_used_statvfs_system', 'network_io_procfs_system', 'memory_used_procfs_system', 'psu_energy_ac_sdia_machine', 'cpu_utilization_procfs_system', 'psu_energy_ac_xgboost_machine', 'carbon_intensity_static_machine'], 'Network Connections provider still in configured_metric_providers' #pylint: disable=consider-using-in
+    assert providers == ['psu_energy_ac_sdia_machine', 'cpu_utilization_mach_system', 'psu_energy_ac_xgboost_machine', 'carbon_intensity_static_machine'] or providers == ['disk_used_statvfs_system', 'network_io_procfs_system', 'memory_used_procfs_system', 'psu_energy_ac_sdia_machine', 'cpu_utilization_procfs_system', 'psu_energy_ac_xgboost_machine', 'carbon_intensity_static_machine'], 'Network Connections provider still in configured_metric_providers' #pylint: disable=consider-using-in
 
 def test_phase_padding_inactive():
     out = io.StringIO()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -147,8 +147,8 @@ def test_uri_github_repo_and_using_default_filename():
     assert uri_in_db == uri, Tests.assertion_info(f"uri: {uri}", uri_in_db)
     assert ps.stderr == '', Tests.assertion_info('no errors', ps.stderr)
 
-    # also check that the tmp folder was deleted locally
-    assert not tmp_folder.exists(), '/tmp/green-metrics-tool was not deleted after run although --file-cleanup was set'
+    # also check that the tmp folder was emptied locally
+    assert tmp_folder.exists() and not any(tmp_folder.iterdir()), '/tmp/green-metrics-tool was not emptied after run although --file-cleanup was set'
 
 ## --branch BRANCH
 #    Optionally specify the git branch when targeting a git repository
@@ -447,8 +447,9 @@ def test_file_cleanup():
         stdout=subprocess.PIPE,
         encoding='UTF-8'
     )
-    assert not os.path.exists('/tmp/green-metrics-tool'), \
-        Tests.assertion_info('tmp directory exists', not os.path.exists('/tmp/green-metrics-tool'))
+    tmp_folder = Path('/tmp/green-metrics-tool')
+    assert tmp_folder.exists() and not any(tmp_folder.iterdir()), \
+        Tests.assertion_info('tmp directory emptied', f"exists={tmp_folder.exists()}, contents={list(tmp_folder.iterdir()) if tmp_folder.exists() else None}")
 
 ## --skip-unsafe and --allow-unsafe
 #pylint: disable=unused-variable


### PR DESCRIPTION
We had the problem that tests under mac would corrupt the docker VM. Building on the work that I did some time back I could now home in. The problem is a stale inode cache in the docker demon. This PR fixes the tests under MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem
Tests running on macOS were corrupting the Docker VM due to stale inode cache in the Docker daemon. This occurred when directory cleanup operations (`rmtree` followed by `mkdir`) caused inode mappings to change across test runs.

## Solution
Introduces platform-aware directory cleanup logic to preserve inode stability on macOS while maintaining full cleanup on other systems.

## Changes
**lib/job/run.py**
- Imports `host_platform` from `lib`
- Modified `_process()` method's cleanup logic to conditionally handle macOS: deletes directory contents in place (removing symlinks and child directories) while preserving the directory itself, versus using full `shutil.rmtree()` on non-macOS platforms

**lib/scenario_runner.py**
- Updated `_initialize_folder()` with macOS-specific cleanup: removes contents in place and exits early, avoiding `rmtree()` + `mkdir()` operations that could change inode mappings under Docker Desktop virtiofs
- Modified Docker build artifact cleanup to call `_initialize_folder()` on macOS (preserving inode), while non-macOS continues using `shutil.rmtree()`

**Impact**: +35/-2 lines across both files. No public API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->