### PR TITLE
(feat): Reworked phase padding

### DIFF
--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -50,7 +50,6 @@ VALUES (
                 "measurement.disabled_metric_providers",
                 "measurement.flow_process_duration",
                 "measurement.total_duration",
-                "measurement.phase_padding",
                 "measurement.system_check_threshold",
                 "measurement.pre_test_sleep",
                 "measurement.idle_duration",
@@ -137,7 +136,6 @@ VALUES (
         },
         "machines": [1],
         "measurement": {
-            "phase_padding": true,
             "quotas": {},
             "dev_no_sleeps": false,
             "skip_optimizations": false,

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -61,7 +61,6 @@ const getSettings = async () => {
         // Checkboxes
         document.querySelector('#measurement-skip-optimizations').checked = data?.data?._capabilities?.measurement?.skip_optimizations === true;
         document.querySelector('#measurement-dev-no-sleeps').checked = data?.data?._capabilities?.measurement?.dev_no_sleeps === true;
-        document.querySelector('#measurement-phase-padding').checked = data?.data?._capabilities?.measurement?.phase_padding === true;
         document.querySelector('#measurement-skip-volume-inspect').checked = data?.data?._capabilities?.measurement?.skip_volume_inspect === true;
 
         // Other

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -124,13 +124,6 @@
                                     <td><button id="save-measurement-total-duration" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
                                 </tr>
                                 <tr>
-                                    <td>Phase padding<br>
-                                        <span><small><i class="question circle icon"></i>Determines if phases shall be padded to account for possible undersampling. Only turn off when you need nanosecond exact cut-offs from measurements and favor undersampling instead of capturing partial samples.</small></span>
-                                    </td>
-                                    <td><input type="checkbox" id="measurement-phase-padding" name="measurement-phase-padding" data-setting="measurement.phase_padding"></td>
-                                    <td><button id="save-measurement-phase-padding" class="ui positive small button" onclick="updateSetting(this);">Save</button></td>
-                                </tr>
-                                <tr>
                                     <td>Pre-test sleep<br>
                                         <span><small><i class="question circle icon"></i>Value is in seconds.</small></span>
                                     </td>

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -131,10 +131,31 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
         machine_energy_current_phase = None
 
         select_query = """
-            WITH lag_table as (
-                SELECT time, value, (time - LAG(time) OVER (ORDER BY time ASC)) AS diff
+            WITH in_range AS (
+                SELECT time, value
                 FROM measurement_values
-                WHERE measurement_metric_id = %s AND time > %s and time < %s
+                WHERE measurement_metric_id = %s
+                  AND time > %s
+                  AND time < %s
+            ),
+            next_one AS (
+                SELECT time, value
+                FROM measurement_values
+                WHERE measurement_metric_id = %s
+                  AND time >= %s          -- same upper bound as above
+                ORDER BY time ASC
+                LIMIT 1
+            ),
+            lag_table as (
+                SELECT
+                    time,
+                    value,
+                    (time - LAG(time) OVER (ORDER BY time ASC)) AS diff
+                FROM (
+                    SELECT time, value FROM in_range
+                    UNION ALL
+                    SELECT time, value FROM next_one
+                )
                 ORDER BY time ASC
             )
             SELECT
@@ -161,7 +182,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
 
 
         for measurement_metric_id, metric, unit, detail_name in metrics:
-            params = (measurement_metric_id, phase['start'], phase['end'])
+            params = (measurement_metric_id, phase['start'], phase['end'], measurement_metric_id, phase['end'])
             results = DB().fetch_one(select_query, params=params)
 
             if metric not in ('carbon_intensity_elephant_machine', 'carbon_intensity_electricity_maps_machine', 'carbon_intensity_static_machine'):
@@ -184,7 +205,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
 
         # now we go through all metrics in the run and aggregate them
         for measurement_metric_id, metric, unit, detail_name in metrics: # unpack
-            params = (measurement_metric_id, phase['start'], phase['end'])
+            params = (measurement_metric_id, phase['start'], phase['end'], measurement_metric_id, phase['end'])
             results = DB().fetch_one(select_query, params=params)
 
             value_sum, max_value, min_value, classic_value_avg, weighted_value_avg, derivative_avg, derivative_max, derivative_min, value_count, sampling_rate_avg, sampling_rate_max, sampling_rate_95p = results

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -10,6 +10,7 @@ from io import StringIO
 from lib.db import DB
 from lib import error_helpers
 
+MAX_POSTGRES_BIGINT = 2**63 - 1
 
 def reconstruct_runtime_phase(run_id, runtime_phase_idx):
     # First we create averages for all types. This includes means and totals
@@ -101,18 +102,20 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
         FROM runs
         WHERE id = %s
         """
-    phases = DB().fetch_one(query, (run_id, ))
+    phase_data = DB().fetch_one(query, (run_id, ))
 
-    if not phases or not phases[0]:
+    if not phase_data or not phase_data[0]:
         error_helpers.log_error('Phases object was empty and no phase_stats could be created. This can happen for failed runs, but should be very rare ...', run_id=run_id)
         return
+
+    phases = phase_data[0]
 
     csv_buffer = StringIO()
 
     machine_power_baseline = None
     runtime_phase_idx = None
 
-    for idx, phase in enumerate(phases[0]):
+    for idx, phase in enumerate(phases):
         if phase['name'] == '[RUNTIME]': # do not process runtime like this, but rather reconstruct it later. Still advance the idx counter though as we want to use the number later
             runtime_phase_idx = idx
             continue
@@ -143,6 +146,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
                 FROM measurement_values
                 WHERE measurement_metric_id = %s
                   AND time >= %s          -- same upper bound as above
+                  AND time < %s
                 ORDER BY time ASC
                 LIMIT 1
             ),
@@ -177,12 +181,13 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
         """
 
         duration = Decimal(phase['end']-phase['start'])
+        next_phase_start = phases[idx+1]['start'] if idx+1 < len(phases) else MAX_POSTGRES_BIGINT
         duration_in_s = Decimal(duration / 1_000_000)
         csv_buffer.write(generate_csv_line(phase['hidden'], run_id, 'phase_time_syscall_system', '[SYSTEM]', f"{idx:03}_{phase['name']}", duration, 'TOTAL', None, None, None, None, None, 'us'))
 
 
         for measurement_metric_id, metric, unit, detail_name in metrics:
-            params = (measurement_metric_id, phase['start'], phase['end'], measurement_metric_id, phase['end'])
+            params = (measurement_metric_id, phase['start'], phase['end'], measurement_metric_id, phase['end'], next_phase_start)
             results = DB().fetch_one(select_query, params=params)
 
             if metric not in ('carbon_intensity_elephant_machine', 'carbon_intensity_electricity_maps_machine', 'carbon_intensity_static_machine'):
@@ -205,7 +210,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
 
         # now we go through all metrics in the run and aggregate them
         for measurement_metric_id, metric, unit, detail_name in metrics: # unpack
-            params = (measurement_metric_id, phase['start'], phase['end'], measurement_metric_id, phase['end'])
+            params = (measurement_metric_id, phase['start'], phase['end'], measurement_metric_id, phase['end'], next_phase_start)
             results = DB().fetch_one(select_query, params=params)
 
             value_sum, max_value, min_value, classic_value_avg, weighted_value_avg, derivative_avg, derivative_max, derivative_min, value_count, sampling_rate_avg, sampling_rate_max, sampling_rate_95p = results

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -73,7 +73,7 @@ class ScenarioRunner:
         ssh_private_key=None,
         docker_prune=False, job_id=None, user_id=1,
         disabled_metric_providers=None, allowed_run_args=None, allowed_volume_mounts=None,
-        phase_padding=True, usage_scenario_variables=None, carbon_simulation=None,
+        usage_scenario_variables=None, carbon_simulation=None,
         category_ids=None,
         measurement_system_check_threshold=3, measurement_pre_test_sleep=5, measurement_idle_duration=60,
         measurement_baseline_duration=60, measurement_post_test_sleep=5, measurement_phase_transition_time=1,
@@ -182,7 +182,7 @@ class ScenarioRunner:
         self._measurement_phase_transition_time = measurement_phase_transition_time
         self._measurement_wait_time_dependencies = measurement_wait_time_dependencies
         self._last_measurement_duration = 0
-        self._phase_padding = phase_padding
+
         configured_metric_providers = utils.get_metric_providers(config, self._disabled_metric_providers)
         self._phase_padding_ms = 0
         if configured_metric_providers:
@@ -2158,11 +2158,7 @@ class ScenarioRunner:
         self._check_total_runtime_exceeded()
 
         phase_time = int(time.time_ns() / 1_000)
-
-        if self._phase_padding:
-            self.__notes_helper.add_note( note=f"Ending phase {phase} [UNPADDED]", detail_name='[NOTES]', timestamp=phase_time)
-            phase_time += self._phase_padding_ms*1000 # value is in ms and we need to get to us
-            time.sleep(self._phase_padding_ms/1000) # no custom sleep here as even with dev_no_sleeps we must ensure phases don't overlap
+        time.sleep(self._phase_padding_ms/1000) # no custom sleep here as even with dev_no_sleeps we must ensure phases don't overlap
 
         if phase not in self.__phases:
             raise RuntimeError(f'Phase "{phase}" not found in known phases: "{list(self.__phases.keys())}". '
@@ -2179,10 +2175,7 @@ class ScenarioRunner:
 
         self.__phases[phase]['end'] = phase_time
 
-        if self._phase_padding:
-            self.__notes_helper.add_note( note=f"Ending phase {phase} [PADDED]", detail_name='[NOTES]', timestamp=phase_time)
-        else:
-            self.__notes_helper.add_note( note=f"Ending phase {phase} [UNPADDED]", detail_name='[NOTES]', timestamp=phase_time)
+        self.__notes_helper.add_note( note=f"Ending phase {phase} [includes next tick]", detail_name='[NOTES]', timestamp=phase_time)
 
     def _run_flows(self):
         ps_to_kill_tmp = []

--- a/lib/user.py
+++ b/lib/user.py
@@ -81,7 +81,7 @@ class User():
             raise ValueError(f"You cannot change this setting: {name}")
 
         match name:
-            case 'measurement.skip_optimizations' | 'measurement.dev_no_sleeps' | 'measurement.phase_padding' | 'measurement.skip_volume_inspect':
+            case 'measurement.skip_optimizations' | 'measurement.dev_no_sleeps' | 'measurement.skip_volume_inspect':
                 if not isinstance(value, bool):
                     raise ValueError(f'The setting {name} must be boolean')
             case 'measurement.flow_process_duration' | 'measurement.total_duration':

--- a/migrations/2026_07_07_remove_phase_padding.sql
+++ b/migrations/2026_07_07_remove_phase_padding.sql
@@ -1,0 +1,13 @@
+UPDATE users
+SET capabilities = jsonb_set(
+    capabilities,
+    '{user,updateable_settings}',
+    (SELECT jsonb_agg(elem)
+     FROM jsonb_array_elements(capabilities->'user'->'updateable_settings') elem
+     WHERE elem != '"measurement.phase_padding"'::jsonb)
+)
+WHERE capabilities->'user'->'updateable_settings' @> '"measurement.phase_padding"'::jsonb;
+
+UPDATE users
+SET capabilities = capabilities #- '{measurement,phase_padding}'
+WHERE (capabilities->'measurement') ? 'phase_padding';

--- a/migrations/2026_07_07_remove_phase_padding.sql
+++ b/migrations/2026_07_07_remove_phase_padding.sql
@@ -2,7 +2,7 @@ UPDATE users
 SET capabilities = jsonb_set(
     capabilities,
     '{user,updateable_settings}',
-    (SELECT jsonb_agg(elem)
+    (SELECT jsonb_agg(COALESCE(elem, '[]'::jsonb))
      FROM jsonb_array_elements(capabilities->'user'->'updateable_settings') elem
      WHERE elem != '"measurement.phase_padding"'::jsonb)
 )

--- a/runner.py
+++ b/runner.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
     parser.add_argument('--verbose-provider-boot', action='store_true', help='Boot metric providers gradually')
     parser.add_argument('--full-docker-prune', action='store_true', help='Stop and remove all containers, build caches, volumes and images on the system')
     parser.add_argument('--docker-prune', action='store_true', help='Prune all unassociated build caches, networks volumes and stopped containers on the system')
-    parser.add_argument('--no-phase-padding', action='store_true', help='Do not add paddings to phase end to capture incomplete last sampling interval.')
     parser.add_argument('--iterations', type=int, default=1, help='Specify how many times each scenario should be run. Default is 1. With multiple files, all files are processed sequentially, then the entire sequence is repeated N times. Example: with files A.yml, B.yml and --iterations 2, the execution order is A, B, A, B.')
 
     # These switches do not alter proper measurements, but might result in data not being generated
@@ -192,7 +191,7 @@ if __name__ == '__main__':
                     user_id=args.user_id, ssh_private_key=ssh_private_key_contents,
                     commit_hash_folder=args.commit_hash_folder,
                     usage_scenario_variables=variables_dict, category_ids=args.category,
-                    phase_padding=not args.no_phase_padding, carbon_simulation=carbon_simulation_to_pass,
+                    carbon_simulation=carbon_simulation_to_pass,
 
                     measurement_system_check_threshold=args.measurement_system_check_threshold,
                     measurement_pre_test_sleep=args.measurement_pre_test_sleep,

--- a/tests/data/usage_scenarios/noop.yml
+++ b/tests/data/usage_scenarios/noop.yml
@@ -12,4 +12,4 @@ flow:
     container: test-container
     commands:
       - type: console
-        command: echo 1
+        command: sleep 1

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -1059,7 +1059,6 @@ class TestFrontendFunctionality:
         assert user._capabilities['measurement']['disabled_metric_providers'] == []
         assert user._capabilities['measurement']['flow_process_duration'] == 86400
         assert user._capabilities['measurement']['total_duration'] == 86400
-        assert user._capabilities['measurement']['phase_padding'] is True
         assert user._capabilities['measurement']['dev_no_sleeps'] is False
         assert user._capabilities['measurement']['skip_optimizations'] is False
         assert user._capabilities['measurement']['system_check_threshold'] == 3
@@ -1081,9 +1080,6 @@ class TestFrontendFunctionality:
 
         value = page.locator('#measurement-total-duration').input_value()
         assert int(value.strip()) == user._capabilities['measurement']['total_duration']
-
-        value = page.locator('#measurement-phase-padding').is_checked()
-        assert value is user._capabilities['measurement']['phase_padding']
 
         value = page.locator('#measurement-dev-no-sleeps').is_checked()
         assert value is user._capabilities['measurement']['dev_no_sleeps']
@@ -1123,7 +1119,6 @@ class TestFrontendFunctionality:
         page.evaluate('$("#measurement-disabled-metric-providers").dropdown("set exactly", "network_connections_proxy_container");')
         page.locator('#measurement-flow-process-duration').fill('456')
         page.locator('#measurement-total-duration').fill('123')
-        page.locator('#measurement-phase-padding').click()
         page.locator('#measurement-pre-test-sleep').fill('100')
         page.locator('#measurement-idle-duration').fill('200')
         page.locator('#measurement-baseline-duration').fill('100')
@@ -1138,7 +1133,6 @@ class TestFrontendFunctionality:
         page.locator('#save-measurement-disabled-metric-providers').click()
         page.locator('#save-measurement-flow-process-duration').click()
         page.locator('#save-measurement-total-duration').click()
-        page.locator('#save-measurement-phase-padding').click()
         page.locator('#save-measurement-pre-test-sleep').click()
         page.locator('#save-measurement-idle-duration').click()
         page.locator('#save-measurement-baseline-duration').click()
@@ -1158,7 +1152,6 @@ class TestFrontendFunctionality:
         assert user._capabilities['measurement']['disabled_metric_providers'] == ['network_connections_proxy_container']
         assert user._capabilities['measurement']['flow_process_duration'] == 456
         assert user._capabilities['measurement']['total_duration'] == 123
-        assert user._capabilities['measurement']['phase_padding'] is False
         assert user._capabilities['measurement']['dev_no_sleeps'] is True
         assert user._capabilities['measurement']['skip_optimizations'] is True
         assert user._capabilities['measurement']['system_check_threshold'] == 2

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -65,9 +65,9 @@ def test_phase_stats_single_energy():
     assert data[0]['unit'] == 'us'
     assert data[0]['value'] == Tests.TEST_MEASUREMENT_RUNTIME_DURATION_NON_HIDDEN
     assert data[0]['type'] == 'TOTAL'
-    assert data[0]['sampling_rate_avg'] is None, 'AVG sampling rate not in expected range'
-    assert data[0]['sampling_rate_max'] is None, 'MAX sampling rate not in expected range'
-    assert data[0]['sampling_rate_95p'] is None, '95p sampling rate not in expected range'
+    assert data[0]['sampling_rate_avg'] is None
+    assert data[0]['sampling_rate_max'] is None
+    assert data[0]['sampling_rate_95p'] is None
 
 
     assert data[1]['metric'] == 'psu_energy_ac_mcp_machine'
@@ -75,9 +75,9 @@ def test_phase_stats_single_energy():
     assert data[1]['unit'] == 'uJ'
     assert data[1]['value'] == Tests.filter_df_runtime_subphase(df, hidden=False)['value'].sum()
     assert data[1]['type'] == 'TOTAL'
-    assert data[1]['sampling_rate_avg'] == 99502, 'AVG sampling rate not in expected range' # hardcoded for now. due for refactor
-    assert data[1]['sampling_rate_max'] == 101999, 'MAX sampling rate not in expected range' # hardcoded for now. due for refactor
-    assert data[1]['sampling_rate_95p'] == 100183, '95p sampling rate not in expected range' # hardcoded for now. due for refactor
+    assert data[1]['sampling_rate_avg'] == 99502 # hardcoded for now. due for refactor
+    assert data[1]['sampling_rate_max'] == 101999 # hardcoded for now. due for refactor
+    assert data[1]['sampling_rate_95p'] == 100183 # hardcoded for now. due for refactor
     assert isinstance(data[1]['sampling_rate_95p'], int)
 
     assert data[2]['metric'] == 'psu_power_ac_mcp_machine'
@@ -85,9 +85,9 @@ def test_phase_stats_single_energy():
     assert data[2]['unit'] == 'mW'
     assert data[2]['value'] == 8384760 # hardcoded bc it is not energy / divided by total_runtime but rather by the samples seen
     assert data[2]['type'] == 'MEAN'
-    assert data[2]['sampling_rate_avg'] == 99502, 'AVG sampling rate not in expected range' # hardcoded for now. due for refactor
-    assert data[2]['sampling_rate_max'] == 101999, 'MAX sampling rate not in expected range'  # hardcoded for now. due for refactor
-    assert data[2]['sampling_rate_95p'] == 100183, '95p sampling rate not in expected range'  # hardcoded for now. due for refactor
+    assert data[2]['sampling_rate_avg'] == 99502 # hardcoded for now. due for refactor
+    assert data[2]['sampling_rate_max'] == 101999  # hardcoded for now. due for refactor
+    assert data[2]['sampling_rate_95p'] == 100183  # hardcoded for now. due for refactor
     assert isinstance(data[2]['sampling_rate_95p'], int)
 
 def test_phase_stats_single_container():
@@ -106,9 +106,9 @@ def test_phase_stats_single_container():
     assert data[0]['type'] == 'TOTAL'
 
     assert data[1]['metric'] == 'cpu_utilization_cgroup_container'
-    assert data[1]['sampling_rate_avg'] == 99956, 'AVG sampling rate not in expected range'
-    assert data[1]['sampling_rate_max'] == 101708, 'MAX sampling rate not in expected range'
-    assert data[1]['sampling_rate_95p'] == 100602, '95p sampling rate not in expected range'
+    assert data[1]['sampling_rate_avg'] == 99956
+    assert data[1]['sampling_rate_max'] == 101708
+    assert data[1]['sampling_rate_95p'] == 100602
     assert isinstance(data[1]['sampling_rate_95p'], int)
 
 
@@ -129,9 +129,9 @@ def test_phase_stats_sub_phase():
     assert data[0]['type'] == 'TOTAL'
     assert data[0]['unit'] == 'us'
     assert data[0]['detail_name'] == '[SYSTEM]'
-    assert data[0]['sampling_rate_avg'] is None, 'AVG sampling rate not in expected range'
-    assert data[0]['sampling_rate_max'] is None, 'MAX sampling rate not in expected range'
-    assert data[0]['sampling_rate_95p'] is None, '95p sampling rate not in expected range'
+    assert data[0]['sampling_rate_avg'] is None
+    assert data[0]['sampling_rate_max'] is None
+    assert data[0]['sampling_rate_95p'] is None
 
 
     assert data[1]['metric'] == 'cpu_energy_rapl_msr_component'
@@ -140,9 +140,9 @@ def test_phase_stats_sub_phase():
     assert data[1]['type'] == 'TOTAL'
     assert data[1]['unit'] == 'uJ'
     assert data[1]['detail_name'] == 'Package_0'
-    assert data[1]['sampling_rate_avg'] == 100105, 'AVG sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[1]['sampling_rate_max'] == 101764, 'MAX sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[1]['sampling_rate_95p'] == 101364, '95p sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[1]['sampling_rate_avg'] == 100105 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[1]['sampling_rate_max'] == 101764 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[1]['sampling_rate_95p'] == 101364 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
 
 
     df = df_cpu_utilization.loc[df_cpu_utilization['detail_name'] == data[4]['detail_name']]
@@ -154,9 +154,9 @@ def test_phase_stats_sub_phase():
     assert data[4]['type'] == 'MEAN'
     assert data[4]['unit'] == 'Ratio'
     assert data[4]['detail_name'] == df_cpu_utilization['detail_name'].iloc[1]
-    assert data[4]['sampling_rate_avg'] == 100413, 'AVG sampling rate not in expected range'
-    assert data[4]['sampling_rate_max'] == 101708, 'MAX sampling rate not in expected range'
-    assert data[4]['sampling_rate_95p'] == 101392, '95p sampling rate not in expected range'
+    assert data[4]['sampling_rate_avg'] == 100413
+    assert data[4]['sampling_rate_max'] == 101708
+    assert data[4]['sampling_rate_95p'] == 101392
 
     df = df_cpu_utilization.loc[df_cpu_utilization['detail_name'] == data[3]['detail_name']]
     df = Tests.filter_df_runtime_subphase(df, phase_name='Stress')
@@ -167,9 +167,9 @@ def test_phase_stats_sub_phase():
     assert data[3]['type'] == 'MEAN'
     assert data[3]['unit'] == 'Ratio'
     assert data[3]['detail_name'] == df_cpu_utilization['detail_name'].iloc[0]
-    assert data[3]['sampling_rate_avg'] == 100413, 'AVG sampling rate not in expected range'
-    assert data[3]['sampling_rate_max'] == 101708, 'MAX sampling rate not in expected range'
-    assert data[3]['sampling_rate_95p'] == 101392, '95p sampling rate not in expected range'
+    assert data[3]['sampling_rate_avg'] == 100413
+    assert data[3]['sampling_rate_max'] == 101708
+    assert data[3]['sampling_rate_95p'] == 101392
 
 def test_phase_stats_multi():
     run_id = Tests.insert_run(Tests.TEST_MEASUREMENT_PHASES)
@@ -187,9 +187,9 @@ def test_phase_stats_multi():
     assert data[1]['type'] == 'TOTAL'
     assert data[1]['unit'] == 'uJ'
     assert data[1]['detail_name'] == 'Package_0'
-    assert data[1]['sampling_rate_avg'] == 99524, 'AVG sampling rate not in expected range'
-    assert data[1]['sampling_rate_max'] == 101764, 'MAX sampling rate not in expected range'
-    assert data[1]['sampling_rate_95p'] ==  100111, '95p sampling rate not in expected range'
+    assert data[1]['sampling_rate_avg'] == 99524
+    assert data[1]['sampling_rate_max'] == 101764
+    assert data[1]['sampling_rate_95p'] ==  100111
 
     assert data[3]['metric'] == 'cpu_power_rapl_msr_component'
     assert data[3]['phase'] == '004_[RUNTIME]'
@@ -197,9 +197,9 @@ def test_phase_stats_multi():
     assert data[3]['type'] == 'MEAN'
     assert data[3]['unit'] == 'mW'
     assert data[3]['detail_name'] == 'Package_0'
-    assert data[3]['sampling_rate_avg'] == 99524, 'AVG sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[3]['sampling_rate_max'] == 101764, 'MAX sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[3]['sampling_rate_95p'] ==  100111, '95p sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[3]['sampling_rate_avg'] == 99524 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[3]['sampling_rate_max'] == 101764 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[3]['sampling_rate_95p'] ==  100111 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
 
 
     assert data[2]['metric'] == 'psu_energy_ac_mcp_machine'
@@ -208,9 +208,9 @@ def test_phase_stats_multi():
     assert data[2]['type'] == 'TOTAL'
     assert data[2]['unit'] == 'uJ'
     assert data[2]['detail_name'] == '[MACHINE]'
-    assert data[2]['sampling_rate_avg'] == 99502, 'AVG sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[2]['sampling_rate_max'] == 101999, 'MAX sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[2]['sampling_rate_95p'] ==  100183, '95p sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[2]['sampling_rate_avg'] == 99502 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[2]['sampling_rate_max'] == 101999 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[2]['sampling_rate_95p'] ==  100183 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
 
     assert data[4]['metric'] == 'psu_power_ac_mcp_machine'
     assert data[4]['phase'] == '004_[RUNTIME]'
@@ -218,9 +218,9 @@ def test_phase_stats_multi():
     assert data[4]['type'] == 'MEAN'
     assert data[4]['unit'] == 'mW'
     assert data[4]['detail_name'] == '[MACHINE]'
-    assert data[4]['sampling_rate_avg'] == 99502, 'AVG sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[4]['sampling_rate_max'] == 101999, 'MAX sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
-    assert data[4]['sampling_rate_95p'] ==  100183, '95p sampling rate not in expected range' # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[4]['sampling_rate_avg'] == 99502 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[4]['sampling_rate_max'] == 101999 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
+    assert data[4]['sampling_rate_95p'] ==  100183 # hardcoded for now ... try Tests.filter_df_runtime_subphase(df_cpu_energy)['time_diff'].mean() when refactoring
 
 
 '''
@@ -248,9 +248,9 @@ def test_cpu_utilization_weighted_average_multi():
     assert data[2]['type'] == 'MEAN'
     assert data[2]['unit'] == 'Ratio'
     assert data[2]['detail_name'] == '939f410a21730a2275e91b8a949884f7f426b89e50e8b2ffceca271b6a4573b6'
-    assert data[2]['sampling_rate_avg'] == 99956, 'AVG sampling rate not in expected range'
-    assert data[2]['sampling_rate_max'] == 101708, 'MAX sampling rate not in expected range'
-    assert data[2]['sampling_rate_95p'] ==  100602, '95p sampling rate not in expected range'
+    assert data[2]['sampling_rate_avg'] == 99956
+    assert data[2]['sampling_rate_max'] == 101708
+    assert data[2]['sampling_rate_95p'] ==  100602
 
     assert data[1]['metric'] == 'cpu_utilization_cgroup_container'
     assert data[1]['phase'] == '004_[RUNTIME]'
@@ -258,9 +258,9 @@ def test_cpu_utilization_weighted_average_multi():
     assert data[1]['type'] == 'MEAN'
     assert data[1]['unit'] == 'Ratio'
     assert data[1]['detail_name'] == '38d1e484f336c40a6e60e4518915a4e385f62fdddd47994d6adcb4fb294b2ec8'
-    assert data[2]['sampling_rate_avg'] == 99956, 'AVG sampling rate not in expected range'
-    assert data[2]['sampling_rate_max'] == 101708, 'MAX sampling rate not in expected range'
-    assert data[2]['sampling_rate_95p'] ==  100602, '95p sampling rate not in expected range'
+    assert data[2]['sampling_rate_avg'] == 99956
+    assert data[2]['sampling_rate_max'] == 101708
+    assert data[2]['sampling_rate_95p'] ==  100602
 
 
 def test_phase_embodied_and_operational_carbon():
@@ -297,9 +297,9 @@ def test_phase_embodied_and_operational_carbon():
     assert embodied_carbon_share_machine['value'] == embodied_carbon_expected
     assert embodied_carbon_share_machine['type'] == 'TOTAL'
 
-    assert embodied_carbon_share_machine['sampling_rate_avg'] is None, 'AVG sampling rate not in expected range'
-    assert embodied_carbon_share_machine['sampling_rate_max'] is None, 'MAX sampling rate not in expected range'
-    assert embodied_carbon_share_machine['sampling_rate_95p'] is None, '95p sampling rate not in expected range'
+    assert embodied_carbon_share_machine['sampling_rate_avg'] is None
+    assert embodied_carbon_share_machine['sampling_rate_max'] is None
+    assert embodied_carbon_share_machine['sampling_rate_95p'] is None
 
 
 def test_phase_operational_carbon_generated_for_cpu_component():
@@ -362,7 +362,7 @@ def test_phase_operational_carbon_uses_dynamic_intensity_without_sci_i():
 
 def test_phase_stats_energy_one_measurement():
     run_id = Tests.insert_run(Tests.TEST_MEASUREMENT_PHASES)
-    df = Tests.import_cpu_energy(run_id, filename='cpu_energy_rapl_msr_component_single_measurement.log')
+    Tests.import_cpu_energy(run_id, filename='cpu_energy_rapl_msr_component_single_measurement.log')
 
     build_and_store_phase_stats(run_id)
 
@@ -376,7 +376,7 @@ def test_phase_stats_energy_one_measurement():
 
     assert data[0]['metric'] == 'cpu_energy_rapl_msr_component'
     assert data[0]['detail_name'] == 'Package_0'
-    assert data[0]['value'] == Tests.filter_df_runtime_subphase(df, hidden=False)['value'].mean()
+    assert data[0]['value'] == 412000
     assert data[0]['sampling_rate_95p'] is None
 
 def test_phase_stats_hidden_energy():
@@ -495,26 +495,26 @@ def test_phase_stats_network_procfs_manually_verifyable():
     assert data[0]['unit'] == 'us'
     assert data[0]['value'] == Tests.TEST_MEASUREMENT_DOWNLOAD_SUBPHASE_DURATION
     assert data[0]['type'] == 'TOTAL'
-    assert data[0]['sampling_rate_avg'] is None, 'AVG sampling rate not in expected range'
-    assert data[0]['sampling_rate_max'] is None, 'MAX sampling rate not in expected range'
-    assert data[0]['sampling_rate_95p'] is None, '95p sampling rate not in expected range'
+    assert data[0]['sampling_rate_avg'] is None
+    assert data[0]['sampling_rate_max'] is None
+    assert data[0]['sampling_rate_95p'] is None
 
     df = df_network_io.loc[df_network_io['detail_name'] == data[2]['detail_name']]
     assert data[2]['metric'] == 'network_total_procfs_system'
     assert data[2]['detail_name'] == 'CURRENT_ACTUAL_NETWORK_INTERFACE'
     assert data[2]['value'] == 3003 # hardcoded as readable in file
-    assert data[2]['sampling_rate_avg'] == 100000, 'AVG sampling rate not in expected range' # we fixed it manually to 100000
-    assert data[2]['sampling_rate_max'] == 100000, 'MAX sampling rate not in expected range'
-    assert data[2]['sampling_rate_95p'] == 100000, '95p sampling rate not in expected range'
+    assert data[2]['sampling_rate_avg'] == 100000 # we fixed it manually to 100000
+    assert data[2]['sampling_rate_max'] == 100000
+    assert data[2]['sampling_rate_95p'] == 100000
     assert isinstance(data[2]['sampling_rate_95p'], int)
 
     df = df_network_io.loc[df_network_io['detail_name'] == data[1]['detail_name']]
     assert data[1]['metric'] == 'network_io_procfs_system'
     assert data[1]['detail_name'] == 'CURRENT_ACTUAL_NETWORK_INTERFACE'
     assert data[1]['value'] == 10010
-    assert data[1]['sampling_rate_avg'] == 100000, 'AVG sampling rate not in expected range' # we fixed it manually to 100000
-    assert data[1]['sampling_rate_max'] == 100000, 'MAX sampling rate not in expected range'
-    assert data[1]['sampling_rate_95p'] == 100000, '95p sampling rate not in expected range'
+    assert data[1]['sampling_rate_avg'] == 100000 # we fixed it manually to 100000
+    assert data[1]['sampling_rate_max'] == 100000
+    assert data[1]['sampling_rate_95p'] == 100000
     assert isinstance(data[1]['sampling_rate_95p'], int)
 
     data = DB().fetch_all('SELECT metric, detail_name, unit, value, type, sampling_rate_avg, sampling_rate_max, sampling_rate_95p FROM phase_stats WHERE phase = %s ', params=('004_[RUNTIME]', ), fetch_mode='dict')
@@ -526,27 +526,27 @@ def test_phase_stats_network_procfs_manually_verifyable():
     assert data[0]['unit'] == 'us'
     assert data[0]['value'] == Tests.TEST_MEASUREMENT_RUNTIME_DURATION_NON_HIDDEN
     assert data[0]['type'] == 'TOTAL'
-    assert data[0]['sampling_rate_avg'] is None, 'AVG sampling rate not in expected range'
-    assert data[0]['sampling_rate_max'] is None, 'MAX sampling rate not in expected range'
-    assert data[0]['sampling_rate_95p'] is None, '95p sampling rate not in expected range'
+    assert data[0]['sampling_rate_avg'] is None
+    assert data[0]['sampling_rate_max'] is None
+    assert data[0]['sampling_rate_95p'] is None
 
 
     df = df_network_io.loc[df_network_io['detail_name'] == data[1]['detail_name']]
     assert data[1]['metric'] == 'network_total_procfs_system'
     assert data[1]['detail_name'] == 'CURRENT_ACTUAL_NETWORK_INTERFACE'
     assert data[1]['value'] == Tests.filter_df_runtime_subphase(df, hidden=False)['value'].sum()
-    assert data[1]['sampling_rate_avg'] == 100000, 'AVG sampling rate not in expected range' # we fixed it manually to 100000
-    assert data[1]['sampling_rate_max'] == 100000, 'MAX sampling rate not in expected range'
-    assert data[1]['sampling_rate_95p'] == 100000, '95p sampling rate not in expected range'
+    assert data[1]['sampling_rate_avg'] == 100000 # we fixed it manually to 100000
+    assert data[1]['sampling_rate_max'] == 100000
+    assert data[1]['sampling_rate_95p'] == 100000
     assert isinstance(data[1]['sampling_rate_95p'], int)
 
     df = df_network_io.loc[df_network_io['detail_name'] == data[3]['detail_name']]
     assert data[3]['metric'] == 'network_io_procfs_system'
     assert data[3]['detail_name'] == 'CURRENT_ACTUAL_NETWORK_INTERFACE'
     assert data[3]['value'] == 878
-    assert data[3]['sampling_rate_avg'] == 100000, 'AVG sampling rate not in expected range' # we fixed it manually to 100000
-    assert data[3]['sampling_rate_max'] == 100000, 'MAX sampling rate not in expected range'
-    assert data[3]['sampling_rate_95p'] == 100000, '95p sampling rate not in expected range'
+    assert data[3]['sampling_rate_avg'] == 100000 # we fixed it manually to 100000
+    assert data[3]['sampling_rate_max'] == 100000
+    assert data[3]['sampling_rate_95p'] == 100000
     assert isinstance(data[3]['sampling_rate_95p'], int)
 
 
@@ -565,9 +565,9 @@ def test_phase_stats_network_procfs():
     assert data[13]['metric'] == 'network_total_procfs_system'
     assert data[13]['detail_name'] == 'wlp170s0'
     assert data[13]['value'] == Tests.filter_df_runtime_subphase(df, hidden=False)['value'].sum()
-    assert data[13]['sampling_rate_avg'] == 99771, 'AVG sampling rate not in expected range'
-    assert data[13]['sampling_rate_max'] == 101780, 'MAX sampling rate not in expected range'
-    assert data[13]['sampling_rate_95p'] == 100411, '95p sampling rate not in expected range'
+    assert data[13]['sampling_rate_avg'] == 99771
+    assert data[13]['sampling_rate_max'] == 101780
+    assert data[13]['sampling_rate_95p'] == 100411
     assert isinstance(data[13]['sampling_rate_95p'], int)
 
     df = df_network_io.loc[df_network_io['detail_name'] == data[2]['detail_name']]
@@ -575,14 +575,13 @@ def test_phase_stats_network_procfs():
     assert data[2]['detail_name'] == 'br-f1a25ccf9cd0'
     assert data[2]['value'] == Tests.filter_df_runtime_subphase(df, hidden=False)['value'].sum()
 
-
     df = df_network_io.loc[df_network_io['detail_name'] == data[16]['detail_name']]
     assert data[16]['metric'] == 'network_io_procfs_system'
     assert data[16]['detail_name'] == 'docker0'
     assert data[16]['value'] == round(Tests.filter_df_runtime_subphase(df, hidden=False)['value'].sum()/Tests.TEST_MEASUREMENT_RUNTIME_DURATION_NON_HIDDEN * 1e6)
-    assert data[16]['sampling_rate_avg'] == 99771, 'AVG sampling rate not in expected range'
-    assert data[16]['sampling_rate_max'] == 101780, 'MAX sampling rate not in expected range'
-    assert data[16]['sampling_rate_95p'] == 100411, '95p sampling rate not in expected range'
+    assert data[16]['sampling_rate_avg'] == 99771
+    assert data[16]['sampling_rate_max'] == 101780
+    assert data[16]['sampling_rate_95p'] == 100411
     assert isinstance(data[16]['sampling_rate_95p'], int)
 
 

--- a/tests/test_config_opts.py
+++ b/tests/test_config_opts.py
@@ -91,68 +91,70 @@ def test_provider_disabling_working():
     # or check bc in linux / macos there is a different result set of configured providers
     assert providers == ['psu_energy_ac_sdia_machine', 'cpu_utilization_mach_system', 'psu_energy_ac_xgboost_machine', 'carbon_intensity_static_machine'] or providers == ['disk_used_statvfs_system', 'network_io_procfs_system', 'memory_used_procfs_system', 'psu_energy_ac_sdia_machine', 'cpu_utilization_procfs_system', 'psu_energy_ac_xgboost_machine', 'carbon_intensity_static_machine'], 'Network Connections provider still in configured_metric_providers' #pylint: disable=consider-using-in
 
-def test_phase_padding_inactive():
+def test_phase_padding():
     out = io.StringIO()
     err = io.StringIO()
 
-    filtered_options = {k: v for k, v in QUICK_OPTIONS.items() if k not in ('dev_no_save', ) }
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/noop.yml', phase_padding=False, **filtered_options)
+    EXPECTED_PHASE_NUMBER = 5
+
+    filtered_options = {k: v for k, v in QUICK_OPTIONS.items() if k not in ('dev_no_save', 'dev_no_metrics', 'dev_no_phase_stats') }
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/noop.yml', **filtered_options)
 
     with redirect_stdout(out), redirect_stderr(err):
         run_id = runner.run()
 
     assert '>>>> MEASUREMENT SUCCESSFULLY COMPLETED <<<<' in out.getvalue()
+
+    query = 'SELECT phases from runs WHERE id = %s '
+    phases = DB().fetch_one(query, (run_id,), fetch_mode='dict')
+
+    assert phases['phases'][EXPECTED_PHASE_NUMBER]['name'] == 'Testing Noop'
+    phase = phases['phases'][EXPECTED_PHASE_NUMBER]
+
     query = """
-            SELECT
-                time, note
-            FROM
-                notes
+            SELECT mv.value from measurement_metrics as mm
+            LEFT JOIN measurement_values mv on mv.measurement_metric_id = mm.id
             WHERE
-                run_id = %s
-            ORDER BY
-                time
+                mm.run_id = %s
+                AND mm.metric = 'psu_energy_ac_xgboost_machine'
+                AND mm.detail_name = '[MACHINE]'
+                AND mv.time > %s
+                AND mv.time < %s
+            ORDER BY mv.time ASC
             """
 
-    notes = DB().fetch_all(query, (run_id,))
+    metrics = DB().fetch_all(query, (run_id, phase['start'], phase['end']))
 
-    # we count the array from the end as depending on if the test is executed alone or in conjunction with other tests 'alpine' will get pulled and produce a note at the beginning that extends the notes
-    assert notes[-6][1] == 'Starting phase Testing Noop'
-    assert notes[-5][1] == 'Ending phase Testing Noop [UNPADDED]'
-    assert notes[-4][1] == 'Ending phase [RUNTIME] [UNPADDED]' # this implictely means we have no PADDED entries
-    assert notes[-4][0] > notes[-5][0] - 300 # end times of reconstructed runtime and last sub-runtime are very close, but not exact, bc we only reconstruct phase_stats but not measurements table. 300 microseconds is a good cutoff
-
-def test_phase_padding_active():
-    out = io.StringIO()
-    err = io.StringIO()
-
-    filtered_options = {k: v for k, v in QUICK_OPTIONS.items() if k not in ('dev_no_save', ) }
-    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/noop.yml', phase_padding=True, **filtered_options)
-
-    with redirect_stdout(out), redirect_stderr(err):
-        run_id = runner.run()
-
-    assert '>>>> MEASUREMENT SUCCESSFULLY COMPLETED <<<<' in out.getvalue()
     query = """
-            SELECT
-                time, note
-            FROM
-                notes
+            SELECT mv.value from measurement_metrics as mm
+            LEFT JOIN measurement_values mv on mv.measurement_metric_id = mm.id
             WHERE
-                run_id = %s
-            ORDER BY
-                time
+                mm.run_id = %s
+                AND mm.metric = 'psu_energy_ac_xgboost_machine'
+                AND mm.detail_name = '[MACHINE]'
+                AND mv.time >= %s
+            ORDER BY mv.time ASC
+            LIMIT 1
             """
 
-    notes = DB().fetch_all(query, (run_id,))
+    value_next_tick = DB().fetch_one(query, (run_id, phase['end']))[0]
 
-    # we count the array from the end as depending on if the test is executed alone or in conjunction with other tests 'alpine' will get pulled and produce a note at the beginning that extends the notes
-    assert notes[-9][1] == 'Starting phase Testing Noop'
-    assert notes[-8][1] == 'Ending phase Testing Noop [UNPADDED]'
-    assert notes[-7][1] == 'Ending phase Testing Noop [PADDED]'
-    FROM_MS_TO_US = 1000
-    assert notes[-7][0] - notes[-8][0] == runner._phase_padding_ms*FROM_MS_TO_US
+    metrics_sum_no_padding = 0
+    for el in metrics:
+        metrics_sum_no_padding += el[0]
 
-    assert notes[-6][1] == 'Ending phase [RUNTIME] [UNPADDED]'
+    query = """
+            SELECT value FROM phase_stats
+            WHERE run_id = %s
+            AND metric = 'psu_energy_ac_xgboost_machine'
+            AND detail_name = '[MACHINE]'
+            AND phase = %s
+            """
+
+    phase_stats = DB().fetch_all(query, (run_id, f"00{EXPECTED_PHASE_NUMBER}_{phase['name']}"))
+    assert len(phase_stats) == 1
+
+    assert phase_stats[0][0] == metrics_sum_no_padding + value_next_tick
 
 
 def test_invalid_category():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -87,17 +87,32 @@ TEST_MEASUREMENT_DURATION_RAW_H = TEST_MEASUREMENT_DURATION_RAW_S/60/60
 
 def filter_df_runtime_subphase(df, *, hidden=False, phase_name=None):
     df_list = []
-    for phase in TEST_MEASUREMENT_PHASES:
+    for idx, phase in enumerate(TEST_MEASUREMENT_PHASES):
+        next_phase_start = TEST_MEASUREMENT_PHASES[idx+1]['start'] if idx+1 < len(TEST_MEASUREMENT_PHASES) else None
         if phase_name:
             if phase['name'] == phase_name:
-                df_list.append(apply_mask(df, phase))
+                df_list.append(apply_mask(df, phase, next_phase_start))
         elif ']' not in phase['name'] and phase['hidden'] is hidden:
-            df_list.append(apply_mask(df, phase))
+            df_list.append(apply_mask(df, phase, next_phase_start))
     return pandas.concat(df_list).sort_index()
 
-def apply_mask(df, phase):
+def apply_mask(df, phase, next_phase_start=None):
     mask = df['time'].between(phase['start'], phase['end'], inclusive="neither")
     df_temp = df[mask].copy()
+
+    # mimic the 'next_one' CTE in lib/phase_stats.py, which pads the phase with
+    # the first value at or after the phase end, so sums/diffs match production.
+    # That value is only borrowed if it does not already belong to the next
+    # phase (time < next_phase_start), otherwise it would get double-counted
+    # once here and once as the next phase's own in-range value.
+    next_row_mask = df['time'] >= phase['end']
+    if next_phase_start is not None:
+        next_row_mask &= df['time'] < next_phase_start
+    next_row = df[next_row_mask].sort_values('time').head(1)
+    if not next_row.empty:
+        df_temp = pandas.concat([df_temp, next_row])
+
+    df_temp = df_temp.sort_values('time')
     df_temp['time_diff'] = df_temp['time'].diff()
     return df_temp
 


### PR DESCRIPTION
Now always on but not pad phase dura…tion but just add next sampling tick in phase_stats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Reworked phase padding so it is no longer user-configurable: phase padding is always applied by incorporating the next sampling tick when building/storing `phase_stats` (rather than padding phase duration).

- Removed `measurement.phase_padding` from persisted user capabilities (default seed + migration stripping existing user JSON).
- Removed the Phase padding UI row and stopped loading/saving the measurement checkbox.
- Removed setting validation/handling for `measurement.phase_padding` so it’s rejected as an unknown setting.
- Removed the `--no-phase-padding` CLI flag and the `phase_padding` option from `ScenarioRunner`; phase end behavior is now unconditional and uses a single “includes next tick” note.
- Updated `build_and_store_phase_stats` aggregation to compute boundary `diff` using the first timestamp at/after `phase['end']` (via a unioned `lag_table` and updated query parameters), shifting derived averages/derivatives/percentiles and sampling-rate stats.
- Updated scenario/filter test utilities to support boundary padding via `next_phase_start`.
- Refreshed/rewrote tests: removed the old active/inactive phase-padding cases and added a consolidated `test_phase_padding`, plus adjusted expected sampling-rate values and related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->