### PR TITLE
Upgrading postgres memory parameters to 8 GB reasonable machine

### DIFF
--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -27,8 +27,10 @@ services:
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-      -c work_mem=16MB
       -c timezone=__TZ__
+      -c shared_buffers=1.2GB
+      -c work_mem=256MB
+      -c maintenance_work_mem=1GB
       -p 9573
 # This option can potentially speed up big queries: https://www.twilio.com/blog/sqlite-postgresql-complicated
   green-coding-nginx:

--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -29,7 +29,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
       -c timezone=__TZ__
       -c shared_buffers=1.2GB
-      -c work_mem=256MB
+      -c work_mem=32MB
       -c maintenance_work_mem=1GB
       -p 9573
 # This option can potentially speed up big queries: https://www.twilio.com/blog/sqlite-postgresql-complicated

--- a/lib/db.py
+++ b/lib/db.py
@@ -94,12 +94,13 @@ class DB:
         # pylint: disable=consider-using-f-string
 
         self._pool = ConnectionPool(
-            "user=%s password=%s host=%s port=%s dbname=%s sslmode=require" % (
+            "user=%s password=%s host=%s port=%s dbname=%s sslmode=require options='%s'" % (
                 config['postgresql']['user'],
                 config['postgresql']['password'],
                 config['postgresql']['host'],
                 config['postgresql']['port'],
                 config['postgresql']['dbname'],
+                ' '.join(config['postgresql'].get('options', []))
             ),
             min_size=1,
             max_size=2,


### PR DESCRIPTION
After running GMT in production for a while we see that some background jobs experience strong memory pressure and makes query partials spill to disk.

This PR addresses this by migrating from mini-developer-machine defaults to reasonable 8 GB dedicated defaults.

We assume every developer machine nowadays has at least 8 GB of memory and is not fully saturated when running GMT. Thus these configs should work everywhere out of the box and provide more long-term stability when deploying GMT in cluster mode without ever tuning configs by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Increased PostgreSQL memory settings in `docker/compose.yml.example` for 8 GB machines.
- Updated `shared_buffers`, `work_mem`, and `maintenance_work_mem` to reduce disk spills and improve background job stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->