### PR TITLE
Image Pruning Fix

### DIFF
--- a/lib/host_platform.py
+++ b/lib/host_platform.py
@@ -35,7 +35,7 @@ def get_tmp_root():
         return Path(tempfile.gettempdir()).resolve(strict=True)
     else:
         return Path('/tmp/').resolve(strict=True)
-    
+
 def clear_file_system_caches():
     if is_windows():
         try:
@@ -120,7 +120,7 @@ def split_volume_spec(volume, maxsplit=-1):
 
 def _docker_image_rows():
     ps = subprocess.run(
-        ['docker', 'images', '--format', '{{.Repository}}:{{.Tag}} {{.ID}}'],
+        ['docker', 'images', '--format', '{{.Repository}}:{{.Tag}}'],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -130,20 +130,15 @@ def _docker_image_rows():
     if ps.returncode != 0:
         raise subprocess.CalledProcessError(ps.returncode, ps.args, output=ps.stdout, stderr=ps.stderr)
 
-    rows = []
-    for line in ps.stdout.splitlines():
-        parts = line.rsplit(maxsplit=1)
-        if len(parts) == 2:
-            rows.append((parts[0], parts[1]))
-    return rows
+    return ps.stdout.splitlines()
 
 
 def remove_gmt_tmp_images():
 
-    image_ids = [image_id for image_name, image_id in _docker_image_rows() if 'gmt_run_tmp' in image_name]
-    
-    if image_ids:
-        subprocess.run(['docker', 'rmi', '-f', *image_ids], stderr=subprocess.DEVNULL, check=False)
+    image_names = [image_name for image_name in _docker_image_rows() if 'gmt_run_tmp' in image_name]
+
+    if image_names:
+        subprocess.run(['docker', 'rmi', '-f', *image_names], stderr=subprocess.DEVNULL, check=False)
 
 
 def stop_all_docker_containers():
@@ -164,10 +159,10 @@ def stop_all_docker_containers():
 
 
 def remove_docker_images_except(whitelist):
-    image_ids = [
-        image_id
-        for image_name, image_id in _docker_image_rows()
+    image_names = [
+        image_name
+        for image_name in _docker_image_rows()
         if not any(whitelisted_image in image_name for whitelisted_image in whitelist)
     ]
-    if image_ids:
-        subprocess.run(['docker', 'rmi', '-f', *image_ids], check=False)
+    if image_names:
+        subprocess.run(['docker', 'rmi', '-f', *image_names], check=False)


### PR DESCRIPTION
Image pruning was happening to all images with same tag. We wa…nt to delete only tags not all IDs on system



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## lib/host_platform.py

Updated Docker image cleanup logic to remove only specific image tags rather than all images sharing the same tag.

**Changes:**
- `_docker_image_rows()`: Modified to return only `REPOSITORY:TAG` strings by removing the `{{.ID}}` field from the Docker format string
- `remove_gmt_tmp_images()`: Updated to filter and remove images using the tag name strings directly
- `remove_docker_images_except()`: Updated to filter images by tag name and pass names to `docker rmi`

The fix addresses a bug where image pruning would delete all images on the system that shared a tag, rather than just removing the specific tag references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->