### PR TITLE
(feat): Reboot happens now always on package update

### DIFF
--- a/cron/client.py
+++ b/cron/client.py
@@ -94,7 +94,7 @@ def reboot_if_uptime_exceeded(reboot_after_s):
         print(f"Uptime {uptime_seconds:.0f}s exceeds reboot_after_seconds {reboot_after_s}s. Rebooting...")
         set_status('reboot')
         subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
-        subprocess.check_output(['sudo', 'systemctl', 'reboot'], encoding='UTF-8', errors='replace')
+        subprocess.check_output(['/usr/bin/sudo', '/usr/bin/systemctl', 'reboot'], encoding='UTF-8', errors='replace')
         time.sleep(86400) # reboot request might not be handled directly, thus we wait until this process gets killed.
 
 
@@ -105,7 +105,7 @@ def do_maintenance():
 
     python_realpath = Path('/usr/bin/python3').resolve(strict=True) # bc typically symlinked to python3.12 or similar
 
-    maintenance_cmd = ['sudo', python_realpath.as_posix(), '-I', '-B', '-S', Path('/usr/local/bin/green-metrics-tool/maintenance.py').resolve(strict=True).as_posix()]
+    maintenance_cmd = ['/usr/bin/sudo', python_realpath.as_posix(), '-I', '-B', '-S', Path('/usr/local/bin/green-metrics-tool/maintenance.py').resolve(strict=True).as_posix()]
 
     # first we need to determine if an apt update is also necessary. We only want to update once a day
     now = time.time()
@@ -227,7 +227,7 @@ def do_measurement_control():
 def reboot():
     set_status('reboot')
     subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
-    subprocess.check_output(['sudo', 'systemctl', 'reboot'], encoding='UTF-8', errors='replace')
+    subprocess.check_output(['/usr/bin/sudo', '/usr/bin/systemctl', 'reboot'], encoding='UTF-8', errors='replace')
     time.sleep(86400)
 
 if __name__ == '__main__':
@@ -369,7 +369,7 @@ if __name__ == '__main__':
                     if config['cluster']['client']['shutdown_on_job_no']:
                         subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
                         time.sleep(60) # sleep for 60 before going to suspend to allow logins to cluster when systems are fresh rebooted for maintenance
-                        subprocess.check_output(['sudo', 'systemctl', config['cluster']['client']['shutdown_on_job_no']], encoding='UTF-8', errors='replace')
+                        subprocess.check_output(['/usr/bin/sudo', '/usr/bin/systemctl', config['cluster']['client']['shutdown_on_job_no']], encoding='UTF-8', errors='replace')
 
                     time.sleep(config['cluster']['client']['sleep_time_no_job'])
 

--- a/cron/client.py
+++ b/cron/client.py
@@ -224,6 +224,12 @@ def do_measurement_control():
         # endlessly in validation until manually handled, which is what we want.
         time.sleep(config['cluster']['client']['time_between_control_workload_validations'])
 
+def reboot():
+    set_status('reboot')
+    subprocess.check_output(['sync'], encoding='UTF-8', errors='replace')
+    subprocess.check_output(['sudo', 'systemctl', 'reboot'], encoding='UTF-8', errors='replace')
+    time.sleep(86400)
+
 if __name__ == '__main__':
     try:
         parser = argparse.ArgumentParser()
@@ -244,11 +250,18 @@ if __name__ == '__main__':
         must_revalidate_bc_new_packages = False
         last_24h_maintenance = 0
 
+        result = DB().fetch_one('SELECT needs_revalidation FROM machines WHERE id = %s', params=(config['machine']['id'],), fetch_mode='dict')
+        if result and result['needs_revalidation']:
+            must_revalidate_bc_new_packages = True
+            DB().query('UPDATE machines SET needs_revalidation = false WHERE id = %s', params=(config['machine']['id'],))
+
         while True:
 
             # run forced maintenance with maintenance every 24 hours
             if not args.testing and last_24h_maintenance < (time.time() - 43200): # every 12 hours
-                must_revalidate_bc_new_packages = do_maintenance()
+                if do_maintenance(): # returns True if packages where installed and then we must do revalidation and reboot
+                    DB().query('UPDATE machines SET needs_revalidation = true WHERE id = %s', params=(config['machine']['id'],))
+                    reboot()
                 last_24h_maintenance = time.time()
 
             job = Job.get_job('run')
@@ -341,7 +354,9 @@ if __name__ == '__main__':
                         )
                 finally: # run periodic maintenance between every run
                     if not args.testing:
-                        must_revalidate_bc_new_packages = do_maintenance() # when new packages are installed, we must revalidate
+                        if do_maintenance(): # returns True if packages where installed and then we must do revalidation and reboot
+                            DB().query('UPDATE machines SET needs_revalidation = true WHERE id = %s', params=(config['machine']['id'],))
+                            reboot()
                         last_24h_maintenance = time.time()
 
             else:

--- a/cron/client.py
+++ b/cron/client.py
@@ -247,13 +247,12 @@ if __name__ == '__main__':
 
         config = GlobalConfig().config
 
-        must_revalidate_bc_new_packages = False
+        needs_revalidation = False
         last_24h_maintenance = 0
 
         result = DB().fetch_one('SELECT needs_revalidation FROM machines WHERE id = %s', params=(config['machine']['id'],), fetch_mode='dict')
         if result and result['needs_revalidation']:
-            must_revalidate_bc_new_packages = True
-            DB().query('UPDATE machines SET needs_revalidation = false WHERE id = %s', params=(config['machine']['id'],))
+            needs_revalidation = True
 
         while True:
 
@@ -277,9 +276,10 @@ if __name__ == '__main__':
                 else:
                     continue # retry all checks
 
-            if not args.testing and (must_revalidate_bc_new_packages or validate.is_validation_needed(config['machine']['id'], config['cluster']['client']['time_between_control_workload_validations'])):
+            if not args.testing and (needs_revalidation or validate.is_validation_needed(config['machine']['id'], config['cluster']['client']['time_between_control_workload_validations'])):
                 do_measurement_control()
-                must_revalidate_bc_new_packages = False # reset as measurement control has run. even if failed
+                DB().query('UPDATE machines SET needs_revalidation = false WHERE id = %s', params=(config['machine']['id'],))
+                needs_revalidation = False # reset as measurement control has run. even if failed
                 continue # re-do temperature checks
 
             if job:

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -216,6 +216,7 @@ CREATE TABLE machines (
     description text NOT NULL,
     available boolean DEFAULT false,
     status_code text,
+    needs_revalidation boolean NOT NULL DEFAULT false,
     jobs_processing text,
     cooldown_time_after_job integer,
     base_temperature integer,

--- a/migrations/2026_06_15_needs_revalidation.sql
+++ b/migrations/2026_06_15_needs_revalidation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE machines ADD COLUMN IF NOT EXISTS needs_revalidation boolean NOT NULL DEFAULT false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR implements automatic system reboots when OS packages are installed during maintenance, with persistence of revalidation state across reboots.

## Database Schema Changes
- Adds `needs_revalidation` boolean column to `machines` table (defaults to `false`)

## Client Logic Changes
- **New `reboot()` function**: Sets client status to 'reboot', syncs filesystem, triggers systemctl reboot, then sleeps
- **Startup initialization**: Reads persisted `machines.needs_revalidation` flag from database to determine if validation is required after boot
- **Scheduled maintenance (12-hour interval)**: When `do_maintenance()` detects installed packages, sets `machines.needs_revalidation = true` and calls `reboot()` instead of just setting an in-process flag
- **Post-job maintenance (finally block)**: Similarly triggers reboot with database persistence when packages are installed
- **Database persistence**: Revalidation flag is stored in the database rather than relying on in-process state, ensuring the requirement survives reboots

## Impact
Ensures newly installed packages are loaded into the running system through automatic reboots, with the revalidation requirement persisting across the reboot cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->