### PR TITLE
Allow users to update their ssh private keys (migration script)

### DIFF
--- a/migrations/2026_06_17_ssh_private_key_updateable.sql
+++ b/migrations/2026_06_17_ssh_private_key_updateable.sql
@@ -7,4 +7,4 @@ SET capabilities = jsonb_set(
         '["ssh_private_key"]'::jsonb
     ),
     true
-);
+) WHERE id != 0;

--- a/migrations/2026_06_17_ssh_private_key_updateable.sql
+++ b/migrations/2026_06_17_ssh_private_key_updateable.sql
@@ -1,0 +1,10 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{user,updateable_settings}',
+    (
+        COALESCE(capabilities->'user'->'updateable_settings', '[]'::jsonb) ||
+        '["ssh_private_key"]'::jsonb
+    ),
+    true
+);


### PR DESCRIPTION
PR https://github.com/green-coding-solutions/green-metrics-tool/pull/1625 introduced the feature that users can set SSH private keys on their own.

However, when I want to update the setting I get an error:

<img width="415" height="121" alt="Image" src="https://github.com/user-attachments/assets/c7f55961-74b7-4c9b-b0b1-43a6f3215079" />

The seed data in `docker/structure.sql:62` includes "ssh_private_key" in the updateable_settings list, but none of the existing migration scripts add it. This PR adds the missing migration script.

The issue was discovered on the SaaS version (https://metrics.green-coding.io/settings.html).