### PR TITLE
(feat): ErrorLog and Email Stream filter to redact HTTP-AUTH and PRivate Keys

### DIFF
--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -23,7 +23,8 @@ from api.api_helpers import (CustomORJSONResponse, ORJSONResponseObjKeep, add_ph
 from lib.global_config import GlobalConfig
 from lib.db import DB
 from lib.diff import get_diffable_rows, diff_rows
-from lib.job.base import Job
+from lib.job.run import RunJob
+from lib.job.email_simple import EmailSimpleJob
 from lib.user import User
 from lib.watchlist import Watchlist
 from lib import utils
@@ -978,11 +979,11 @@ async def runs_add(software: Software, no_url_check: bool = False, user: User = 
         amount = 1
 
     for _ in range(0,amount):
-        job_ids_inserted.append(Job.insert('run', user_id=user._id, name=software.name, url=software.repo_url, email=software.email, branch=software.branch, commit_hash=software.commit_hash, filename=software.filename, machine_id=software.machine_id, usage_scenario_variables=software.usage_scenario_variables, category_ids=unique_category_ids, carbon_simulation=carbon_simulation))
+        job_ids_inserted.append(RunJob.insert(user_id=user._id, name=software.name, url=software.repo_url, email=software.email, branch=software.branch, commit_hash=software.commit_hash, filename=software.filename, machine_id=software.machine_id, usage_scenario_variables=software.usage_scenario_variables, category_ids=unique_category_ids, carbon_simulation=carbon_simulation))
 
     # notify admin of new add
     if notification_email := GlobalConfig().config['admin']['notification_email']:
-        Job.insert('email-simple', user_id=user._id, name='New run added from Web Interface', message=pprint.pformat(software.model_dump(), width=60, indent=2), email=notification_email)
+        EmailSimpleJob.insert(user_id=user._id, name='New run added from Web Interface', message=pprint.pformat(software.model_dump(), width=60, indent=2), email=notification_email)
 
     return CustomORJSONResponse({'success': True, 'data': job_ids_inserted}, status_code=202)
 

--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -153,6 +153,10 @@ async def get_jobs(
     if data is None or data == []:
         return Response(status_code=204) # No-Content
 
+    # jobs.url is kept unredacted in the DB as the cluster worker needs the real
+    # credentials to clone the repo. Redact it here as it is never needed by the client.
+    data = [(*row[:3], utils.filter_sensitive_data(row[3]), *row[4:]) for row in data]
+
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @router.put('/v1/job')

--- a/cron/client.py
+++ b/cron/client.py
@@ -11,7 +11,8 @@ import json
 import argparse
 from pathlib import Path
 
-from lib.job.base import Job
+from lib.job.run import RunJob
+from lib.job.email_simple import EmailSimpleJob
 from lib.global_config import GlobalConfig
 from lib.db import DB
 from lib.repo_info import get_repo_info
@@ -201,8 +202,7 @@ def do_measurement_control():
     try:
         message = validate.validate_workload_stddev(stddev_data, cwl['metrics'])
         if config['cluster']['client']['send_control_workload_status_mail'] and config['admin']['notification_email']:
-            Job.insert(
-                'email-simple',
+            EmailSimpleJob.insert(
                 user_id=0, # User 0 is the [GMT-SYSTEM] user
                 email=config['admin']['notification_email'],
                 name=f"{config['machine']['description']} is operating normally. All STDDEV fine.",
@@ -263,7 +263,7 @@ if __name__ == '__main__':
                     reboot()
                 last_24h_maintenance = time.time()
 
-            job = Job.get_job('run')
+            job = RunJob.get_job()
             if job and job.check_job_running():
                 error_helpers.log_error('Job is still running. This is usually an error case! Continuing for now ...', machine=config['machine']['description'])
                 if not args.testing:
@@ -345,8 +345,7 @@ if __name__ == '__main__':
 
                     # reduced error message to client, but only if no ConfigurationCheckError
                     if job._email:
-                        Job.insert(
-                            'email-simple',
+                        EmailSimpleJob.insert(
                             user_id=job._user_id,
                             email=job._email,
                             name='Measurement Job on Green Metrics Tool Cluster failed',

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -12,7 +12,9 @@ import argparse
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib import error_helpers
-from lib.job.base import Job
+from lib.job.run import RunJob
+from lib.job.email import EmailJob
+from lib.job.email_simple import EmailSimpleJob
 from lib.global_config import GlobalConfig
 from lib.terminal_colors import TerminalColors
 from lib.system_checks import ConfigurationCheckError
@@ -25,6 +27,11 @@ from lib.db import DB
 
     After 14 days all FAILED and NOTIFIED jobs will be deleted.
 """
+
+JOB_TYPE_CLASSES = {
+    'run': RunJob,
+    'email': EmailJob, # abstract family covering email-simple, email-report, ...
+}
 
 
 if __name__ == '__main__':
@@ -49,7 +56,7 @@ if __name__ == '__main__':
                 sys.exit(1)
             GlobalConfig(config_location=args.config_override)
 
-        job_main = Job.get_job(args.type)
+        job_main = JOB_TYPE_CLASSES[args.type].get_job()
         if not job_main:
             print(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), 'No job to process. Exiting')
             sys.exit(0)
@@ -65,8 +72,7 @@ if __name__ == '__main__':
 
             # reduced error message to client, but only if no ConfigurationCheckError
             if job_main._email and not isinstance(exc, ConfigurationCheckError):
-                Job.insert(
-                    'email-simple',
+                EmailSimpleJob.insert(
                     user_id=job_main._user_id,
                     email=job_main._email,
                     name='Measurement Job on Green Metrics Tool Cluster failed',

--- a/cron/watchlist.py
+++ b/cron/watchlist.py
@@ -31,7 +31,7 @@ def schedule_watchlist_item():
     data = DB().fetch_all(query)
 
     for [item_id, name, repo_url, branch, filename, usage_scenario_variables, category_ids, carbon_simulation, machine_id, user_id, schedule_mode, last_marker, scheduled_today, scheduled_last_week] in data:
-        print(f"Watchlist item is on {schedule_mode} schedule", repo_url, branch, filename, machine_id)
+        print(f"Watchlist item is on {schedule_mode} schedule", utils.filter_sensitive_data(repo_url), branch, filename, machine_id)
 
         if schedule_mode == 'one-off':
             raise ValueError('Watchlist item with "one-off" schedule mode should never be in table!')
@@ -90,6 +90,8 @@ if __name__ == '__main__':
                 ORDER BY w.repo_url ASC
             """
             show_data = DB().fetch_all(show_query, fetch_mode='dict')
+            for row in show_data:
+                row['repo_url'] = utils.filter_sensitive_data(row['repo_url'])
             pp = pprint.PrettyPrinter(indent=4)
             pp.pprint(show_data)
 

--- a/cron/watchlist.py
+++ b/cron/watchlist.py
@@ -12,7 +12,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.global_config import GlobalConfig
 from lib.db import DB
-from lib.job.base import Job
+from lib.job.run import RunJob
 from lib import utils
 from lib import error_helpers
 
@@ -40,13 +40,13 @@ def schedule_watchlist_item():
             if not scheduled_today:
                 print('\nWatchlist item was not scheduled today', scheduled_today)
                 DB().query('UPDATE watchlist SET last_scheduled = NOW() WHERE id = %s', params=(item_id,))
-                Job.insert('run', user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
+                RunJob.insert(user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
                 print('\tInserted')
         elif schedule_mode == 'weekly':
             if not scheduled_last_week:
                 print('\tWatchlist item was not scheduled in last 7 days', scheduled_last_week)
                 DB().query('UPDATE watchlist SET last_scheduled = NOW() WHERE id = %s', params=(item_id,))
-                Job.insert('run', user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
+                RunJob.insert(user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
                 print('\tInserted')
         elif schedule_mode in ['tag', 'tag-variance']:
             last_marker_new = utils.get_repo_last_marker(repo_url, 'tags')
@@ -55,7 +55,7 @@ def schedule_watchlist_item():
                 continue
             amount = 3 if 'variance' in schedule_mode else 1
             for _ in range(0,amount):
-                Job.insert('run', user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
+                RunJob.insert(user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
                 print('Updating Hash', last_marker_new)
                 DB().query('UPDATE watchlist SET last_marker = %s WHERE id = %s', params=(last_marker_new, item_id, ))
 
@@ -67,7 +67,7 @@ def schedule_watchlist_item():
             amount = 3 if 'variance' in schedule_mode else 1
             for _ in range(0,amount):
                 print('Updating Hash', last_marker_new)
-                Job.insert('run', user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
+                RunJob.insert(user_id=user_id, name=name, url=repo_url, branch=branch, filename=filename, usage_scenario_variables=usage_scenario_variables, category_ids=category_ids, carbon_simulation=carbon_simulation, machine_id=machine_id)
                 DB().query('UPDATE watchlist SET last_marker = %s WHERE id = %s', params=(last_marker_new, item_id, ))
 
 if __name__ == '__main__':

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,6 +9,7 @@ PyYAML==6.0.3
 anybadge==1.16.0
 orjson==3.11.9
 scipy==1.16.3
+psutil==7.2.2
 schema==0.7.8
 deepdiff==9.1.0
 redis==8.0.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -18,5 +18,6 @@ requests==2.34.2
 uvicorn-worker==0.4.0
 cachetools==7.1.4
 cryptography==49.0.0
+energy-dependency-inspector==0.5.1
 
 pytest==9.1.1 # needed because we need to exit in db.py if tests run with wrong config

--- a/lib/error_helpers.py
+++ b/lib/error_helpers.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from lib.terminal_colors import TerminalColors
 from lib.global_config import GlobalConfig
 from lib.db import DB
+from lib.utils import filter_sensitive_data
+
 
 def end_error(*messages, **kwargs):
     log_error(*messages, **kwargs)
@@ -37,6 +39,7 @@ Error: {err}
     """
 
     error_string = error_string.replace('\x00', '0x00') # If we store to DB: Postgres cannot handle null bytes (\x00) in text fields or \u0000 in JSONB columns
+    error_string = filter_sensitive_data(error_string)
     return error_string
 
 

--- a/lib/job/base.py
+++ b/lib/job/base.py
@@ -25,6 +25,11 @@ from lib.configuration_check_error import ConfigurationCheckError
 """
 
 class Job(ABC):
+    # Concrete subclasses must set this to the exact value stored in jobs.type (e.g. 'run', 'email-simple'),
+    # or to a SQL LIKE pattern ending in '%' to match a family of types (e.g. 'email-%').
+    # get_job() and insert() rely on it to know which rows they are responsible for.
+    JOB_TYPE = None
+
     def __init__(self, *, job_id, run_id, state, name, email, url,  branch, commit_hash, filename, usage_scenario_variables, category_ids, carbon_simulation, machine_id, user_id, machine_description, message, created_at):
         self._id = job_id
         self._state = state
@@ -78,12 +83,15 @@ class Job(ABC):
     def _process(self, **kwargs):
         pass
 
+    # Concrete subclasses must implement this with whatever explicit, type-specific
+    # parameters they need and delegate to _insert_row() with their own JOB_TYPE.
     @classmethod
-    def insert(cls, job_type, *, user_id, run_id=None, name=None, url=None, email=None, branch=None, commit_hash=None, filename=None, machine_id=None, usage_scenario_variables=None, category_ids=None, carbon_simulation=None, message=None):
+    @abstractmethod
+    def insert(cls, **kwargs):
+        pass
 
-        if job_type == 'run' and (not branch or not url or not filename or not machine_id):
-            raise RuntimeError('For adding runs branch, url, filename and machine_id must be set')
-
+    @classmethod
+    def _insert_row(cls, *, run_id=None, name=None, url=None, email=None, branch=None, commit_hash=None, filename=None, machine_id=None, usage_scenario_variables=None, category_ids=None, carbon_simulation=None, message=None, user_id):
         if usage_scenario_variables is None:
             usage_scenario_variables = {}
 
@@ -93,13 +101,17 @@ class Job(ABC):
                 VALUES
                     (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'WAITING', NOW()) RETURNING id;
                 """
-        params = (run_id, job_type, name, url, email, branch, commit_hash, filename, json.dumps(usage_scenario_variables), category_ids, json.dumps(carbon_simulation), machine_id, user_id, message)
+        params = (run_id, cls.JOB_TYPE, name, url, email, branch, commit_hash, filename, json.dumps(usage_scenario_variables), category_ids, json.dumps(carbon_simulation), machine_id, user_id, message)
 
         return DB().fetch_one(query, params=params)[0]
 
-    # A static method to get a job object
+    # Fetches the next WAITING job for the type (or type family) the calling class is responsible for.
+    # e.g. RunJob.get_job() only ever returns 'run' jobs, EmailJob.get_job() any 'email-*' job.
     @classmethod
-    def get_job(cls, job_type):
+    def get_job(cls):
+        if not cls.JOB_TYPE:
+            raise NotImplementedError(f"{cls.__name__} must define JOB_TYPE to be used with get_job()")
+
         cls.clear_old_jobs()
 
         query = '''
@@ -114,15 +126,15 @@ class Job(ABC):
         params = []
         config = GlobalConfig().config
 
-        if job_type == 'run':
-            query = f"{query} j.type = 'run' AND j.state = 'WAITING' AND j.machine_id = %s "
-            params.append(config['machine']['id'])
-        elif job_type == 'email':
+        if cls.JOB_TYPE.endswith('%'):
             query = f"{query} j.type LIKE %s AND j.state = 'WAITING'"
-            params.append(f"{job_type}-%")
         else:
             query = f"{query} j.type = %s AND j.state = 'WAITING'"
-            params.append(job_type)
+        params.append(cls.JOB_TYPE)
+
+        if cls.JOB_TYPE == 'run':
+            query = f"{query} AND j.machine_id = %s"
+            params.append(config['machine']['id'])
 
         if config['cluster']['client']['jobs_processing'] == 'random':
             query = f"{query} ORDER BY RANDOM()"

--- a/lib/job/base.py
+++ b/lib/job/base.py
@@ -51,7 +51,7 @@ class Job(ABC):
 
     @abstractmethod
     def check_job_running(self):
-        pass
+        raise NotImplementedError
 
     def update_state(self, state):
         query_update = "UPDATE jobs SET state = %s WHERE id=%s"
@@ -81,14 +81,14 @@ class Job(ABC):
 
     @abstractmethod
     def _process(self, **kwargs):
-        pass
+        raise NotImplementedError
 
     # Concrete subclasses must implement this with whatever explicit, type-specific
     # parameters they need and delegate to _insert_row() with their own JOB_TYPE.
     @classmethod
     @abstractmethod
     def insert(cls, **kwargs):
-        pass
+        raise NotImplementedError
 
     @classmethod
     def _insert_row(cls, *, run_id=None, name=None, url=None, email=None, branch=None, commit_hash=None, filename=None, machine_id=None, usage_scenario_variables=None, category_ids=None, carbon_simulation=None, message=None, user_id):

--- a/lib/job/email.py
+++ b/lib/job/email.py
@@ -7,9 +7,12 @@ faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to st
 
 from lib.db import DB
 from lib.job.base import Job
+from lib.utils import filter_sensitive_data
 
 
 class EmailJob(Job):
+    # Matches any of the concrete 'email-*' types (email-simple, email-report, ...)
+    JOB_TYPE = 'email-%'
 
     def check_job_running(self):
         query = "SELECT id FROM jobs WHERE type LIKE 'email-%' AND state = 'RUNNING'"
@@ -18,3 +21,21 @@ class EmailJob(Job):
     #pylint: disable=arguments-differ
     def _process(self):
         raise NotImplementedError('EmailJob cannot be used directly. Please use child class')
+
+    # Emails are persisted to the DB as the 'message' column of a job before being sent out.
+    # Filter here so no credentials or private keys ever reach storage or an outgoing email.
+    # Concrete subclasses (EmailSimpleJob, EmailReportJob, ...) set their own JOB_TYPE and
+    # inherit this implementation as-is.
+    #pylint: disable=arguments-differ
+    @classmethod
+    def insert(cls, *, user_id, email, name, message=None, run_id=None):
+        if cls is EmailJob:
+            raise NotImplementedError('EmailJob cannot be used directly. Please use child class')
+
+        return cls._insert_row(
+            user_id=user_id,
+            email=email,
+            name=name,
+            run_id=run_id,
+            message=filter_sensitive_data(message),
+        )

--- a/lib/job/email_report.py
+++ b/lib/job/email_report.py
@@ -17,6 +17,7 @@ from lib.job.email import EmailJob
 
 
 class EmailReportJob(EmailJob):
+    JOB_TYPE = 'email-report'
 
     #pylint: disable=arguments-differ
     def _process(self):

--- a/lib/job/email_simple.py
+++ b/lib/job/email_simple.py
@@ -10,6 +10,7 @@ from lib import email_helpers
 from lib.job.email import EmailJob
 
 class EmailSimpleJob(EmailJob):
+    JOB_TYPE = 'email-simple'
 
     #pylint: disable=arguments-differ
     def _process(self):

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -17,7 +17,6 @@ from lib.db import DB
 from lib.user import User
 from lib.terminal_colors import TerminalColors
 from lib.scenario_runner import ScenarioRunner
-import optimization_providers.base
 
 
 class RunJob(Job):
@@ -98,7 +97,9 @@ class RunJob(Job):
             # Start main code. Only URL is allowed for cron jobs
             self._run_id = runner.run()
 
-            # We need to import this here as we need the correct config file
+            # We need to import this here as we need the correct config file, and to avoid a circular
+            # import (optimization_providers.base imports api.scenario_runner, which imports RunJob)
+            import optimization_providers.base #pylint: disable=import-outside-toplevel
             print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
             optimization_providers.base.import_reporters()
             print(TerminalColors.HEADER, '\nRunning optimization reporters ...', TerminalColors.ENDC)

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -23,8 +23,8 @@ class RunJob(Job):
     JOB_TYPE = 'run'
 
     def check_job_running(self):
-        query = "SELECT id FROM jobs WHERE type = 'run' AND state = 'RUNNING' AND machine_id = %s"
-        return DB().fetch_one(query, params=(self._machine_id, ))
+        query = "SELECT id FROM jobs WHERE type = %s AND state = 'RUNNING' AND machine_id = %s"
+        return DB().fetch_one(query, params=(self.JOB_TYPE, self._machine_id, ))
 
     #pylint: disable=arguments-differ
     @classmethod

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -18,7 +18,6 @@ from lib.user import User
 from lib.terminal_colors import TerminalColors
 from lib.scenario_runner import ScenarioRunner
 
-
 class RunJob(Job):
     JOB_TYPE = 'run'
 

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -12,6 +12,7 @@ import os
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.job.base import Job
+from lib.job.email_report import EmailReportJob
 from lib.db import DB
 from lib.user import User
 from lib.terminal_colors import TerminalColors
@@ -20,10 +21,31 @@ import optimization_providers.base
 
 
 class RunJob(Job):
+    JOB_TYPE = 'run'
 
     def check_job_running(self):
         query = "SELECT id FROM jobs WHERE type = 'run' AND state = 'RUNNING' AND machine_id = %s"
         return DB().fetch_one(query, params=(self._machine_id, ))
+
+    #pylint: disable=arguments-differ
+    @classmethod
+    def insert(cls, *, user_id, name, url, branch, filename, machine_id, email=None, commit_hash=None, usage_scenario_variables=None, category_ids=None, carbon_simulation=None):
+        if not branch or not url or not filename or not machine_id:
+            raise RuntimeError('For adding runs branch, url, filename and machine_id must be set')
+
+        return cls._insert_row(
+            user_id=user_id,
+            name=name,
+            url=url,
+            email=email,
+            commit_hash=commit_hash,
+            branch=branch,
+            filename=filename,
+            machine_id=machine_id,
+            usage_scenario_variables=usage_scenario_variables,
+            category_ids=category_ids,
+            carbon_simulation=carbon_simulation,
+        )
 
     #pylint: disable=arguments-differ
     def _process(self, docker_prune=False, full_docker_prune=False):
@@ -84,8 +106,7 @@ class RunJob(Job):
 
 
             if self._email:
-                Job.insert(
-                    'email-report',
+                EmailReportJob.insert(
                     user_id=self._user_id,
                     email=self._email,
                     name=f"Measurement Job '{self._name}' successfully processed on Green Metrics Tool Cluster",

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -400,7 +400,7 @@ class ScenarioRunner:
 
         if self._uri_type == 'URL':
             if self._dev_cache_repos and self._repo_folder.exists() and self._repo_folder.is_dir() and any(self._repo_folder.iterdir()):
-                print('Skipping clone of ', self._uri, 'as it was already present on disk and --dev-cache-repos was set')
+                print('Skipping clone of ', utils.filter_sensitive_data(self._uri), 'as it was already present on disk and --dev-cache-repos was set')
             else:
                 self._initialize_folder(self._repo_folder) # should be cleared for a new run, bc we otherwise do not understand which files are new
 

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -11,8 +11,6 @@ from metric_providers.base import MetricProviderConfigurationError
 faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to stderr
 
 from lib.secure_variable import SecureVariable
-from lib.venv_checker import check_venv
-check_venv() # this check must even run before __main__ as imports might not get resolved
 
 import subprocess
 import json

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -419,7 +419,7 @@ class ScenarioRunner:
                 command.append(self._uri)
                 command.append(self._repo_folder.as_posix())
 
-                print('Cloning ', self._uri)
+                print('Cloning ', utils.filter_sensitive_data(self._uri))
                 subprocess.run(
                     command,
                     check=True,
@@ -495,9 +495,9 @@ class ScenarioRunner:
 
             # only skip checkout if switch active and files in dir present
             if self._dev_cache_repos and relation_path.exists() and relation_path.is_dir() and any(relation_path.iterdir()):
-                print('Skipping clone of ', relation['url'], 'as it was already present on disk and --dev-cache-repos was set')
+                print('Skipping clone of ', utils.filter_sensitive_data(relation['url']), 'as it was already present on disk and --dev-cache-repos was set')
             else:
-                print('Cloning ', relation['url'])
+                print('Cloning ', utils.filter_sensitive_data(relation['url']))
                 subprocess.run(
                     command,
                     check=True,
@@ -992,6 +992,20 @@ class ScenarioRunner:
         measurement_config['custom_metrics'] = self.__custom_metrics
         measurement_config['phase_padding'] = self._phase_padding_ms
 
+        params=(self._job_id, self._name, self._uri, self._branch, self._original_filename.as_posix(), json.dumps(self.__relations),
+                self._commit_hash, self._commit_timestamp, json.dumps(self._arguments),
+                json.dumps(machine_specs), json.dumps(measurement_config),
+                json.dumps(self._usage_scenario_original), json.dumps(self._usage_scenario_variables), list(self._category_ids) if self._category_ids else None,
+                gmt_hash,
+                GlobalConfig().config['machine']['id'], self._user_id,
+        )
+
+        # general approach as it is better to maintain when we add new items
+        params = [
+            utils.filter_sensitive_data(item) if isinstance(item, str) else item
+            for item in params
+        ]
+
         # We issue a fetch_one() instead of a query() here, cause we want to get the RUN_ID
         self._run_id = DB().fetch_one("""
                 INSERT INTO runs (
@@ -1009,14 +1023,7 @@ class ScenarioRunner:
                     %s, %s, NOW()
                 )
                 RETURNING id
-                """, params=(
-                    self._job_id, self._name, self._uri, self._branch, self._original_filename.as_posix(), json.dumps(self.__relations),
-                    self._commit_hash, self._commit_timestamp, json.dumps(self._arguments),
-                    json.dumps(machine_specs), json.dumps(measurement_config),
-                    json.dumps(self._usage_scenario_original), json.dumps(self._usage_scenario_variables), list(self._category_ids) if self._category_ids else None,
-                    gmt_hash,
-                    GlobalConfig().config['machine']['id'], self._user_id,
-                ))[0]
+                """, params=params)[0]
         return self._run_id
 
     def _import_metric_providers(self):

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -1949,7 +1949,7 @@ class ScenarioRunner:
         log_entry = {
             'type': log_type.value,
             'id': str(log_id),
-            'cmd': command_string,
+            'cmd': utils.filter_sensitive_data(command_string),
             'phase': phase
         }
 
@@ -1960,6 +1960,7 @@ class ScenarioRunner:
                 log_entry['stdout'] = stdout.decode('UTF-8', errors='replace').replace('\x00', '0x00')
             else:
                 log_entry['stdout'] = str(stdout).replace('\x00', '0x00') # we just force it to a string. This can garble output a bit though
+            log_entry['stdout'] = utils.filter_sensitive_data(log_entry['stdout'])
         if stderr is not None:
             if isinstance(stderr, str):
                 log_entry['stderr'] = stderr.replace('\x00', '0x00') # Postgres cannot handle null bytes (\x00) in text fields or \u0000 in JSONB columns
@@ -1967,6 +1968,7 @@ class ScenarioRunner:
                 log_entry['stderr'] = stderr.decode('UTF-8', errors='replace').replace('\x00', '0x00')
             else:
                 log_entry['stderr'] = str(stderr).replace('\x00', '0x00') # we just force it to a string. This can garble output a bit though
+            log_entry['stderr'] = utils.filter_sensitive_data(log_entry['stderr'])
         if flow is not None:
             log_entry['flow'] = flow
         if exception_class is not None:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,4 +1,5 @@
 import random
+import re
 import string
 import subprocess
 import os
@@ -7,6 +8,22 @@ from urllib.parse import urlparse
 from functools import cache
 from pathlib import Path
 
+# Matches the userinfo part of a URI that uses HTTP-AUTH, e.g. https://user:pass@host/path
+URI_CREDENTIALS_RE = re.compile(r'([a-zA-Z][a-zA-Z0-9+.\-]*://)[^\s/@:]+(?::[^\s/@]*)?@')
+
+# Matches PEM encoded private key blocks (RSA, EC, OPENSSH, DSA, generic, encrypted, ...)
+PRIVATE_KEY_RE = re.compile(r'-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----', re.DOTALL)
+
+REDACTED = '*****GMT-REDACTED*****'
+
+def filter_sensitive_data(text):
+    if not text:
+        return text
+    text = URI_CREDENTIALS_RE.sub(rf'\1{REDACTED}@', text)
+    text = PRIVATE_KEY_RE.sub(REDACTED, text)
+    return text
+
+# The above are defined before this import as lib.error_helpers imports them back from here (circular import)
 from lib import error_helpers
 from lib import host_platform
 from lib.db import DB

--- a/runner.py
+++ b/runner.py
@@ -19,6 +19,7 @@ GMT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.scenario_runner import ScenarioRunner
 from lib import error_helpers
+from lib import utils
 from lib.terminal_colors import TerminalColors
 from lib.db import DB
 from lib.global_config import GlobalConfig
@@ -96,7 +97,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if args.uri[0:8] == 'https://' or args.uri[0:7] == 'http://' or args.uri[0:6] == 'ssh://' or args.uri[0:4] == 'git@':
-        print(TerminalColors.OKBLUE, '\nDetected supplied URL: ', args.uri, TerminalColors.ENDC)
+        print(TerminalColors.OKBLUE, '\nDetected supplied URL: ', utils.filter_sensitive_data(args.uri), TerminalColors.ENDC)
         run_type = 'URL'
     elif Path(args.uri).is_dir():
         print(TerminalColors.OKBLUE, '\nDetected supplied folder: ', args.uri, TerminalColors.ENDC)

--- a/tests/api/test_api_scenario_runner.py
+++ b/tests/api/test_api_scenario_runner.py
@@ -9,6 +9,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.db import DB
 from lib import utils
+from lib.job.run import RunJob
 from lib import metric_importer
 from lib.global_config import GlobalConfig
 from lib.phase_stats import build_and_store_phase_stats
@@ -65,6 +66,24 @@ def test_get_runs_created_after_filter():
     assert response_filtered.status_code == 200
     assert len(response_filtered.json()['data']) == 1
 
+
+def test_get_jobs_redacts_url_credentials():
+    run_name = 'test_' + utils.randomword(12)
+    credentialed_url = 'https://admin:s3cr3t@github.com/green-coding-solutions/green-metrics-tool'
+
+    job_id = RunJob.insert(user_id=1, name=run_name, url=credentialed_url, branch='main', filename='usage_scenario.yml', machine_id=1)
+
+    response = requests.get(f"{API_URL}/v2/jobs?job_id={job_id}", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    data = response.json()['data']
+    assert data[0][0] == job_id
+    assert 'admin' not in data[0][3]
+    assert 's3cr3t' not in data[0][3]
+    assert '*****GMT-REDACTED*****' in data[0][3]
+
+    # the DB copy must stay usable so the cluster worker can actually clone the repo later
+    raw_url = DB().fetch_one('SELECT url FROM jobs WHERE id = %s', params=(job_id,))[0]
+    assert raw_url == credentialed_url
 
 def test_compare_valid():
     Tests.import_demo_data()

--- a/tests/cron/test_client.py
+++ b/tests/cron/test_client.py
@@ -5,7 +5,7 @@ from pathlib import Path
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib import utils
-from lib.job.base import Job
+from lib.job.run import RunJob
 from tests import test_functions as Tests
 
 def test_simple_cluster_run():
@@ -21,7 +21,7 @@ def test_simple_cluster_run():
 
     Tests.shorten_sleep_times(1)
 
-    Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+    RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
 
     ps = subprocess.run(
             ['python3', '../cron/client.py', '--testing', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/../test-config.yml"],

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -8,7 +8,8 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.db import DB
 from lib import utils
-from lib.job.base import Job
+from lib.job.run import RunJob
+from lib.job.email_simple import EmailSimpleJob
 from lib.user import User
 from tests import test_functions as Tests
 
@@ -62,9 +63,9 @@ def test_insert_job():
     branch = 'main'
     machine_id = 1
 
-    job_id = Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+    job_id = RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
     assert job_id is not None
-    job = Job.get_job('run')
+    job = RunJob.get_job()
     assert job._state == 'WAITING'
 
 def test_simple_run_job_no_quota():
@@ -76,7 +77,7 @@ def test_simple_run_job_no_quota():
     branch = 'main'
     machine_id = 1
 
-    Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+    RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
 
     ps = subprocess.run(
             ['python3', '../cron/jobs.py', 'run', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/../test-config.yml"],
@@ -101,7 +102,7 @@ def test_simple_run_job_quota_gets_deducted():
     branch = 'main'
     machine_id = 1
 
-    Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+    RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
 
     user = User(1)
     user._capabilities['measurement']['quotas'] = {'1': 10_000 * 60} # typical quota is 10.000 minutes
@@ -132,7 +133,7 @@ def test_simple_run_job_with_variables():
     machine_id = 1
     usage_scenario_variables = {'__GMT_VAR_COMMAND__': 'stress-ng'}
 
-    Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id, usage_scenario_variables=usage_scenario_variables)
+    RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id, usage_scenario_variables=usage_scenario_variables)
 
     ps = subprocess.run(
             ['python3', '../cron/jobs.py', 'run', '--config-override', f"{os.path.dirname(os.path.realpath(__file__))}/../test-config.yml"],
@@ -148,15 +149,6 @@ def test_simple_run_job_with_variables():
     assert 'MEASUREMENT SUCCESSFULLY COMPLETED' in ps.stdout,\
         Tests.assertion_info('MEASUREMENT SUCCESSFULLY COMPLETED', ps.stdout)
 
-def test_simple_run_job_missing_filename_branch():
-    name = utils.randomword(12)
-    url = 'https://github.com/green-coding-solutions/pytest-dummy-repo'
-    machine_id = 1
-
-    with pytest.raises(RuntimeError):
-        Job.insert('run', user_id=1, name=name, url=url, machine_id=machine_id)
-
-
 def test_simple_run_job_wrong_machine_id():
     name = utils.randomword(12)
     url = 'https://github.com/green-coding-solutions/pytest-dummy-repo'
@@ -165,7 +157,7 @@ def test_simple_run_job_wrong_machine_id():
     machine_id = 100
 
     with pytest.raises(psycopg.errors.ForeignKeyViolation):
-        Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+        RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
 
 def test_measurement_quota_exhausted():
     name = utils.randomword(12)
@@ -174,7 +166,7 @@ def test_measurement_quota_exhausted():
     branch = 'main'
     machine_id = 1
 
-    Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+    RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
 
     user = User(1)
     user._capabilities['measurement']['quotas'] = {'1': 2678400}
@@ -197,7 +189,7 @@ def test_machine_not_allowed():
     filename = 'usage_scenario.yml'
     branch = 'main'
     machine_id = 1
-    Job.insert('run', user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
+    RunJob.insert(user_id=1, name=name, url=url, branch=branch, filename=filename, machine_id=machine_id)
 
     user = User(1)
     user._capabilities['machines'] = []
@@ -223,8 +215,7 @@ def todo_test_simple_email_job():
     email = 'fakeemailaddress'
     message = 'simple job'
 
-    Job.insert(
-        'email-simple',
+    EmailSimpleJob.insert(
         user_id=1,
         email=email,
         name=subject,

--- a/tests/cron/test_watchlist.py
+++ b/tests/cron/test_watchlist.py
@@ -127,6 +127,24 @@ def test_run_schedule_watchlist_item_update_commit():
     assert watchlist_item_db['last_marker'] == GMT_LAST_COMMIT_HASH
 
 
+def test_run_schedule_daily_redacts_credentials_in_stdout(capsys):
+    watchlist_item_modified = WATCHLIST_ITEM.copy()
+    watchlist_item_modified['repo_url'] = 'https://admin:s3cr3t@github.com/green-coding-solutions/green-metrics-tool'
+
+    Watchlist.insert(**watchlist_item_modified)
+    schedule_watchlist_item()
+
+    captured = capsys.readouterr()
+    assert 'admin' not in captured.out
+    assert 's3cr3t' not in captured.out
+    assert '*****GMT-REDACTED*****' in captured.out
+
+    # the DB copy must stay usable so the cluster worker can actually clone the repo later
+    jobs = get_jobs()
+    assert len(jobs) == 1
+    assert jobs[0]['url'] == watchlist_item_modified['repo_url']
+
+
 def test_run_schedule_watchlist_item_non_existing_branch():
     watchlist_item_modified = WATCHLIST_ITEM.copy()
     watchlist_item_modified['branch'] = 'non-existing-branch-for-testing'

--- a/tests/data/usage_scenarios/relations_checkout_credentials_test.yml
+++ b/tests/data/usage_scenarios/relations_checkout_credentials_test.yml
@@ -1,0 +1,21 @@
+name: Relations Checkout Credentials Test
+author: Arne Tarara
+description: Relations Checkout Test where the relation URL carries HTTP-AUTH credentials
+
+services:
+  test-container:
+    image: gcb_stress
+    build:
+      context: ../stress-application
+
+relations:
+  helpers:
+    url: https://admin:s3cr3t@github.com/green-coding-solutions/gmt-helpers
+    commit_hash: b8c6c7575e493c9808ceeea2a5e7311c61b16419
+
+flow:
+  - name: I will not get here in this test
+    container: test-container
+    commands:
+        - type: console
+          command: echo 1

--- a/tests/lib/test_email_job.py
+++ b/tests/lib/test_email_job.py
@@ -1,0 +1,81 @@
+import pytest
+
+from lib.job.email import EmailJob
+from lib.job.email_simple import EmailSimpleJob
+from lib.job.email_report import EmailReportJob
+from lib.db import DB
+from tests import test_functions as Tests
+
+OPENSSH_EXAMPLE_PRIVATE_KEY = Tests.OPENSSH_EXAMPLE_PRIVATE_KEY
+
+
+def _job_row(job_id):
+    return DB().fetch_one(
+        'SELECT type, message FROM jobs WHERE id = %s',
+        params=(job_id,),
+        fetch_mode='dict',
+    )
+
+
+def test_email_job_cannot_be_used_directly():
+    with pytest.raises(NotImplementedError):
+        EmailJob.insert(user_id=1, email='foo@example.com', name='Test')
+
+
+def test_insert_redacts_uri_credentials_in_db():
+    job_id = EmailSimpleJob.insert(
+        user_id=1,
+        email='foo@example.com',
+        name='Test',
+        message='repo: https://admin:s3cr3t@github.com/org/repo.git',
+    )
+
+    job = _job_row(job_id)
+    assert job is not None, Tests.assertion_info('a jobs row', 'none found')
+    assert job['type'] == 'email-simple'
+    assert 'admin' not in job['message']
+    assert 's3cr3t' not in job['message']
+    assert '*****GMT-REDACTED*****' in job['message']
+
+
+def test_insert_redacts_private_keys_in_db():
+    job_id = EmailSimpleJob.insert(
+        user_id=1,
+        email='foo@example.com',
+        name='Test',
+        message=f"Here is the key:\n{OPENSSH_EXAMPLE_PRIVATE_KEY}\nEnd of message",
+    )
+
+    job = _job_row(job_id)
+    assert job is not None, Tests.assertion_info('a jobs row', 'none found')
+    assert OPENSSH_EXAMPLE_PRIVATE_KEY not in job['message']
+    assert 'BEGIN OPENSSH PRIVATE KEY' not in job['message']
+    assert '*****GMT-REDACTED*****' in job['message']
+
+
+def test_insert_leaves_clean_message_untouched_in_db():
+    job_id = EmailSimpleJob.insert(
+        user_id=1,
+        email='foo@example.com',
+        name='Test',
+        message='nothing sensitive here',
+    )
+
+    job = _job_row(job_id)
+    assert job is not None, Tests.assertion_info('a jobs row', 'none found')
+    assert job['message'] == 'nothing sensitive here'
+    assert '*****GMT-REDACTED*****' not in job['message']
+
+
+def test_insert_without_message_stays_null_in_db():
+    job_id = EmailReportJob.insert(
+        user_id=1,
+        email='foo@example.com',
+        name='Test',
+        run_id=None,
+    )
+
+    job = _job_row(job_id)
+    assert job is not None, Tests.assertion_info('a jobs row', 'none found')
+    assert job['type'] == 'email-report'
+    assert job['message'] is None

--- a/tests/lib/test_error_helpers.py
+++ b/tests/lib/test_error_helpers.py
@@ -1,0 +1,55 @@
+from lib import error_helpers
+from lib.db import DB
+from tests import test_functions as Tests
+
+OPENSSH_EXAMPLE_PRIVATE_KEY = Tests.OPENSSH_EXAMPLE_PRIVATE_KEY
+
+
+def _last_system_log():
+    return DB().fetch_one(
+        "SELECT title, message, level FROM system_logs WHERE title = 'Green Metrics Tool Error' ORDER BY id DESC LIMIT 1",
+        fetch_mode='dict',
+    )
+
+
+def test_log_error_redacts_uri_credentials_in_stderr_and_db(capsys):
+    error_helpers.log_error('Clone failed', repo_url='https://admin:s3cr3t@github.com/org/repo.git')
+
+    captured = capsys.readouterr()
+    assert 'admin' not in captured.err
+    assert 's3cr3t' not in captured.err
+    assert '*****GMT-REDACTED*****' in captured.err
+
+    log_row = _last_system_log()
+    assert log_row is not None, Tests.assertion_info('a system_logs row', 'none found')
+    assert 'admin' not in log_row['message']
+    assert 's3cr3t' not in log_row['message']
+    assert '*****GMT-REDACTED*****' in log_row['message']
+
+
+def test_log_error_redacts_private_keys_in_stderr_and_db(capsys):
+    error_helpers.log_error('SSH connection failed', ssh_key=OPENSSH_EXAMPLE_PRIVATE_KEY)
+
+    captured = capsys.readouterr()
+    assert OPENSSH_EXAMPLE_PRIVATE_KEY not in captured.err
+    assert 'BEGIN OPENSSH PRIVATE KEY' not in captured.err
+    assert '*****GMT-REDACTED*****' in captured.err
+
+    log_row = _last_system_log()
+    assert log_row is not None, Tests.assertion_info('a system_logs row', 'none found')
+    assert OPENSSH_EXAMPLE_PRIVATE_KEY not in log_row['message']
+    assert 'BEGIN OPENSSH PRIVATE KEY' not in log_row['message']
+    assert '*****GMT-REDACTED*****' in log_row['message']
+
+
+def test_log_error_leaves_clean_messages_untouched(capsys):
+    error_helpers.log_error('Simple failure', detail='nothing sensitive here')
+
+    captured = capsys.readouterr()
+    assert 'nothing sensitive here' in captured.err
+    assert '*****GMT-REDACTED*****' not in captured.err
+
+    log_row = _last_system_log()
+    assert log_row is not None, Tests.assertion_info('a system_logs row', 'none found')
+    assert 'nothing sensitive here' in log_row['message']
+    assert '*****GMT-REDACTED*****' not in log_row['message']

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -268,6 +268,56 @@ def test_relations_checkout_specific_commit_hash():
         assert checked_out_commit_hash == relation_commit_hash, Tests.assertion_info(f"commit_hash: {relation_commit_hash}", checked_out_commit_hash)
         assert commit_message == expected_message, Tests.assertion_info(f"commit_message: {expected_message}", commit_message)
 
+def test_relations_checkout_redacts_credentials_in_db():
+    run_name = 'test_' + utils.randomword(12)
+    relation_key = 'helpers'
+    real_repo_url = 'https://github.com/green-coding-solutions/gmt-helpers'
+
+    runner = ScenarioRunner(
+        name=run_name,
+        uri=GMT_DIR,
+        uri_type='folder',
+        filename='tests/data/usage_scenarios/relations_checkout_credentials_test.yml',
+        dev_cache_repos=True,
+        dev_no_container_dependency_collection=True,
+        skip_download_dependencies=True,
+        skip_optimizations=True,
+        dev_no_sleeps=True,
+        dev_no_system_checks=True,
+    )
+    runner._create_folders()
+
+    relation_path = runner._relations_folder.joinpath(relation_key)
+    # Pre-seed the relation folder with a real, credential-free clone so --dev-cache-repos skips
+    # the actual git clone below. The fake credentials in the fixture's relation URL are therefore
+    # never used for a real network/auth call - only their redaction on DB storage is under test.
+    if not (relation_path.exists() and any(relation_path.iterdir())):
+        subprocess.run(
+            ['git', 'clone', '--depth', '1', real_repo_url, relation_path.as_posix()],
+            check=True,
+            capture_output=True,
+            encoding='UTF-8',
+            errors='replace',
+        )
+
+    with Tests.RunUntilManager(runner) as context:
+        context.run_until('initialize_run')
+
+    run_data = utils.get_run_data(run_name)
+    assert run_data is not None, Tests.assertion_info('a runs row', 'none found')
+
+    relation_data = run_data['relations'][relation_key]
+    assert 'admin' not in relation_data['url']
+    assert 's3cr3t' not in relation_data['url']
+    assert '*****GMT-REDACTED*****' in relation_data['url']
+    assert relation_data['commit_hash'] == 'b8c6c7575e493c9808ceeea2a5e7311c61b16419'
+
+    usage_scenario_data = str(run_data['usage_scenario'])
+    assert 'admin' not in usage_scenario_data
+    assert 's3cr3t' not in usage_scenario_data
+    assert '*****GMT-REDACTED*****' in usage_scenario_data
+
+
 # #   --name NAME
 # #    A name which will be stored to the database to discern this run from others
 def test_name_is_in_db():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1032,6 +1032,73 @@ def test_logs_null_byte_handling():
             if key in ('stdout', 'stderr'):
                 assert '\x00' not in value, f"Null bytes should be automatically cleaned: {repr(value)}"
 
+def test_checkout_failure_redacts_credentials_in_run_logs():
+    """A failed git clone/checkout stringifies CalledProcessError with the full argv (including
+    any credentialed URI), and that string is what run()'s exception handler feeds into
+    _add_to_current_run_log() as stderr. Verify the credentials are redacted before the entry
+    is persisted to runs.logs."""
+    run_name = 'test_' + utils.randomword(12)
+    credentialed_url = 'https://admin:s3cr3t@github.com/green-coding-solutions/this-repo-definitely-does-not-exist-ab12cd34'
+
+    runner = ScenarioRunner(
+        name=run_name,
+        uri=GMT_DIR,
+        uri_type='folder',
+        filename='tests/data/usage_scenarios/basic_stress.yml',
+        dev_no_container_dependency_collection=True,
+        skip_download_dependencies=True,
+        skip_optimizations=True,
+        dev_no_system_checks=True,
+        dev_cache_build=True,
+        dev_no_sleeps=True,
+        dev_no_metrics=True,
+        dev_no_phase_stats=True,
+        dev_no_save=False,
+    )
+
+    with Tests.RunUntilManager(runner) as context:
+        context.run_until('initialize_run')
+
+    assert runner._run_id is not None, 'run must be initialized in DB for this test to be meaningful'
+
+    # Reproduce exactly what a failed _checkout_repository()/_checkout_relations() produces:
+    # a subprocess.CalledProcessError whose str() embeds the full argv, credentials included.
+    try:
+        subprocess.run(
+            ['git', 'clone', '--depth', '1', '--single-branch', credentialed_url, '/tmp/this-should-not-be-created'],
+            check=True,
+            capture_output=True,
+            encoding='UTF-8',
+            errors='replace',
+            env=runner._get_git_environment(),
+        )
+        assert False, 'expected clone of a non-existent repository to fail'
+    except subprocess.CalledProcessError as exc:
+        # sanity check that the raw exception does in fact carry the credentials
+        assert 'admin' in str(exc) and 's3cr3t' in str(exc), Tests.assertion_info('credentials in str(exc)', str(exc))
+
+        runner._add_to_current_run_log(
+            container_name='[SYSTEM]',
+            log_type=LogType.EXCEPTION,
+            log_id=id(exc),
+            cmd='run_scenario',
+            phase='[RUNTIME]',
+            stderr=f"{str(exc)}\n\n{exc.stderr}",
+            stdout=exc.stdout,
+            exception_class=exc.__class__.__name__,
+        )
+
+    runner._save_run_logs()
+
+    logs = DB().fetch_one('SELECT logs FROM runs WHERE id = %s', params=(runner._run_id,))[0]
+    entry = logs['[SYSTEM]'][0]
+
+    assert 'admin' not in entry['cmd']
+    assert 'admin' not in entry['stderr']
+    assert 's3cr3t' not in entry['cmd']
+    assert 's3cr3t' not in entry['stderr']
+    assert '*****GMT-REDACTED*****' in entry['stderr']
+
 def test_logs_invalid_character_handling():
     """Test that invalid UTF-8 character in logs are automatically replaced"""
     runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/capture_logs_with_invalid_character.yml', dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True, dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_save=False)


### PR DESCRIPTION
This PR was specifically crafted to not patch sys.stdout/sys.stderr as the overhead would be tremendous and the gain would only to have clean server logs. Server logs thus can in cases of a code oversight still contain unredacted passwords. DB is save though

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added sensitive-data redaction for HTTP-AUTH credentials and private keys across ErrorLog, email/job payloads, and URL/command logging.

- Implemented `lib.utils.filter_sensitive_data()` (with shared redaction markers) to strip URI credentials and PEM private keys.
- Applied redaction at output/serialization points (error formatting, run/scenario runner logs and stored command/stdout/stderr, cron/watchlist scheduling status, and runner URI echo) rather than monkeypatching `sys.stdout`/`sys.stderr`.
- Extended `/v2/jobs` to redact `jobs.url` in API responses while keeping the DB value unchanged for backend cloning.
- Refactored job insertion/routing to dedicated job classes with explicit `JOB_TYPE` (`RunJob`, `EmailSimpleJob`, `EmailReportJob`, etc.) and sanitized email/message fields before persistence; added URI filtering to watchlist “show”/status output.

Tests added/updated to verify redaction in stderr/system logs, DB-stored job/email message fields, API job URL responses, watchlist stdout, and relations checkout/run-log persistence, including new credentialed scenario YAML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->