### PR TITLE
(feat): Added System logs to DB and frontend and error handling

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -22,7 +22,7 @@ from lib.user import User
 from lib.db import DB
 from lib.secure_variable import SecureVariable
 
-from api.object_specifications import UserSetting
+from api.object_specifications import UserSetting, SystemLogDelete
 
 app = FastAPI()
 
@@ -254,6 +254,38 @@ async def get_cluster_changelog(
         return Response(status_code=204)  # No-Content
 
     return CustomORJSONResponse({'success': True, 'data': data})
+
+@app.get('/v1/system-logs')
+async def get_system_logs(
+    # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
+    user: User = Depends(authenticate) # pylint: disable=unused-argument
+    ):
+
+    data = DB().fetch_all(
+        'SELECT id, title, message, level, created_at FROM system_logs ORDER BY created_at DESC',
+        []
+    )
+    if data is None or data == []:
+        return Response(status_code=204)
+    return CustomORJSONResponse({'success': True, 'data': data})
+
+@app.put('/v1/system-log')
+async def update_system_log(
+    log: SystemLogDelete,
+    # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
+    user: User = Depends(authenticate), # pylint: disable=unused-argument
+    ):
+
+    if log.action != 'delete':
+        raise HTTPException(status_code=422, detail=f"Unsupported action: {log.action}")
+
+    query = 'DELETE FROM system_logs WHERE id = %s RETURNING id'
+    deleted = DB().fetch_one(query, params=[log.log_id])
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail='System log entry not found')
+
+    return Response(status_code=202)
 
 
 if GlobalConfig().config.get('activate_scenario_runner', False):

--- a/api/main.py
+++ b/api/main.py
@@ -262,7 +262,7 @@ async def get_system_logs(
     ):
 
     data = DB().fetch_all(
-        'SELECT id, title, message, level, created_at FROM system_logs ORDER BY created_at DESC',
+        'SELECT id, title, message, level, created_at FROM system_logs ORDER BY created_at DESC LIMIT 20',
         []
     )
     if data is None or data == []:

--- a/api/object_specifications.py
+++ b/api/object_specifications.py
@@ -29,6 +29,14 @@ class WatchlistChange(BaseModel):
 
     model_config = ConfigDict(extra='forbid')
 
+### System Logs
+
+class SystemLogDelete(BaseModel):
+    log_id: int
+    action: Literal['delete']
+
+    model_config = ConfigDict(extra='forbid')
+
 ### Software Add
 
 class Software(BaseModel):

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -283,6 +283,9 @@ CREATE TABLE system_logs (
     updated_at timestamp with time zone
 );
 
+CREATE INDEX system_logs_created_at_idx
+    ON system_logs (created_at DESC, id DESC);
+
 CREATE TRIGGER system_logs_moddatetime
     BEFORE UPDATE ON system_logs
     FOR EACH ROW

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -112,7 +112,9 @@ VALUES (
                 "/v2/hog/add",
                 "/v2/hog/top_processes",
                 "/v2/hog/details",
-                "/v1/run/{run_id}"
+                "/v1/run/{run_id}",
+                "/v1/system-logs",
+                "/v1/system-log"
             ]
         },
         "data": {
@@ -271,6 +273,20 @@ CREATE TRIGGER jobs_moddatetime
 INSERT INTO "jobs"("type","state","name","email","url","branch","filename","usage_scenario_variables","category_ids","machine_id","message","user_id","created_at","updated_at")
 	VALUES
 	(E'run',E'FINISHED',E'This is a demo job - Please delete when you run in cluster mode',NULL,E'demo-url',E'demo-branch',E'demo-filename',E'{}',NULL,1,NULL,1,E'2025-10-03 07:57:29.829712+00',NULL);
+
+CREATE TABLE system_logs (
+    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    title text NOT NULL,
+    message text NOT NULL,
+    level text NOT NULL DEFAULT 'error',
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone
+);
+
+CREATE TRIGGER system_logs_moddatetime
+    BEFORE UPDATE ON system_logs
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime (updated_at);
 
 CREATE TABLE runs (
     id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,

--- a/frontend/cluster-status.html
+++ b/frontend/cluster-status.html
@@ -73,6 +73,15 @@
 
         <h3>Jobs queue</h3>
         <table id="jobs-table" class="ui celled striped table"></table>
+
+        <div id="system-logs-section">
+            <h3>System Logs</h3>
+            <table id="system-logs-table" class="ui celled striped table"></table>
+        </div>
+        <div id="system-logs-no-access" class="ui info message" style="display: none;">
+            <i class="info circle icon"></i>
+            System logs are not available for your account. Admin rights are required to view this section.
+        </div>
     </div>
     <div class="ui overlay large modal" id="machine-configuration">
         <div class="header">Details</div>

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -322,7 +322,7 @@ const refreshView = async (repo, branch, workflow_id, chart_instance) => {
         document.querySelector('#message-no-data').style.display = 'none';
 
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) {
+        if (err instanceof APIHTTPError && err.status === 204) {
             document.querySelectorAll('.container-no-data').forEach(el => el.style.display = 'none')
             document.querySelector('#message-no-data').style.display = '';
             return

--- a/frontend/js/cluster-changelog.js
+++ b/frontend/js/cluster-changelog.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
         try {
             cluster_changelog = await makeAPICall('/v1/cluster/changelog')
         } catch (err) {
-            if (err instanceof APIEmptyResponse204) { // empty data is an OK response
+            if (err instanceof APIHTTPError && err.status === 204) { // empty data is an OK response
                 return
             } else {
                 showNotification('Could not get cluster changelog data from API', err);

--- a/frontend/js/cluster-status-history.js
+++ b/frontend/js/cluster-status-history.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
         try {
             cluster_status_data = await makeAPICall('/v1/cluster/status/history')
         } catch (err) {
-            if (err instanceof APIEmptyResponse204) { // empty data is an OK response
+            if (err instanceof APIHTTPError && err.status === 204) { // empty data is an OK response
                 return
             } else {
                 showNotification('Could not get cluster status history data from API', err);

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -1,4 +1,17 @@
 
+async function deleteSystemLog(e){
+    e.preventDefault()
+    const log_id = this.getAttribute('data-log-id');
+    try {
+        await makeAPICall('/v1/system-log', {log_id: parseInt(log_id), action: 'delete'}, null, true)
+        this.closest('tr').remove();
+        showNotification('Log deleted', 'System log entry deleted successfully', 'success');
+    } catch (err) {
+        showNotification('Could not delete log', err);
+    }
+    return false;
+};
+
 async function cancelJob(e){
     e.preventDefault()
     const job_id = this.getAttribute('data-job-id');
@@ -32,6 +45,16 @@ $(document).ready(function () {
             jobs_data = await makeAPICall('/v2/jobs')
         } catch (err) {
             showNotification('Could not get jobs data from API', err); // we do not return here, as empty data is an OK response
+        }
+
+        let system_logs_data = null;
+        try {
+            system_logs_data = await makeAPICall('/v1/system-logs')
+        } catch (err) {
+            if (!(err instanceof APIEmptyResponse204)) {
+                document.getElementById('system-logs-section').style.display = 'none';
+                document.getElementById('system-logs-no-access').style.display = '';
+            }
         }
 
         $('#machines-table').DataTable({
@@ -138,6 +161,28 @@ $(document).ready(function () {
                 document.querySelectorAll('.cancel-job').forEach(el => {
                     el.removeEventListener('click', cancelJob)
                     el.addEventListener('click', cancelJob)
+                })
+            },
+        });
+
+        $('#system-logs-table').DataTable({
+            data: system_logs_data?.data,
+            columns: [
+                { data: 0, title: 'ID'},
+                { data: 1, title: 'Title', render: (el) => escapeString(el)},
+                { data: 2, title: 'Message', render: (el) => `<pre style="white-space:pre-wrap;max-height:150px;overflow:auto;margin:0">${escapeString(el)}</pre>`},
+                { data: 3, title: 'Level', render: (el) => escapeString(el)},
+                { data: 4, title: 'Created at', render: (el) => el == null ? '-' : dateToYMD(new Date(el))},
+                { data: 0, title: '-', class: 'log-action', render: (el) =>
+                    `<a class="delete-log" data-log-id="${el}"><i class="ui large icon red times circle"></i></a>`
+                },
+            ],
+            deferRender: true,
+            order: [[4, 'desc']],
+            drawCallback: function() {
+                document.querySelectorAll('.delete-log').forEach(el => {
+                    el.removeEventListener('click', deleteSystemLog)
+                    el.addEventListener('click', deleteSystemLog)
                 })
             },
         });

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -4,7 +4,7 @@ async function deleteSystemLog(e){
     const log_id = this.getAttribute('data-log-id');
     try {
         await makeAPICall('/v1/system-log', {log_id: parseInt(log_id), action: 'delete'}, null, true)
-        this.closest('tr').remove();
+        $('#system-logs-table').DataTable().row(this.closest('tr')).remove().draw();
         showNotification('Log deleted', 'System log entry deleted successfully', 'success');
     } catch (err) {
         showNotification('Could not delete log', err);

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -51,9 +51,11 @@ $(document).ready(function () {
         try {
             system_logs_data = await makeAPICall('/v1/system-logs')
         } catch (err) {
-            if (!(err instanceof APIEmptyResponse204)) {
+            if (err instanceof APIHTTPError && err.status === 401) {
                 document.getElementById('system-logs-section').style.display = 'none';
                 document.getElementById('system-logs-no-access').style.display = '';
+            } else if (!(err instanceof APIHTTPError && err.status === 204)) {
+                showNotification('Could not get system logs from API', err);
             }
         }
 

--- a/frontend/js/compare-simple.js
+++ b/frontend/js/compare-simple.js
@@ -52,7 +52,7 @@ const fetchSinglePhaseStats = async (run_id) => {
         const response = await makeAPICall(`/v1/phase_stats/single/${encodeURIComponent(run_id)}`);
         return response?.data || null;
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) return null;
+        if (err instanceof APIHTTPError && err.status === 204) return null;
         showNotification(`Could not load phase stats for run ${run_id}`, err);
         return null;
     }

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -62,7 +62,7 @@ const fetchWarningsForRuns = async (run_ids) => {
             const data = await makeAPICall('/v1/warnings/' + run_id);
             if (data?.data) warnings.push(...data.data);
         } catch (err) {
-            if (err instanceof APIEmptyResponse204) {
+            if (err instanceof APIHTTPError && err.status === 204) {
                 console.log('No warnings where present in API response. Skipping error as this is allowed case.')
             } else {
                 showNotification('Could not get warnings data from API', err);

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -23,7 +23,12 @@ const toHttpsUri = (uri) => {
     return uri;
 };
 
-class APIEmptyResponse204 extends Error {}
+class APIHTTPError extends Error {
+    constructor(status, message) {
+        super(message);
+        this.status = status;
+    }
+}
 
 const date_options = {
   year: 'numeric',
@@ -163,7 +168,7 @@ const getClusterStatus = async (status_ok_selector, status_warning_selector) => 
         document.querySelector('.cluster-health-message.yellow').style.display = 'flex'; // show
 
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) {
+        if (err instanceof APIHTTPError && err.status === 204) {
             document.querySelector('.cluster-health-message.success').style.display = 'flex'; // show
         } else {
             showNotification('Could not get cluster health status data from API', err); // no return as we want other calls to happen
@@ -279,7 +284,7 @@ const createExternalIconLink = (url) => {
 const showNotification = (message_title, message_text, type='error') => {
     if (typeof message_text === 'object') console.log(message_text); // this is most likey an error. We need it in the console
 
-    const message = (typeof message_text === 'string' || typeof message_text === 'object') ? message_text : JSON.stringify(message_text);
+    const message = typeof message_text === 'string' ? message_text : (message_text instanceof Error ? message_text.message : JSON.stringify(message_text));
     $('body')
       .toast({
         class: type,
@@ -349,13 +354,15 @@ async function makeAPICall(path, values=null, force_authentication_token=null, f
     }
 
     let json_response = null;
+    let _http_status = null;
     if(localStorage.getItem('remove_idle') === 'true') path += (path.includes('?') ? '&' : '?') + 'remove_idle=true'
 
     await fetch(API_URL + path, options)
     .then(response => {
+        _http_status = response.status;
         if (response.status == 204) {
             // 204 responses use no body, so json() call would fail
-            throw new APIEmptyResponse204('No data to display. API returned empty response (HTTP 204)')
+            throw new APIHTTPError(204, 'No data to display. API returned empty response (HTTP 204)')
         }
         if (response.status == 202) {
             return
@@ -366,9 +373,9 @@ async function makeAPICall(path, values=null, force_authentication_token=null, f
     .then(my_json => {
         if (my_json != null && my_json.success != true) {
             if (Array.isArray(my_json.err) && my_json.err.length !== 0)
-                throw my_json.err[0]?.msg
+                throw new APIHTTPError(_http_status, my_json.err[0]?.msg)
             else
-                throw my_json.err
+                throw new APIHTTPError(_http_status, my_json.err)
         }
         json_response = my_json
     })

--- a/frontend/js/simulation-yearly.js
+++ b/frontend/js/simulation-yearly.js
@@ -57,7 +57,7 @@ const fetchMeasurements = async (runId) => {
         const measurements = await makeAPICall(`/v1/measurements/single/${safeRunId}`);
         return measurements?.data || [];
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) return [];
+        if (err instanceof APIHTTPError && err.status === 204) return [];
         throw err;
     }
 };
@@ -68,7 +68,7 @@ const fetchPhaseStats = async (runId) => {
         const response = await makeAPICall(`/v1/phase_stats/single/${safeRunId}`);
         return response?.data || null;
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) return null;
+        if (err instanceof APIHTTPError && err.status === 204) return null;
         throw err;
     }
 };

--- a/frontend/js/simulation.js
+++ b/frontend/js/simulation.js
@@ -542,7 +542,7 @@ const fetchMeasurements = async (runId) => {
         const measurements = await makeAPICall(`/v1/measurements/single/${safeRunId}`);
         return measurements?.data || [];
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) {
+        if (err instanceof APIHTTPError && err.status === 204) {
             return [];
         }
         throw err;

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -843,7 +843,7 @@ const fetchAndFillNetworkIntercepts = async (run_id) => {
     try {
         network = await makeAPICall('/v1/network/' + run_id)
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) {
+        if (err instanceof APIHTTPError && err.status === 204) {
             console.log('No network intercepts present in API response. Skipping error as this is allowed case.')
         } else {
             showNotification('Could not get network intercepts data from API', err);
@@ -1048,7 +1048,7 @@ const fetchAndFillWarnings = async (run_id) => {
     try {
         warnings = await makeAPICall('/v1/warnings/' + run_id)
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) {
+        if (err instanceof APIHTTPError && err.status === 204) {
             console.log('No warnings where present in API response. Skipping error as this is allowed case.')
         } else {
             showNotification('Could not get warnings data from API', err);

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -399,7 +399,7 @@ const loadCharts = async () => {
         document.querySelector('#message-no-data').style.display = 'none';
 
     } catch (err) {
-        if (err instanceof APIEmptyResponse204) {
+        if (err instanceof APIHTTPError && err.status === 204) {
             document.querySelectorAll('.container-no-data').forEach(el => el.style.display = 'none')
             document.querySelector('#message-no-data').style.display = '';
             document.querySelector('a.item[data-tab=two]').click()
@@ -463,7 +463,7 @@ const loadCharts = async () => {
             cluster_changelog_data = (await makeAPICall(`/v1/cluster/changelog?${changelogParams.toString()}`)).data ?? [];
         }
     } catch (err) {
-        if (!(err instanceof APIEmptyResponse204)) {
+        if (!(err instanceof APIHTTPError && err.status === 204)) {
             showNotification('Could not get cluster changelog data from API', err);
         }
     }

--- a/lib/error_helpers.py
+++ b/lib/error_helpers.py
@@ -56,6 +56,8 @@ def log_error(*messages, **kwargs):
     timestamp = datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S %Z%z')
     final_message += f"\n\nOriginal date and time: {timestamp}"
 
+    # No need to catch exception here as the original exception was written to stderr in line 53
+    # and if DB insert fails it will also be logged to stderr
     DB().query(
         "INSERT INTO system_logs (title, message, level) VALUES (%s, %s, 'error')",
         params=('Green Metrics Tool Error', final_message)

--- a/lib/error_helpers.py
+++ b/lib/error_helpers.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from lib.terminal_colors import TerminalColors
 from lib.global_config import GlobalConfig
-from lib.job.base import Job
+from lib.db import DB
 
 def end_error(*messages, **kwargs):
     log_error(*messages, **kwargs)
@@ -52,11 +52,11 @@ def log_error(*messages, **kwargs):
 
     print(TerminalColors.FAIL, err, TerminalColors.ENDC, file=sys.stderr)
 
-    if error_email := GlobalConfig().config['admin']['error_email']:
-        final_message = format_error(*messages, **kwargs, traceback_first=False)
+    final_message = format_error(*messages, **kwargs, traceback_first=False)
+    timestamp = datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S %Z%z')
+    final_message += f"\n\nOriginal date and time: {timestamp}"
 
-        timestamp = datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S %Z%z')
-        final_message += f"\n\nOriginal date and time: {timestamp}"
-
-        # User 0 is the [GMT-SYSTEM] user
-        Job.insert('email-simple', user_id=0, email=error_email, name='Green Metrics Tool Error', message=final_message)
+    DB().query(
+        "INSERT INTO system_logs (title, message, level) VALUES (%s, %s, 'error')",
+        params=('Green Metrics Tool Error', final_message)
+    )

--- a/migrations/2026_06_25_system_logs.sql
+++ b/migrations/2026_06_25_system_logs.sql
@@ -12,6 +12,9 @@ CREATE TRIGGER system_logs_moddatetime
     FOR EACH ROW
     EXECUTE PROCEDURE moddatetime (updated_at);
 
+CREATE INDEX system_logs_created_at_idx
+    ON system_logs (created_at DESC, id DESC);
+
 UPDATE users
 SET capabilities = jsonb_set(
     capabilities,

--- a/migrations/2026_06_25_system_logs.sql
+++ b/migrations/2026_06_25_system_logs.sql
@@ -1,0 +1,22 @@
+CREATE TABLE system_logs (
+    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    title text NOT NULL,
+    message text NOT NULL,
+    level text NOT NULL DEFAULT 'error',
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone
+);
+
+CREATE TRIGGER system_logs_moddatetime
+    BEFORE UPDATE ON system_logs
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime (updated_at);
+
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{api,routes}',
+    (capabilities->'api'->'routes') || '"/v1/system-logs"'::jsonb || '"/v1/system-log"'::jsonb
+)
+WHERE id = 1
+    AND NOT (capabilities->'api'->'routes' ? '/v1/system-logs');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added system logs support across the stack.

- Introduced a new `system_logs` table (with `updated_at` trigger) and updated the seeded `users` capabilities/routes and the corresponding migration to grant access to:
  - `GET /v1/system-logs`
  - `PUT /v1/system-log`
- Backend:
  - Added authenticated `GET /v1/system-logs` to list the most recent logs (ordered by `created_at` desc, limited to 20) and return `204` when empty.
  - Added authenticated `PUT /v1/system-log` to delete a log (`SystemLogDelete` model; only supports `action: "delete"`), with clear status handling (`422` unsupported action, `404` if not found, `202` on success).
- Error handling:
  - Updated `log_error` to persist errors into `system_logs` (removing the previous job/email flow).
  - Refactored frontend “no content” (`204`) handling to consistently treat `APIHTTPError` with `status === 204` as the empty/non-fatal case.
- Frontend:
  - Added a “System Logs” section with an admin/no-access UI state.
  - Wired the page to fetch and display logs in a DataTable and support deleting individual log rows via the new delete endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->