### PR TITLE
(feat): Custom metrics can be any unit

### DIFF
--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -135,8 +135,8 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
             <td>${scope}</td>
             <td><span class="detail-name-ellipsis" title="${detail_name}">${detail_name}</span></td>
             <td>${metric_data.type}</td>
-            <td><span title="${detail_data.mean} ${metric_data.unit}">${transformed_value?.toFixed(2)}</span> ${ transformed_value?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data.mean} ${metric_data.unit}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
-            <td>${transformed_unit}</td>
+            <td><span title="${detail_data.mean} ${escapeString(metric_data.unit)}">${transformed_value?.toFixed(2)}</span> ${ transformed_value?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data.mean} ${escapeString(metric_data.unit)}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
+            <td>${escapeString(transformed_unit)}</td>
             <td>${std_dev_text_table}</td>
             <td>${max_value}</td>
             <td>${min_value}</td>
@@ -155,8 +155,8 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
             <td>${scope}</td>
             <td><span class="detail-name-ellipsis" title="${detail_name}">${detail_name}</span></td>
             <td>${metric_data.type}</td>
-            <td><span title="${detail_data.mean} ${metric_data.unit}">${transformed_value?.toFixed(2)}</span> ${ transformed_value?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data.mean} ${metric_data.unit}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
-            <td>${transformed_unit}</td>
+            <td><span title="${detail_data.mean} ${escapeString(metric_data.unit)}">${transformed_value?.toFixed(2)}</span> ${ transformed_value?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data.mean} ${escapeString(metric_data.unit)}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
+            <td>${escapeString(transformed_unit)}</td>
             <td>${max_value}</td>
             <td>${min_value}</td>
             <td>
@@ -217,9 +217,9 @@ const displayDiffMetricBox = (phase, metric_name, metric_data, detail_name, deta
         <td>${scope}</td>
         <td><span class="detail-name-ellipsis" title="${detail_name}">${detail_name}</span></td>
         <td>${metric_data.type}</td>
-        <td><span title="${detail_data_array[0]} ${metric_data.unit}">${transformed_value_1?.toFixed(2)}</span> ${ transformed_value_1?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data_array[0]} ${metric_data.unit}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
-        <td><span title="${detail_data_array[1]} ${metric_data.unit}">${transformed_value_2?.toFixed(2)}</span> ${ transformed_value_2?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data_array[1]} ${metric_data.unit}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
-        <td>${transformed_unit}</td>
+        <td><span title="${detail_data_array[0]} ${escapeString(metric_data.unit)}">${transformed_value_1?.toFixed(2)}</span> ${ transformed_value_1?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data_array[0]} ${escapeString(metric_data.unit)}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
+        <td><span title="${detail_data_array[1]} ${escapeString(metric_data.unit)}">${transformed_value_2?.toFixed(2)}</span> ${ transformed_value_2?.toFixed(2) == '0.00' ? `<span data-tooltip="Value is lower than rounding. Unrounded value is ${detail_data_array[1]} ${escapeString(metric_data.unit)}" data-position="bottom center" data-inverted><i class="question circle icon link"></i></span>` : ''}</td>
+        <td>${escapeString(transformed_unit)}</td>
         <td class="${icon_color}">${relative_difference}</td>
         <td>${extra_label}</td>`;
 

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -6,19 +6,28 @@ from datetime import datetime
 
 # https://github.com/compose-spec/compose-spec/blob/master/spec.md
 
+VALID_CHARS = set(string.ascii_letters + string.digits + '_' + '-')
+
+VALID_CHARS_SPACE = VALID_CHARS.copy()
+VALID_CHARS_SPACE.add(' ')
+
 class SchemaChecker():
     def __init__(self, validate_compose_flag):
         self._validate_compose_flag = validate_compose_flag
 
+    def no_newlines(self, value):
+        if re.findall(r'\n', value):
+            raise SchemaError(f"{value} must not contain a newline character")
+        return value
+
+
     def is_valid_string(self, value):
-        valid_chars = set(string.ascii_letters + string.digits + '_' + '-')
-        if not set(value).issubset(valid_chars):
+        if not set(value).issubset(VALID_CHARS):
             raise SchemaError(f"{value} does not use valid characters! (a-zA-Z0-9_-)")
         return value
 
     def is_valid_string_with_spaces(self, value):
-        valid_chars = set(string.ascii_letters + string.digits + '_' + '-' + ' ')
-        if not set(value).issubset(valid_chars):
+        if not set(value).issubset(VALID_CHARS_SPACE):
             raise SchemaError(f"{value} does not use valid characters! (a-zA-Z0-9_-) and space")
         return value
 
@@ -106,7 +115,7 @@ class SchemaChecker():
             Optional('architecture'): And(str, Use(self.not_empty)),
             Optional('custom_metrics'): {
                 And(str, Use(self.not_empty), Use(self.is_valid_string)): {
-                    'unit': And(str, Use(self.not_empty), Use(self.is_valid_string_with_spaces)),
+                    'unit': And(str, Use(self.not_empty), Use(self.no_newlines)),
                     Optional('regex'): And(str, Use(self.not_empty), Use(self.regex_has_two_groups)),
                     Optional('sci'): bool,
                 },


### PR DESCRIPTION
This PR allows for the metric value to be any character except newline (which would break parsing).

Furthermore frontend was checked to not have XSS escapes with the value anymore now with new allowed chars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Custom Metrics Character Validation Expansion

This PR expands the character set allowed in custom metric values by changing validation logic to accept any character except newlines, which would break parsing.

### Changes

**Backend** (`lib/schema_checker.py`):
- Centralized allowed character rules into top-level constants (`VALID_CHARS`, `VALID_CHARS_SPACE`)
- Added new validation helper `no_newlines()` method to reject values containing newline characters
- Updated custom metrics `unit` field validation to use `no_newlines` instead of `is_valid_string_with_spaces`, effectively expanding the allowed character set from a restricted whitelist to allowing all characters except newlines

**Frontend** (`frontend/js/helpers/metric-boxes.js`):
- Consistently applied HTML escaping (`escapeString()`) to unit strings in tooltip/title attributes across `displaySimpleMetricBox` and `displayDiffMetricBox` functions to prevent XSS attacks with the expanded character set

### Security
The frontend was audited and verified to properly handle XSS escaping with the newly allowed characters, confirming no security vulnerabilities are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->