### PR TITLE
(rework): CarbonDB worker jobs now use 60 day window; Optimized backfill queries

### DIFF
--- a/cron/backfill_carbon_intensity.py
+++ b/cron/backfill_carbon_intensity.py
@@ -9,8 +9,6 @@ import os
 import json
 import fcntl
 
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-
 import requests
 from cachetools import cached
 
@@ -26,20 +24,27 @@ from lib.cache_definitions import NoNoneOrNegativeValuesCache
 
 def process(table):
 
-    print(f"Current rows in DB where {table}.carbon_intensity_g is missing in last 30 Minutes", fetch_carbon_intensity_missing(table, count_only=True))
+    data = fetch_carbon_intensity_missing(table)
+    print(f"Rows in DB where {table}.carbon_intensity_g is missing in last 30 Minutes:", len(data))
 
-    updated_rows = update_carbon_intensity_from_db_cache(table)
+    if not data:
+        return
 
+    ids = [row[0] for row in data]
+
+    updated_rows = update_carbon_intensity_from_db_cache(table, ids)
     print('Updated rows', updated_rows)
 
-    print(f"Rows after db cached update where {table}.carbon_intensity_g is missing in last 30 Minutes", fetch_carbon_intensity_missing(table, count_only=True))
+    updated_ids = {row[0] for row in updated_rows}
+    remaining_data = [row for row in data if row[0] not in updated_ids]
 
-    data = fetch_carbon_intensity_missing(table)
-    backfill_carbon_intensity_missing(table, data)
+    print(f"Rows left after db cached update where {table}.carbon_intensity_g is missing in last 30 Minutes:", len(remaining_data))
 
-    print(f"Rows left after manual row-level update where {table}.carbon_intensity_g is missing in last 30 Minutes", fetch_carbon_intensity_missing(table, count_only=True))
+    backfill_carbon_intensity_missing(table, remaining_data)
 
-def update_carbon_intensity_from_db_cache(table):
+    print(f"Rows manually backfilled where {table}.carbon_intensity_g was missing in last 30 Minutes:", len(remaining_data))
+
+def update_carbon_intensity_from_db_cache(table, ids):
     # Backfilled carbon intensity data should only be 30 minutes apart
     query = f"""
         WITH carbon_missing AS (
@@ -51,11 +56,10 @@ def update_carbon_intensity_from_db_cache(table):
               ON ci.latitude = from_table.latitude
              AND ci.longitude = from_table.longitude
              AND ABS(EXTRACT(EPOCH FROM (from_table.created_at - ci.created_at::timestamp))) < EXTRACT(EPOCH FROM INTERVAL '30 MINUTES')
-            WHERE from_table.carbon_intensity_g IS NULL
+            WHERE from_table.id = ANY(%s)
             ORDER BY
                 from_table.id,
                 ABS(EXTRACT(EPOCH FROM (from_table.created_at - ci.created_at::timestamp))) ASC
-            LIMIT 1
         )
         UPDATE {table} from_table
         SET carbon_intensity_g = cm.carbon_intensity_g
@@ -65,16 +69,11 @@ def update_carbon_intensity_from_db_cache(table):
             AND cm.carbon_intensity_g IS NOT NULL
         RETURNING from_table.id, from_table.carbon_intensity_g;
     """
-    return DB().fetch_all(query)
+    return DB().fetch_all(query, params=(ids,))
 
-def fetch_carbon_intensity_missing(table, count_only=False):
-    if count_only:
-        selection = 'COUNT(*)'
-    else:
-        selection = 'id, latitude, longitude'
-
+def fetch_carbon_intensity_missing(table):
     query = f"""
-        SELECT {selection}
+        SELECT id, latitude, longitude
         FROM {table}
         WHERE
             carbon_intensity_g is NULL

--- a/cron/backfill_geo.py
+++ b/cron/backfill_geo.py
@@ -26,20 +26,27 @@ from lib.cache_definitions import NoNoneOrNegativeValuesCache
 
 def process(table):
 
-    print(f"Current rows in DB where {table}.lat/lon is missing in last 30 days", fetch_geo_missing(table, count_only=True))
+    data = fetch_geo_missing(table)
+    print(f"Rows in DB where {table}.lat/lon is missing in last 30 days:", len(data))
 
-    updated_rows = update_geo_from_db_cache(table)
+    if not data:
+        return
 
+    ids = [row[0] for row in data]
+
+    updated_rows = update_geo_from_db_cache(table, ids)
     print('Updated rows', updated_rows)
 
-    print(f"Rows after db cached update where {table}.lat/lon is missing in last 30 days", fetch_geo_missing(table, count_only=True))
+    updated_ids = {row[0] for row in updated_rows}
+    remaining_data = [row for row in data if row[0] not in updated_ids]
 
-    data = fetch_geo_missing(table)
-    backfill_geo_missing(table, data)
+    print(f"Rows left after db cached update where {table}.lat/lon is missing in last 30 days:", len(remaining_data))
 
-    print(f"Rows left after manual row-level update where {table}.lat/lon is missing in last 30 days", fetch_geo_missing(table, count_only=True))
+    backfill_geo_missing(table, remaining_data)
 
-def update_geo_from_db_cache(table):
+    print(f"Rows manually backfilled where {table}.lat/lon was missing in last 30 days:", len(remaining_data))
+
+def update_geo_from_db_cache(table, ids):
     query = f"""
         WITH geo_missing AS (
             SELECT DISTINCT ON (from_table.id)
@@ -52,8 +59,7 @@ def update_geo_from_db_cache(table):
                   ip.ip_address = from_table.ip_address
                   AND ABS(EXTRACT(EPOCH FROM (from_table.created_at - ip.created_at::timestamp))) < EXTRACT(EPOCH FROM INTERVAL '30 DAYS')
             WHERE
-                (from_table.latitude IS NULL OR from_table.longitude IS NULL)
-                AND (from_table.carbon_intensity_g IS NULL) -- indicates it is not user set
+                from_table.id = ANY(%s)
             ORDER BY
                 from_table.id,
                 ABS(EXTRACT(EPOCH FROM (from_table.created_at - ip.created_at::timestamp))) ASC
@@ -66,25 +72,19 @@ def update_geo_from_db_cache(table):
         WHERE from_table.id = gm.id
           AND gm.latitude IS NOT NULL
           AND gm.longitude IS NOT NULL
-        RETURNING from_table.id, from_table.latitude, from_table.longitude;
+        RETURNING from_table.id;
     """
 
-    return DB().fetch_all(query)
+    return DB().fetch_all(query, params=(ids,))
 
-def fetch_geo_missing(table, count_only=False):
-
-    if count_only:
-        selection = 'COUNT(*)'
-    else:
-        selection = 'id, ip_address'
-
+def fetch_geo_missing(table):
     query = f"""
-        SELECT {selection}
+        SELECT id, ip_address
         FROM {table} as from_table
         WHERE
             (from_table.longitude is NULL OR from_table.latitude IS NULL)
             AND from_table.carbon_intensity_g IS NULL -- indicates it is not user set
-            AND from_table.ip_address IS NOT NULL
+            AND from_table.ip_address IS NOT NULL -- needed to ignore carbondb data rows copied from scenario runner which never have an ip address
             AND created_at > NOW() - INTERVAL '30 DAYS'
     """
     data = DB().fetch_all(query)

--- a/cron/carbondb_compress.py
+++ b/cron/carbondb_compress.py
@@ -83,7 +83,7 @@ def compress_carbondb_raw():
         DROP TABLE IF EXISTS carbondb_data_raw_tmp;
 
         CREATE TEMPORARY TABLE carbondb_data_raw_tmp AS
-        SELECT * FROM carbondb_data_raw WHERE time > EXTRACT(EPOCH FROM NOW() - INTERVAL '60 days');;
+        SELECT * FROM carbondb_data_raw WHERE time > EXTRACT(EPOCH FROM ((NOW() - INTERVAL '60 days')::date::timestamp))*1e6; -- Time filter must be starting from midnight and not include elapsed minutes in the day to work with select later which cuts off time info
 
         UPDATE carbondb_data_raw_tmp AS cdrt
         SET "type" = s.id

--- a/cron/carbondb_compress.py
+++ b/cron/carbondb_compress.py
@@ -83,7 +83,7 @@ def compress_carbondb_raw():
         DROP TABLE IF EXISTS carbondb_data_raw_tmp;
 
         CREATE TEMPORARY TABLE carbondb_data_raw_tmp AS
-        SELECT * FROM carbondb_data_raw;
+        SELECT * FROM carbondb_data_raw WHERE time > EXTRACT(EPOCH FROM NOW() - INTERVAL '60 days');;
 
         UPDATE carbondb_data_raw_tmp AS cdrt
         SET "type" = s.id

--- a/cron/carbondb_copy_over_and_remove_duplicates.py
+++ b/cron/carbondb_copy_over_and_remove_duplicates.py
@@ -141,8 +141,7 @@ def remove_duplicates():
             AND a.energy_kwh = b.energy_kwh
             AND a.carbon_kg = b.carbon_kg
             AND a.user_id = b.user_id
-            AND a.created_at > NOW() - INTERVAL '60 DAYS' -- 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days. In case this is reduced choose at least 31 days to avoid race conditions
-            AND b.created_at > NOW() - INTERVAL '60 DAYS' -- 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days. In case this is reduced choose at least 31 days to avoid race conditions
+            AND a.time > EXTRACT(EPOCH FROM ((NOW() - INTERVAL '60 days')::date::timestamp))*1e6 -- 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days. In case this is reduced choose at least 31 days to avoid race conditions - Time filter must be starting from midnight and not include elapsed minutes in the day to work with copy over which cuts off time info
     ''')
 
 

--- a/cron/carbondb_copy_over_and_remove_duplicates.py
+++ b/cron/carbondb_copy_over_and_remove_duplicates.py
@@ -8,7 +8,7 @@ from lib.db import DB
 from lib import error_helpers
 
 
-def copy_over_power_hog(interval=30): # 30 days is the merge window. Until then we allow old data to arrive
+def copy_over_power_hog(interval=60): # 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days
     params = []
     query = '''
         INSERT INTO carbondb_data_raw
@@ -38,7 +38,7 @@ def copy_over_power_hog(interval=30): # 30 days is the merge window. Until then 
     DB().query(query, params=params)
 
 
-def copy_over_eco_ci(interval=30): # 30 days is the merge window. Until then we allow old data to arrive
+def copy_over_eco_ci(interval=60): # 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days
     params = []
     query = '''
         INSERT INTO carbondb_data_raw
@@ -67,7 +67,7 @@ def copy_over_eco_ci(interval=30): # 30 days is the merge window. Until then we 
 
     DB().query(query, params=params)
 
-def copy_over_scenario_runner(interval=30): # 30 days is the merge window. Until then we allow old data to arrive
+def copy_over_scenario_runner(interval=60): # 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days
     params = []
     query = '''
         INSERT INTO carbondb_data_raw
@@ -118,7 +118,7 @@ def validate_table_constraints():
             OR machine IS NULL
             OR source IS NULL
             OR tags IS NULL)
-            AND created_at > NOW() - INTERVAL '31 DAYS' -- interval + 1 day to avoid race condition
+            AND created_at > NOW() - INTERVAL '60 DAYS' -- 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days. In case this is reduced choose at least 31 days to avoid race conditions
             AND created_at < NOW() - INTERVAL '30 MINUTES' -- data just arrived can be null, before it is backfilled
      ''')
 
@@ -141,8 +141,8 @@ def remove_duplicates():
             AND a.energy_kwh = b.energy_kwh
             AND a.carbon_kg = b.carbon_kg
             AND a.user_id = b.user_id
-            AND a.created_at > NOW() - INTERVAL '31 DAYS' -- interval + 1 day to avoid race condition
-            AND b.created_at > NOW() - INTERVAL '31 DAYS' -- interval + 1 day to avoid race condition
+            AND a.created_at > NOW() - INTERVAL '60 DAYS' -- 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days. In case this is reduced choose at least 31 days to avoid race conditions
+            AND b.created_at > NOW() - INTERVAL '60 DAYS' -- 30 days is the merge window. Until then we allow old data to arrive. But we copy a larger timespan in case server errors happend or the job did not run for a couple of days. In case this is reduced choose at least 31 days to avoid race conditions
     ''')
 
 

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -671,6 +671,7 @@ CREATE TABLE carbondb_data_raw (
     updated_at timestamp with time zone
 );
 
+CREATE INDEX carbondb_data_raw_time_type_user_idx ON carbondb_data_raw (time, type, user_id);
 CREATE INDEX "carbondb_data_raw_backfill_geo" ON "carbondb_data_raw"("latitude","longitude","carbon_intensity_g","created_at");
 
 CREATE TRIGGER carbondb_data_raw_moddatetime

--- a/docker/structure.sql
+++ b/docker/structure.sql
@@ -478,7 +478,12 @@ CREATE TABLE ci_measurements (
     updated_at timestamp with time zone
 );
 CREATE INDEX "ci_measurements_subselect" ON ci_measurements(repo, branch, workflow_id, created_at);
-CREATE INDEX "ci_measurements_backfill_geo" ON "ci_measurements"("latitude","longitude","carbon_intensity_g","created_at");
+
+CREATE INDEX ci_measurements_missing_lon ON ci_measurements (created_at)
+    WHERE longitude IS NULL AND carbon_intensity_g IS NULL; -- partial index only for backfill geo
+
+CREATE INDEX ci_measurements_missing_lat ON ci_measurements (created_at)
+    WHERE latitude IS NULL AND carbon_intensity_g IS NULL; -- partial index only for backfill geo
 
 CREATE TRIGGER ci_measurements_moddatetime
     BEFORE UPDATE ON ci_measurements
@@ -727,7 +732,11 @@ CREATE TABLE hog_simplified_measurements (
 CREATE INDEX idx_measurements_user_id ON hog_simplified_measurements(user_id);
 CREATE INDEX idx_measurements_timestamp ON hog_simplified_measurements(timestamp);
 CREATE INDEX idx_measurements_machine_uuid ON hog_simplified_measurements(machine_uuid);
-CREATE INDEX "hog_simplified_measurements_backfill_geo" ON "hog_simplified_measurements"("latitude","longitude","carbon_intensity_g","created_at");
+CREATE INDEX hog_simplified_measurements_missing_lon ON hog_simplified_measurements (created_at)
+    WHERE longitude IS NULL AND carbon_intensity_g IS NULL; -- partial index only for backfill geo
+
+CREATE INDEX hog_simplified_measurements_missing_lat ON hog_simplified_measurements (created_at)
+    WHERE latitude IS NULL AND carbon_intensity_g IS NULL; -- partial index only for backfill geo
 
 
 CREATE TABLE hog_top_processes (


### PR DESCRIPTION
We are now using a 60 day window as we have seen errors when processing carbondb sometimes when backfill apis are not available for longer than 24 hours.

to not miss data while copying and compressing we now add an internal 30 buffer / grace period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Expands CarbonDB backfill/processing windows from ~24 hours to **60 days** and uses a **30-day grace/buffer** to prevent missing data when backfill/copy APIs lag.
- Refactors **carbon intensity** and **geo** backfills into a two-phase flow: run **DB-cache updates** for a computed set of missing rows, then manually fill only the **remaining** rows still missing values.
- Optimizes backfill queries by passing **explicit row ID lists** into cached update helpers (and simplifying the “missing” fetch helpers accordingly) rather than relying on broader null filters.
- Limits **compression** and related transformations to the **last 60 days** by changing the source query to a 60-day time window.
- Widens CarbonDB copy/merge/dedup operations to the **60-day** window (function defaults, constraint validation, and dedup cutoff logic updated).
- Updates `docker/structure.sql` with **new/adjusted indexes**, including partial indexes for missing geo backfills and a new `carbondb_data_raw(time, type, user_id)` index to improve performance (including compression-related access patterns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->