### PR TITLE
simple compare table

### DIFF
--- a/frontend/compare-simple.html
+++ b/frontend/compare-simple.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- Standard Meta -->
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href="/images/favicon.ico">
+    <link rel="icon" href="/images/favicon.ico">
+    <link rel="icon" href="/images/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" href="/images/favicon-32x32.png" sizes="32x32">
+    <!-- Site Properties -->
+    <title>Green Metrics Tool - Simple Compare</title>
+    <meta name="referrer" content="no-referrer-when-downgrade" />
+    <meta name="description" content="Simple side-by-side comparison of run metrics" />
+    <script src="/dist/js/jquery.min.js" defer></script>
+    <script src="/dist/js/datatables.min.js" defer></script>
+    <script src="/dist/js/toast.min.js" defer></script>
+    <script src="/dist/js/transition.min.js" defer></script>
+    <script src="/dist/js/accordion.min.js" defer></script>
+    <script src="/dist/js/dropdown.min.js" defer></script>
+    <script src="/js/helpers/config.js" defer></script>
+    <script src="/js/helpers/main.js" defer></script>
+    <script src="/js/helpers/converters.js" defer></script>
+    <script src="/js/compare-simple.js" defer></script>
+
+    <link rel="stylesheet" type="text/css" class="ui" href="/dist/css/semantic_reduced.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/green-coding.css">
+    <link rel="stylesheet" type="text/css" href="/dist/css/datatables.min.css">
+</head>
+<body class="preload">
+    <gmt-menu data-active-item="runs-repos"></gmt-menu>
+    <div class="main ui container" id="main">
+        <h1 class="ui header float left">
+            <a id="menu-toggle" class="opened"><i class="bars bordered inverted left icon opened"></i></a>
+            <span>Simple comparison of runs</span>
+        </h1>
+        <div class="ui full-width-card card">
+            <div class="content">
+                <div class="header">
+                    <a class="ui red ribbon label">
+                        <h3>Controls</h3>
+                    </a>
+                </div>
+                <div class="description">
+                    <div class="ui form">
+                        <div class="fields">
+                            <div class="four wide field">
+                                <label>Phase</label>
+                                <select id="phase-select" class="ui fluid dropdown">
+                                    <option value="[BASELINE]">Baseline</option>
+                                    <option value="[INSTALLATION]">Installation</option>
+                                    <option value="[BOOT]">Boot</option>
+                                    <option value="[IDLE]">Idle</option>
+                                    <option value="[RUNTIME]" selected>Runtime</option>
+                                    <option value="[REMOVE]">Remove</option>
+                                </select>
+                            </div>
+                            <div class="twelve wide field">
+                                <label>Display Options</label>
+                                <div class="ui small buttons">
+                                    <button id="axis-switch-button" class="ui basic button" type="button" data-tooltip="Swap axes (metrics ↔ runs)" data-position="top center" data-inverted="">
+                                        <i class="exchange icon"></i>
+                                        <span id="axis-switch-label">Metrics on Y / Runs on X</span>
+                                    </button>
+                                    <button id="colorize-button" class="ui basic button" type="button" data-tooltip="Color cells from green (lowest per metric) to red (highest)" data-position="top center" data-inverted="">
+                                        <i class="tint icon"></i>
+                                        <span id="colorize-label">Colorize</span>
+                                    </button>
+                                    <button id="source-toggle-button" class="ui basic button" type="button" data-tooltip="Toggle Source column" data-position="top center" data-inverted="">
+                                        <i class="eye icon"></i>
+                                        <span id="source-toggle-label">Source</span>
+                                    </button>
+                                    <button id="detail-toggle-button" class="ui basic button" type="button" data-tooltip="Toggle Detail column" data-position="top center" data-inverted="">
+                                        <i class="eye icon"></i>
+                                        <span id="detail-toggle-label">Detail</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="loader-compare-simple" class="ui segment">
+            <div class="ui active inverted dimmer">
+                <div class="ui text loader">Loading run data</div>
+            </div>
+            <p><br><br><br></p>
+        </div>
+
+        <div id="no-data-message" class="ui icon message warning hidden">
+            <i class="info circle icon"></i>
+            <div class="content">
+                <div class="header">No data for this phase</div>
+                <p>None of the selected runs have data for the selected phase.</p>
+            </div>
+        </div>
+
+        <div class="ui full-width-card card">
+            <div class="content">
+                <div class="header">
+                    <a class="ui blue ribbon label">
+                        <h3>Comparison Table</h3>
+                    </a>
+                </div>
+                <div class="description">
+                    <table id="compare-simple-table" class="ui celled striped table" style="width:100%"></table>
+                </div>
+            </div>
+        </div>
+
+        <div class="clearing" style="display:block; height: 10px;"></div>
+    </div>
+</body>
+</html>

--- a/frontend/compare-simple.html
+++ b/frontend/compare-simple.html
@@ -78,6 +78,12 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="fields">
+                            <div class="sixteen wide field">
+                                <label>Metrics (leave empty to show all)</label>
+                                <select id="metrics-select" multiple="" class="ui fluid search multiple selection dropdown"></select>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/frontend/js/compare-simple.js
+++ b/frontend/js/compare-simple.js
@@ -1,0 +1,377 @@
+"use strict";
+
+const DEFAULT_PHASE = '[RUNTIME]';
+
+const compareSimpleState = {
+    runIds: [],
+    runMeta: {},
+    phaseStats: {},
+    availablePhases: new Set(),
+    selectedPhase: DEFAULT_PHASE,
+    metricsOnY: true,
+    colorize: false,
+    showSource: false,
+    showDetail: false,
+    dataTable: null,
+};
+
+// Green (hsl 120) → red (hsl 0), low = best.
+const colorForRatio = (ratio) => {
+    const r = Math.max(0, Math.min(1, ratio));
+    const hue = 120 * (1 - r);
+    return `hsl(${hue}, 70%, 80%)`;
+};
+
+const buildMetricRanges = (metricKeys, lookup) => {
+    const ranges = {};
+    metricKeys.forEach((m) => {
+        const key = `${m.metric_name}||${m.detail_name}`;
+        const values = compareSimpleState.runIds
+            .map((rid) => lookup[rid][key]?.mean)
+            .filter((v) => v != null && !Number.isNaN(v));
+        if (values.length < 2) return;
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        if (min === max) return;
+        ranges[key] = { min, max };
+    });
+    return ranges;
+};
+
+const fetchSinglePhaseStats = async (run_id) => {
+    try {
+        const response = await makeAPICall(`/v1/phase_stats/single/${encodeURIComponent(run_id)}`);
+        return response?.data || null;
+    } catch (err) {
+        if (err instanceof APIEmptyResponse204) return null;
+        showNotification(`Could not load phase stats for run ${run_id}`, err);
+        return null;
+    }
+};
+
+const fetchRunMeta = async (run_id) => {
+    try {
+        const response = await makeAPICall(`/v2/run/${encodeURIComponent(run_id)}`);
+        return response?.data || null;
+    } catch (err) {
+        showNotification(`Could not load run info for ${run_id}`, err);
+        return null;
+    }
+};
+
+const buildRunLabel = (run_id, meta) => {
+    if (!meta) return run_id.slice(0, 8);
+    const parts = [];
+    if (meta.name) parts.push(escapeString(meta.name));
+    if (meta.commit_hash) parts.push(`<code>${escapeString(String(meta.commit_hash).slice(0, 7))}</code>`);
+    return parts.join('<br>') || run_id.slice(0, 8);
+};
+
+const extractMetricRowsForPhase = (phaseStatsObject, phase, run_id) => {
+    const rows = [];
+    const phase_data = phaseStatsObject?.data?.[phase]?.data;
+    if (!phase_data) return rows;
+
+    for (const metric_name in phase_data) {
+        const metric_data = phase_data[metric_name];
+        const unit = metric_data.unit;
+        for (const detail_name in metric_data.data) {
+            const detail = metric_data.data[detail_name];
+            // For a single run the key in detail.data is the run_id itself.
+            const value_entry = detail.data?.[run_id] || Object.values(detail.data || {})[0];
+            if (value_entry == null) continue;
+            const [converted_value, converted_unit] = convertValue(value_entry.mean, unit);
+            rows.push({
+                metric_name,
+                detail_name,
+                source: getPretty(metric_name, 'source'),
+                clean_name: getPretty(metric_name, 'clean_name'),
+                unit: converted_unit,
+                mean: converted_value,
+            });
+        }
+    }
+    return rows;
+};
+
+const buildMetricKeys = (phase) => {
+    const map = new Map();
+    compareSimpleState.runIds.forEach((run_id) => {
+        const stats = compareSimpleState.phaseStats[run_id];
+        if (!stats) return;
+        const rows = extractMetricRowsForPhase(stats, phase, run_id);
+        rows.forEach((row) => {
+            const key = `${row.metric_name}||${row.detail_name}`;
+            if (!map.has(key)) {
+                map.set(key, {
+                    metric_name: row.metric_name,
+                    detail_name: row.detail_name,
+                    source: row.source,
+                    clean_name: row.clean_name,
+                    unit: row.unit,
+                });
+            }
+        });
+    });
+    return [...map.values()].sort((a, b) => {
+        if (a.source !== b.source) return a.source.localeCompare(b.source);
+        if (a.clean_name !== b.clean_name) return a.clean_name.localeCompare(b.clean_name);
+        return a.detail_name.localeCompare(b.detail_name);
+    });
+};
+
+const buildValueLookup = (phase) => {
+    const lookup = {};
+    compareSimpleState.runIds.forEach((run_id) => {
+        lookup[run_id] = {};
+        const stats = compareSimpleState.phaseStats[run_id];
+        if (!stats) return;
+        const rows = extractMetricRowsForPhase(stats, phase, run_id);
+        rows.forEach((row) => {
+            lookup[run_id][`${row.metric_name}||${row.detail_name}`] = { mean: row.mean, unit: row.unit };
+        });
+    });
+    return lookup;
+};
+
+const formatValue = (value) => {
+    if (value == null || Number.isNaN(value)) return '';
+    return numberFormatter.format(value);
+};
+
+const populatePhaseDropdown = () => {
+    const select = document.querySelector('#phase-select');
+    const allowedPhases = ['[BASELINE]', '[INSTALLATION]', '[BOOT]', '[IDLE]', '[RUNTIME]', '[REMOVE]'];
+
+    Array.from(select.options).forEach((opt) => {
+        if (!compareSimpleState.availablePhases.has(opt.value)) {
+            opt.disabled = true;
+            opt.text = `${opt.text} (no data)`;
+        }
+    });
+
+    if (!compareSimpleState.availablePhases.has(compareSimpleState.selectedPhase)) {
+        const fallback = allowedPhases.find((p) => compareSimpleState.availablePhases.has(p));
+        if (fallback) {
+            compareSimpleState.selectedPhase = fallback;
+            select.value = fallback;
+        }
+    } else {
+        select.value = compareSimpleState.selectedPhase;
+    }
+
+    select.addEventListener('change', () => {
+        compareSimpleState.selectedPhase = select.value;
+        renderTable();
+    });
+
+    $(select).dropdown();
+};
+
+const updateAxisSwitchLabel = () => {
+    const label = document.querySelector('#axis-switch-label');
+    label.textContent = compareSimpleState.metricsOnY
+        ? 'Metrics on Y / Runs on X'
+        : 'Runs on Y / Metrics on X';
+};
+
+const resetTableElement = () => {
+    const tableEl = $('#compare-simple-table');
+    if (compareSimpleState.dataTable) {
+        compareSimpleState.dataTable.destroy();
+        compareSimpleState.dataTable = null;
+    }
+    tableEl.empty();
+};
+
+const renderMetricsOnY = (metricKeys, lookup) => {
+    const ranges = compareSimpleState.colorize ? buildMetricRanges(metricKeys, lookup) : {};
+    const columns = [
+        { title: 'Metric', data: 'metric' },
+    ];
+    if (compareSimpleState.showSource) {
+        columns.push({ title: 'Source', data: 'source' });
+    }
+    if (compareSimpleState.showDetail) {
+        columns.push({ title: 'Detail', data: 'detail' });
+    }
+    columns.push({ title: 'Unit', data: 'unit' });
+    compareSimpleState.runIds.forEach((run_id, idx) => {
+        const label = buildRunLabel(run_id, compareSimpleState.runMeta[run_id]);
+        columns.push({
+            title: `<a href="/stats.html?id=${encodeURIComponent(run_id)}" target="_blank">${label}</a>`,
+            data: `run_${idx}`,
+            className: 'dt-body-right',
+            render: function (val, type) {
+                if (type === 'display' || type === 'filter') return formatValue(val);
+                return val == null ? null : val;
+            },
+            createdCell: function (td, cellData, rowData) {
+                const range = ranges[rowData._key];
+                if (!range || cellData == null || Number.isNaN(cellData)) return;
+                td.style.backgroundColor = colorForRatio((cellData - range.min) / (range.max - range.min));
+            },
+        });
+    });
+
+    const data = metricKeys.map((m) => {
+        const key = `${m.metric_name}||${m.detail_name}`;
+        const row = {
+            _key: key,
+            metric: escapeString(m.clean_name),
+            source: escapeString(m.source),
+            detail: escapeString(m.detail_name),
+            unit: escapeString(m.unit || ''),
+        };
+        compareSimpleState.runIds.forEach((run_id, idx) => {
+            row[`run_${idx}`] = lookup[run_id][key]?.mean ?? null;
+        });
+        return row;
+    });
+
+    return { columns, data };
+};
+
+const renderRunsOnY = (metricKeys, lookup) => {
+    const ranges = compareSimpleState.colorize ? buildMetricRanges(metricKeys, lookup) : {};
+    const columns = [
+        {
+            title: 'Run',
+            data: 'run',
+            render: function (val, type) {
+                if (type === 'display') return val;
+                return val.replace(/<[^>]*>/g, '');
+            },
+        },
+    ];
+    metricKeys.forEach((m, idx) => {
+        const key = `${m.metric_name}||${m.detail_name}`;
+        const header = `${escapeString(m.clean_name)}<br><small>${escapeString(m.source)} / ${escapeString(m.detail_name)}${m.unit ? ` (${escapeString(m.unit)})` : ''}</small>`;
+        columns.push({
+            title: header,
+            data: `metric_${idx}`,
+            className: 'dt-body-right',
+            render: function (val, type) {
+                if (type === 'display' || type === 'filter') return formatValue(val);
+                return val == null ? null : val;
+            },
+            createdCell: function (td, cellData) {
+                const range = ranges[key];
+                if (!range || cellData == null || Number.isNaN(cellData)) return;
+                td.style.backgroundColor = colorForRatio((cellData - range.min) / (range.max - range.min));
+            },
+        });
+    });
+
+    const data = compareSimpleState.runIds.map((run_id) => {
+        const label = buildRunLabel(run_id, compareSimpleState.runMeta[run_id]);
+        const row = {
+            run: `<a href="/stats.html?id=${encodeURIComponent(run_id)}" target="_blank">${label}</a>`,
+        };
+        metricKeys.forEach((m, idx) => {
+            row[`metric_${idx}`] = lookup[run_id][`${m.metric_name}||${m.detail_name}`]?.mean ?? null;
+        });
+        return row;
+    });
+
+    return { columns, data };
+};
+
+const renderTable = () => {
+    const phase = compareSimpleState.selectedPhase;
+    const metricKeys = buildMetricKeys(phase);
+    const noDataEl = document.querySelector('#no-data-message');
+
+    if (metricKeys.length === 0) {
+        resetTableElement();
+        noDataEl.classList.remove('hidden');
+        return;
+    }
+    noDataEl.classList.add('hidden');
+
+    const lookup = buildValueLookup(phase);
+    const { columns, data } = compareSimpleState.metricsOnY
+        ? renderMetricsOnY(metricKeys, lookup)
+        : renderRunsOnY(metricKeys, lookup);
+
+    resetTableElement();
+
+    compareSimpleState.dataTable = $('#compare-simple-table').DataTable({
+        data: data,
+        columns: columns,
+        deferRender: true,
+        autoWidth: false,
+        lengthMenu: [[25, 50, 100, -1], [25, 50, 100, 'All']],
+        pageLength: 100,
+        layout: {
+            topStart: 'pageLength',
+            topEnd: 'search',
+            bottomStart: 'info',
+            bottomEnd: 'paging',
+        },
+        order: [],
+    });
+};
+
+$(document).ready(() => {
+    (async () => {
+        const url_params = getURLParams();
+
+        if (url_params['ids'] == null || url_params['ids'] === '' || url_params['ids'] === 'null') {
+            showNotification('No ids', 'ids parameter in URL is empty or not present. Did you follow a correct URL?');
+            document.querySelector('#loader-compare-simple').remove();
+            return;
+        }
+
+        compareSimpleState.runIds = url_params['ids'].split(',').filter((s) => s.length > 0);
+
+        if (compareSimpleState.runIds.length === 0) {
+            showNotification('No ids', 'ids parameter is empty after parsing.');
+            document.querySelector('#loader-compare-simple').remove();
+            return;
+        }
+
+        const results = await Promise.all(compareSimpleState.runIds.map(async (run_id) => {
+            const [stats, meta] = await Promise.all([
+                fetchSinglePhaseStats(run_id),
+                fetchRunMeta(run_id),
+            ]);
+            return { run_id, stats, meta };
+        }));
+
+        results.forEach(({ run_id, stats, meta }) => {
+            if (stats) {
+                compareSimpleState.phaseStats[run_id] = stats;
+                Object.keys(stats.data || {}).forEach((p) => compareSimpleState.availablePhases.add(p));
+            }
+            if (meta) compareSimpleState.runMeta[run_id] = meta;
+        });
+
+        document.querySelector('#loader-compare-simple').remove();
+
+        populatePhaseDropdown();
+        updateAxisSwitchLabel();
+
+        document.querySelector('#axis-switch-button').addEventListener('click', () => {
+            compareSimpleState.metricsOnY = !compareSimpleState.metricsOnY;
+            updateAxisSwitchLabel();
+            renderTable();
+        });
+
+        const wireToggleButton = (selector, stateKey) => {
+            const btn = document.querySelector(selector);
+            btn.addEventListener('click', () => {
+                compareSimpleState[stateKey] = !compareSimpleState[stateKey];
+                btn.classList.toggle('active', compareSimpleState[stateKey]);
+                btn.classList.toggle('basic', !compareSimpleState[stateKey]);
+                renderTable();
+            });
+        };
+
+        wireToggleButton('#colorize-button', 'colorize');
+        wireToggleButton('#source-toggle-button', 'showSource');
+        wireToggleButton('#detail-toggle-button', 'showDetail');
+
+        renderTable();
+    })();
+});

--- a/frontend/js/compare-simple.js
+++ b/frontend/js/compare-simple.js
@@ -8,8 +8,9 @@ const compareSimpleState = {
     phaseStats: {},
     availablePhases: new Set(),
     selectedPhase: DEFAULT_PHASE,
-    metricsOnY: true,
-    colorize: false,
+    selectedMetrics: null, // null = no filter (show all); otherwise a Set of `${metric_name}||${detail_name}` keys
+    metricsOnY: false,
+    colorize: true,
     showSource: false,
     showDetail: false,
     dataTable: null,
@@ -141,8 +142,9 @@ const formatValue = (value) => {
 
 const populatePhaseDropdown = () => {
     const select = document.querySelector('#phase-select');
-    const allowedPhases = ['[BASELINE]', '[INSTALLATION]', '[BOOT]', '[IDLE]', '[RUNTIME]', '[REMOVE]'];
+    const mainPhases = ['[BASELINE]', '[INSTALLATION]', '[BOOT]', '[IDLE]', '[RUNTIME]', '[REMOVE]'];
 
+    // Mark hardcoded main-phase options as disabled when no run produced data for them.
     Array.from(select.options).forEach((opt) => {
         if (!compareSimpleState.availablePhases.has(opt.value)) {
             opt.disabled = true;
@@ -150,8 +152,26 @@ const populatePhaseDropdown = () => {
         }
     });
 
+    // Append sub-phases (anything without [BRACKETS]) that exist in any run, grouped under an optgroup.
+    const subPhases = [...compareSimpleState.availablePhases]
+        .filter((p) => !mainPhases.includes(p))
+        .sort((a, b) => a.localeCompare(b));
+
+    if (subPhases.length > 0) {
+        const group = document.createElement('optgroup');
+        group.label = 'Sub-phases';
+        subPhases.forEach((phase) => {
+            const opt = document.createElement('option');
+            opt.value = phase;
+            opt.text = phase;
+            group.appendChild(opt);
+        });
+        select.appendChild(group);
+    }
+
     if (!compareSimpleState.availablePhases.has(compareSimpleState.selectedPhase)) {
-        const fallback = allowedPhases.find((p) => compareSimpleState.availablePhases.has(p));
+        const fallback = mainPhases.find((p) => compareSimpleState.availablePhases.has(p))
+            || subPhases[0];
         if (fallback) {
             compareSimpleState.selectedPhase = fallback;
             select.value = fallback;
@@ -162,10 +182,42 @@ const populatePhaseDropdown = () => {
 
     select.addEventListener('change', () => {
         compareSimpleState.selectedPhase = select.value;
+        // Re-list the dropdown options for the new phase, but keep the selection — metrics that don't
+        // exist in the new phase are silently dropped from view but preserved in state for if the user
+        // switches back.
+        populateMetricsDropdown();
         renderTable();
     });
 
     $(select).dropdown();
+};
+
+const populateMetricsDropdown = () => {
+    const select = document.querySelector('#metrics-select');
+    const allMetrics = buildMetricKeys(compareSimpleState.selectedPhase);
+
+    if ($(select).data('moduleDropdown')) {
+        $(select).dropdown('destroy');
+    }
+    select.innerHTML = '';
+    allMetrics.forEach((m) => {
+        const opt = document.createElement('option');
+        opt.value = `${m.metric_name}||${m.detail_name}`;
+        opt.text = `${m.clean_name} — ${m.detail_name}${m.unit ? ` (${m.unit})` : ''}`;
+        if (compareSimpleState.selectedMetrics != null && compareSimpleState.selectedMetrics.has(opt.value)) {
+            opt.selected = true;
+        }
+        select.appendChild(opt);
+    });
+
+    $(select).dropdown({
+        placeholder: 'All metrics shown',
+        onChange: () => {
+            const selected = Array.from(select.selectedOptions).map((o) => o.value);
+            compareSimpleState.selectedMetrics = selected.length === 0 ? null : new Set(selected);
+            renderTable();
+        },
+    });
 };
 
 const updateAxisSwitchLabel = () => {
@@ -246,7 +298,17 @@ const renderRunsOnY = (metricKeys, lookup) => {
     ];
     metricKeys.forEach((m, idx) => {
         const key = `${m.metric_name}||${m.detail_name}`;
-        const header = `${escapeString(m.clean_name)}<br><small>${escapeString(m.source)} / ${escapeString(m.detail_name)}${m.unit ? ` (${escapeString(m.unit)})` : ''}</small>`;
+        const nameLine = m.unit
+            ? `${escapeString(m.clean_name)} <small>(${escapeString(m.unit)})</small>`
+            : escapeString(m.clean_name);
+        const parts = [`<div>${nameLine}</div>`];
+        if (compareSimpleState.showSource) {
+            parts.push(`<small class="detail-name-ellipsis" title="${escapeString(m.source)}">${escapeString(m.source)}</small>`);
+        }
+        if (compareSimpleState.showDetail) {
+            parts.push(`<small class="detail-name-ellipsis" title="${escapeString(m.detail_name)}">${escapeString(m.detail_name)}</small>`);
+        }
+        const header = parts.join('');
         columns.push({
             title: header,
             data: `metric_${idx}`,
@@ -279,15 +341,19 @@ const renderRunsOnY = (metricKeys, lookup) => {
 
 const renderTable = () => {
     const phase = compareSimpleState.selectedPhase;
-    const metricKeys = buildMetricKeys(phase);
+    const allMetricKeys = buildMetricKeys(phase);
     const noDataEl = document.querySelector('#no-data-message');
 
-    if (metricKeys.length === 0) {
+    if (allMetricKeys.length === 0) {
         resetTableElement();
         noDataEl.classList.remove('hidden');
         return;
     }
     noDataEl.classList.add('hidden');
+
+    const metricKeys = compareSimpleState.selectedMetrics == null
+        ? allMetricKeys
+        : allMetricKeys.filter((m) => compareSimpleState.selectedMetrics.has(`${m.metric_name}||${m.detail_name}`));
 
     const lookup = buildValueLookup(phase);
     const { columns, data } = compareSimpleState.metricsOnY
@@ -339,17 +405,26 @@ $(document).ready(() => {
             return { run_id, stats, meta };
         }));
 
+        const phaseSetsPerRun = [];
         results.forEach(({ run_id, stats, meta }) => {
             if (stats) {
                 compareSimpleState.phaseStats[run_id] = stats;
-                Object.keys(stats.data || {}).forEach((p) => compareSimpleState.availablePhases.add(p));
+                phaseSetsPerRun.push(new Set(Object.keys(stats.data || {})));
             }
             if (meta) compareSimpleState.runMeta[run_id] = meta;
         });
 
+        // Intersection across all runs that returned stats — a phase is only "available" when every run has it.
+        if (phaseSetsPerRun.length > 0) {
+            compareSimpleState.availablePhases = phaseSetsPerRun.reduce(
+                (acc, set) => new Set([...acc].filter((p) => set.has(p))),
+            );
+        }
+
         document.querySelector('#loader-compare-simple').remove();
 
         populatePhaseDropdown();
+        populateMetricsDropdown();
         updateAxisSwitchLabel();
 
         document.querySelector('#axis-switch-button').addEventListener('click', () => {
@@ -360,10 +435,14 @@ $(document).ready(() => {
 
         const wireToggleButton = (selector, stateKey) => {
             const btn = document.querySelector(selector);
-            btn.addEventListener('click', () => {
-                compareSimpleState[stateKey] = !compareSimpleState[stateKey];
+            const syncVisual = () => {
                 btn.classList.toggle('active', compareSimpleState[stateKey]);
                 btn.classList.toggle('basic', !compareSimpleState[stateKey]);
+            };
+            syncVisual();
+            btn.addEventListener('click', () => {
+                compareSimpleState[stateKey] = !compareSimpleState[stateKey];
+                syncVisual();
                 renderTable();
             });
         };

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -2,17 +2,17 @@
 
 const compareButton = () => {
     const checkedBoxes = document.querySelectorAll('input[type=checkbox]:checked');
-
-    let link = '/compare.html?ids='
-
-    checkedBoxes.forEach(checkbox => {
-        link = `${link}${checkbox.value},`;
-    });
-    link = link.slice(0,link.length-1);
+    const ids = Array.from(checkedBoxes).map(cb => cb.value).join(',');
 
     const value = document.querySelector('#compare-force-mode').value;
-    link = `${link}&force_mode=${value}`
     localStorage.setItem('compare_mode_last_value', value);
+
+    let link;
+    if (value === 'simple_table') {
+        link = `/compare-simple.html?ids=${ids}`;
+    } else {
+        link = `/compare.html?ids=${ids}&force_mode=${value}`;
+    }
 
     window.open(link, '_blank');
 }

--- a/frontend/runs.html
+++ b/frontend/runs.html
@@ -160,6 +160,7 @@
                                     <option value="usage_scenarios">Usage Scenarios</option>
                                     <option value="usage_scenario_variables">Variables</option>
                                     <option value="repos">Repos</option>
+                                    <option value="simple_table">Simple Table</option>
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Introduces a new "Simple Table" comparison view for comparing run metrics side-by-side, as an alternative to the existing compare interface.

## Changes

**New Files:**
- `frontend/compare-simple.html`: Page layout for the simple compare view with controls to select phases, toggle axis swap, enable cell colorization, and show/hide source and detail columns
- `frontend/js/compare-simple.js`: Interactive comparison table renderer that fetches run metrics, maintains UI state (phase selection, orientation, toggles), computes per-metric min/max ranges for optional color highlighting, and populates a DataTable with formatted metric values

**Modified Files:**
- `frontend/js/helpers/runs.js`: Updated compare button handler to route to `/compare-simple.html` when "simple_table" mode is selected, otherwise routes to the existing `/compare.html`
- `frontend/runs.html`: Added "Simple Table" option to the compare-mode dropdown

## Key Features
- Phase-based metric comparison across multiple runs
- Dynamic metric colorization based on min/max value ranges
- Configurable display options (axis orientation, column visibility)
- Client-side state management with URL parameter integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/green-metrics-tool/pull/1702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->