### PR TITLE
(feat): CPU undersampling gated by not allowing more than 10ms sampling rate

### DIFF
--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -159,7 +159,7 @@ runs:
           TEST_PATH="${DEFAULT_TEST_PATH}"
         fi
 
-        python3 -m ${{ inputs.tests-command }} "${TEST_PATH}" -rA | tee /tmp/test-results.txt
+        python3 -m ${{ inputs.tests-command }} ${TEST_PATH} -rA | tee /tmp/test-results.txt
 
     - name: Display Results
       shell: bash

--- a/lib/c/gmt-lib.c
+++ b/lib/c/gmt-lib.c
@@ -75,6 +75,37 @@ double parse_double(char *argument) {
     return number;
 }
 
+// Minimum allowed sampling interval, derived from the kernel's clock tick rate.
+// /proc/stat counters are only updated once per tick (USER_HZ, typically 100Hz
+// on Linux == 10ms per tick). Sampling faster than this can result in two reads
+// landing within the same tick, producing a zero delta and a division by zero
+// (SIGFPE) in providers that compute a ratio from consecutive /proc/stat reads.
+unsigned int get_min_sleep_time_ms(void) {
+    long ticks_per_sec = sysconf(_SC_CLK_TCK);
+    if (ticks_per_sec <= 0) {
+        fprintf(stderr, "Error - could not determine kernel clock tick rate via sysconf(_SC_CLK_TCK)\n");
+        exit(1);
+    }
+    // ms per tick, rounded up so we never accept an interval that could
+    // legitimately produce a zero-delta read
+    return (unsigned int)((1000 + ticks_per_sec - 1) / ticks_per_sec);
+}
+
+// Rejects sampling intervals faster than the kernel updates /proc/stat.
+// Otherwise two consecutive reads can land in the same tick, producing a
+// zero total delta and a division-by-zero (SIGFPE) further down the line.
+void validate_min_sleep_time(unsigned int msleep_time, unsigned int min_msleep_time_ms) {
+    if (msleep_time < min_msleep_time_ms) {
+        fprintf(stderr,
+            "Error - requested sampling interval (%u ms) is below the kernel's "
+            "clock tick period (%u ms). /proc/stat is only updated once per tick, "
+            "so sampling faster than this can produce a zero-delta read and crash "
+            "with a division by zero. Use -i %u or higher.\n",
+            msleep_time, min_msleep_time_ms, min_msleep_time_ms);
+        exit(1);
+    }
+}
+
 void get_time_offset(struct timespec *offset) {
     struct timespec realtime, monotonic;
 

--- a/lib/c/gmt-lib.h
+++ b/lib/c/gmt-lib.h
@@ -11,6 +11,8 @@ double parse_double(char *argument);
 void get_time_offset(struct timespec *offset);
 void get_adjusted_time(struct timeval *adjusted, struct timespec *offset);
 bool is_partition_sysfs(unsigned int major_number, unsigned int minor_number);
+unsigned int get_min_sleep_time_ms(void);
+void validate_min_sleep_time(unsigned int msleep_time, unsigned int min_msleep_time_ms);
 
 
 #endif // GMT_LIB_H

--- a/metric_providers/cpu/utilization/cgroup/container/source.c
+++ b/metric_providers/cpu/utilization/cgroup/container/source.c
@@ -19,6 +19,7 @@ static int user_id = -1;
 static long int user_hz;
 static unsigned int msleep_time=1000;
 static struct timespec offset;
+static unsigned int min_msleep_time_ms = 0;
 
 static long int read_cpu_proc(char* path, int mode) {
     FILE* fd = fopen(path, "r");
@@ -142,6 +143,7 @@ int main(int argc, char **argv) {
     setvbuf(stdout, NULL, _IONBF, 0);
     user_hz = sysconf(_SC_CLK_TCK);
     user_id = getuid();
+    min_msleep_time_ms = get_min_sleep_time_ms(); // must run before we validate -i
 
     static struct option long_options[] =
     {
@@ -158,7 +160,8 @@ int main(int argc, char **argv) {
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
             printf("\t-s      : string of container IDs or cgroup names separated by comma\n");
-            printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n\n");
+            printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
+            printf("\t          (must be >= kernel tick period, currently %u ms)\n\n", min_msleep_time_ms);
             printf("\t-c      : check system and exit\n");
             printf("\n");
 
@@ -171,6 +174,7 @@ int main(int argc, char **argv) {
             resolution = res.tv_sec + (((double)res.tv_nsec)/1.0e9);
             printf("\tSystemHZ\t%ld\n", (unsigned long)(1/resolution + 0.5));
             printf("\tCLOCKS_PER_SEC\t%ld\n", CLOCKS_PER_SEC);
+            printf("\tMinSampleMS\t%u\n", min_msleep_time_ms);
             exit(0);
         case 'i':
             msleep_time = parse_int(optarg);
@@ -198,6 +202,8 @@ int main(int argc, char **argv) {
         check_path("/proc/stat");
         exit(check_path("/sys/fs/cgroup/cpu.stat"));
     }
+
+    validate_min_sleep_time(msleep_time, min_msleep_time_ms);
 
     get_time_offset(&offset);
 

--- a/metric_providers/cpu/utilization/procfs/system/source.c
+++ b/metric_providers/cpu/utilization/procfs/system/source.c
@@ -34,6 +34,7 @@ typedef struct procfs_time_t { // struct is a specification and this static make
 // not pollute another threads state
 static unsigned int msleep_time=1000;
 static struct timespec offset;
+static unsigned int min_msleep_time_ms = 0;
 
 static void read_cpu_proc(procfs_time_t* procfs_time_struct) {
 
@@ -84,7 +85,8 @@ static void output_stats() {
     // printf("%ld%06ld %f\n", now.tv_sec, now.tv_usec, (double)compute_time_reading / (double)(compute_time_reading+idle_reading));
 
     // main output to Stdout
-    printf("%ld%06ld %ld\n", now.tv_sec, now.tv_usec, (compute_time_reading*10000) / (compute_time_reading+non_compute_reading) ); // Deliberate integer conversion. Precision with 0.01% is good enough
+    double utilization_reading = ((double)compute_time_reading * 10000.0) / (double)(compute_time_reading+non_compute_reading);
+    printf("%ld%06ld %ld\n", now.tv_sec, now.tv_usec, (long)utilization_reading ); // Deliberate integer conversion. Precision with 0.01% is good enough
 }
 
 int main(int argc, char **argv) {
@@ -94,12 +96,15 @@ int main(int argc, char **argv) {
 
     setvbuf(stdout, NULL, _IONBF, 0);
 
+    min_msleep_time_ms = get_min_sleep_time_ms(); // must run before we validate -i
+
     while ((c = getopt (argc, argv, "i:hc")) != -1) {
         switch (c) {
         case 'h':
             printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
             printf("\t-h      : displays this help\n");
             printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
+            printf("\t          (must be >= kernel tick period, currently %u ms)\n", min_msleep_time_ms);
             printf("\t-c      : check system and exit\n");
             printf("\n");
 
@@ -111,6 +116,7 @@ int main(int argc, char **argv) {
             resolution = res.tv_sec + (((double)res.tv_nsec)/1.0e9);
             printf("\tSystemHZ\t%ld\n", (unsigned long)(1/resolution + 0.5));
             printf("\tCLOCKS_PER_SEC\t%ld\n", CLOCKS_PER_SEC);
+            printf("\tMinSampleMS\t%u\n", min_msleep_time_ms);
             exit(0);
         case 'i':
             msleep_time = parse_int(optarg);
@@ -127,6 +133,8 @@ int main(int argc, char **argv) {
     if(check_system_flag){
         exit(check_path("/proc/stat"));
     }
+
+    validate_min_sleep_time(msleep_time, min_msleep_time_ms);
 
     get_time_offset(&offset);
 


### PR DESCRIPTION


The issue was the average done on the values, not the sampling per-se.

When averaging over a 10ms timespan which we sampled at 1 ms we will always have 9 empty frames. Only one is meaningful. However this frame if carrying the info of being 100% utilization will then only be accounted for one frame. This means we average-away a lot of utilization by mapping it to a shorter timeframe than it actually happened in.

The best way to solve this is to clamp to 10 ms max