### PR TITLE
(rework): Fronted moved away from async and moved to real threads

### DIFF
--- a/api/carbondb.py
+++ b/api/carbondb.py
@@ -12,11 +12,11 @@ from lib.db import DB
 router = APIRouter()
 
 @router.post('/v1/carbondb/add')
-async def add_carbondb_deprecated():
+def add_carbondb_deprecated():
     return Response("This endpoint is not supported anymore. Please migrate to /v2/carbondb/add !", status_code=410)
 
 @router.post('/v2/carbondb/add')
-async def add_carbondb(
+def add_carbondb(
     request: Request,
     energydata: EnergyData,
     user: User = Depends(authenticate) # pylint: disable=unused-argument
@@ -31,11 +31,11 @@ async def add_carbondb(
 
 
 @router.get('/v1/carbondb/')
-async def get_carbondb_deprecated():
+def get_carbondb_deprecated():
     return Response("This endpoint is not supported anymore. Please migrate to /v2/carbondb/ !", status_code=410)
 
 @router.get('/v2/carbondb')
-async def carbondb_get(
+def carbondb_get(
     user: User = Depends(authenticate),
     start_date: date | None = None, end_date: date | None = None,
     tags_include: str | None = None, tags_exclude: str | None = None,
@@ -173,7 +173,7 @@ async def carbondb_get(
 
 
 @router.get('/v2/carbondb/filters')
-async def carbondb_get_filters(
+def carbondb_get_filters(
     user: User = Depends(authenticate)
     ):
 
@@ -191,7 +191,7 @@ async def carbondb_get_filters(
     return CustomORJSONResponse({'success': True, 'data': {'types': results['types'], 'tags': results['tags'], 'machines': results['machines'], 'projects': results['projects'], 'sources': results['sources'], 'users': visible_users}})
 
 @router.get('/v1/carbondb/insights')
-async def get_insights(user: User = Depends(authenticate)):
+def get_insights(user: User = Depends(authenticate)):
 
     query = '''
             SELECT COUNT(id), DATE(MIN(date))

--- a/api/eco_ci.py
+++ b/api/eco_ci.py
@@ -113,7 +113,7 @@ def old_v1_measurement_add_endpoint():
 
 
 @router.post('/v2/ci/measurement/add')
-async def post_ci_measurement_add(
+def post_ci_measurement_add(
     request: Request,
     measurement: CI_Measurement,
     user: User = Depends(authenticate)  # pylint: disable=unused-argument
@@ -124,7 +124,7 @@ async def post_ci_measurement_add(
     return _insert_ci_measurement(request, measurement, user)
 
 @router.post('/v3/ci/measurement/add')
-async def post_ci_measurement_add_v3(
+def post_ci_measurement_add_v3(
     request: Request,
     measurement: CI_MeasurementV3,
     user: User = Depends(authenticate)  # pylint: disable=unused-argument
@@ -137,7 +137,7 @@ async def post_ci_measurement_add_v3(
 
 
 @router.get('/v1/ci/measurements')
-async def get_ci_measurements(repo: str, branch: str, workflow: str, start_date: date, end_date: date, job_id: str | None = None, user: User = Depends(authenticate)):
+def get_ci_measurements(repo: str, branch: str, workflow: str, start_date: date, end_date: date, job_id: str | None = None, user: User = Depends(authenticate)):
 
     params = [user.is_super_user(), user.visible_users(), repo, branch, workflow, str(start_date), str(end_date)]
 
@@ -173,7 +173,7 @@ async def get_ci_measurements(repo: str, branch: str, workflow: str, start_date:
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @router.get('/v1/ci/stats')
-async def get_ci_stats(repo: str, branch: str, workflow: str, start_date: date, end_date: date, user: User = Depends(authenticate)):
+def get_ci_stats(repo: str, branch: str, workflow: str, start_date: date, end_date: date, user: User = Depends(authenticate)):
 
 
     query = '''
@@ -234,7 +234,7 @@ async def get_ci_stats(repo: str, branch: str, workflow: str, start_date: date, 
 
 
 @router.get('/v1/ci/repositories')
-async def get_ci_repositories(repo: str | None = None, sort_by: str = 'name', user: User = Depends(authenticate)):
+def get_ci_repositories(repo: str | None = None, sort_by: str = 'name', user: User = Depends(authenticate)):
 
     query = '''
         SELECT repo, source, MAX(created_at) as last_run
@@ -262,7 +262,7 @@ async def get_ci_repositories(repo: str | None = None, sort_by: str = 'name', us
     return CustomORJSONResponse({'success': True, 'data': data}) # no escaping needed, as it happend on ingest
 
 @router.get('/v1/ci/runs')
-async def get_ci_runs(repo: str, user: User = Depends(authenticate)):
+def get_ci_runs(repo: str, user: User = Depends(authenticate)):
 
 
     query = '''
@@ -294,7 +294,7 @@ async def get_ci_runs(repo: str, user: User = Depends(authenticate)):
 ## User 1 restricted to only this route but a fully populated 'visible_users' array
 @router.head('/v1/ci/badge/get')
 @router.get('/v1/ci/badge/get')
-async def get_ci_badge_get(repo: str, branch: str, workflow:str, mode: str = 'last', metric: str = 'energy', duration_days: int | None = None, unit: str = 'watt-hours', user: User = Depends(authenticate)):
+def get_ci_badge_get(repo: str, branch: str, workflow:str, mode: str = 'last', metric: str = 'energy', duration_days: int | None = None, unit: str = 'watt-hours', user: User = Depends(authenticate)):
     if metric == 'energy':
         metric = 'energy_uj'
         metric_unit = 'uJ'
@@ -372,7 +372,7 @@ async def get_ci_badge_get(repo: str, branch: str, workflow:str, mode: str = 'la
 
 
 @router.get('/v1/ci/insights')
-async def get_insights(user: User = Depends(authenticate)):
+def get_insights(user: User = Depends(authenticate)):
 
     query = '''
             SELECT COUNT(id), DATE(MIN(created_at))

--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Request, Response, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 
 from starlette.responses import RedirectResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -101,6 +102,11 @@ app.add_middleware(
     allow_headers=['*'],
 )
 
+# Compresses JSON bodies over the wire (compare/timeline/phase_stats responses can run into the
+# hundreds of KB). Below minimum_size the gzip framing overhead outweighs any savings, so small
+# responses (e.g. Depends-only 202/204s) pass through uncompressed.
+app.add_middleware(GZipMiddleware, minimum_size=1000)
+
 def obfuscate_authentication_token(headers: StarletteHeaders):
     headers_mut = headers.mutablecopy()
     if 'x-authentication' in headers_mut:
@@ -153,11 +159,11 @@ async def robots_txt():
 
 # Read your own authentication token. Used by AJAX requests to test if token is valid and save it in local storage
 @app.get('/v1/user/settings')
-async def get_user_settings(user: User = Depends(authenticate)):
+def get_user_settings(user: User = Depends(authenticate)):
     return CustomORJSONResponse({'success': True, 'data': user.to_dict()})
 
 @app.put('/v1/user/setting')
-async def update_user_setting(setting: UserSetting, user: User = Depends(authenticate)):
+def update_user_setting(setting: UserSetting, user: User = Depends(authenticate)):
 
     try:
         user.change_setting(setting.name, setting.value)
@@ -167,7 +173,7 @@ async def update_user_setting(setting: UserSetting, user: User = Depends(authent
     return Response(status_code=202) # No-Content
 
 @app.get('/v1/cluster/status')
-async def get_cluster_status(
+def get_cluster_status(
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
     user: User = Depends(authenticate) # pylint: disable=unused-argument
     ):
@@ -187,7 +193,7 @@ async def get_cluster_status(
 
 
 @app.get('/v1/cluster/status/history')
-async def get_cluster_status_history(
+def get_cluster_status_history(
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
     user: User = Depends(authenticate) # pylint: disable=unused-argument
     ):
@@ -205,7 +211,7 @@ async def get_cluster_status_history(
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @app.get('/v1/cluster/changelog')
-async def get_cluster_changelog(
+def get_cluster_changelog(
     machine_id: int | None = None,
     start_date: date | None = None,
     end_date: date | None = None,
@@ -256,7 +262,7 @@ async def get_cluster_changelog(
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @app.get('/v1/system-logs')
-async def get_system_logs(
+def get_system_logs(
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
     user: User = Depends(authenticate) # pylint: disable=unused-argument
     ):
@@ -270,7 +276,7 @@ async def get_system_logs(
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @app.put('/v1/system-log')
-async def update_system_log(
+def update_system_log(
     log: SystemLogDelete,
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
     user: User = Depends(authenticate), # pylint: disable=unused-argument

--- a/api/power_hog.py
+++ b/api/power_hog.py
@@ -23,7 +23,7 @@ def old_v1_hog_add_endpoint():
     return CustomORJSONResponse({'success': False, 'err': 'This endpoint is deprecated. Please migrate to /v2/hog/add'}, status_code=410)
 
 @router.post('/v2/hog/add')
-async def add_hog(
+def add_hog(
     request: Request,
     measurements: List[HogMeasurement],
     user: User = Depends(authenticate) # pylint: disable=unused-argument
@@ -130,7 +130,7 @@ async def add_hog(
     return Response(status_code=202)
 
 @router.get('/v2/hog/top_processes')
-async def hog_get_top_processes():
+def hog_get_top_processes():
     query = """
         SELECT
             name,
@@ -158,7 +158,7 @@ async def hog_get_top_processes():
 
 
 @router.get('/v2/hog/details')
-async def user_detail(
+def user_detail(
     user: User = Depends(authenticate),
     start_date: date | None = None,
     end_date: date | None = None,
@@ -273,7 +273,7 @@ async def user_detail(
 
 
 @router.get('/v1/hog/insights')
-async def get_insights(user: User = Depends(authenticate)):
+def get_insights(user: User = Depends(authenticate)):
 
     query = '''
             SELECT COUNT(id), DATE(MIN(created_at))

--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -95,7 +95,7 @@ def parse_carbon_simulation(carbon_simulation):
 
 # Return a list of all known machines in the cluster
 @router.get('/v1/machines')
-async def get_machines(
+def get_machines(
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
     user: User = Depends(authenticate), # pylint: disable=unused-argument
     ):
@@ -112,7 +112,7 @@ def old_v1_jobs_endpoint():
 
 
 @router.get('/v2/jobs')
-async def get_jobs(
+def get_jobs(
     machine_id: int | None = None,
     state: str | None = None,
     job_id: int | None = None,
@@ -161,7 +161,7 @@ async def get_jobs(
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @router.put('/v1/job')
-async def update_job(
+def update_job(
     job: JobChange,
     user: User = Depends(authenticate),
     ):
@@ -211,7 +211,7 @@ async def update_job(
 
 # A route for deleting watchlist entries
 @router.put('/v1/watchlist')
-async def update_watchlist(
+def update_watchlist(
     change: WatchlistChange,
     user: User = Depends(authenticate),  # consistent with jobs
     ):
@@ -235,7 +235,7 @@ async def update_watchlist(
 
 # A route to return all of the available entries in our catalog.
 @router.get('/v1/notes/{run_id}')
-async def get_notes(run_id, user: User = Depends(authenticate)):
+def get_notes(run_id, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
 
@@ -260,7 +260,7 @@ async def get_notes(run_id, user: User = Depends(authenticate)):
 
 
 @router.get('/v1/warnings/{run_id}')
-async def get_warnings(run_id, user: User = Depends(authenticate)):
+def get_warnings(run_id, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
 
@@ -283,7 +283,7 @@ async def get_warnings(run_id, user: User = Depends(authenticate)):
 
 
 @router.get('/v1/network/{run_id}')
-async def get_network(run_id: str, user: User = Depends(authenticate)):
+def get_network(run_id: str, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         return ORJSONResponseObjKeep({'success': False, 'data': 'Run ID is not a valid UUID or empty'}, status_code=422)
 
@@ -313,7 +313,7 @@ async def get_network(run_id: str, user: User = Depends(authenticate)):
 
 
 @router.get('/v1/repositories')
-async def get_repositories(
+def get_repositories(
     uri: str | None = None,
     branch: str | None = None,
     machine_id: int | None = None,
@@ -375,7 +375,7 @@ def old_v1_runs_endpoint():
 
 # A route to return all of the available entries in our catalog.
 @router.get('/v2/runs')
-async def get_runs(
+def get_runs(
     name: str | None = None,
     uri: str | None = None,
     branch: str | None = None,
@@ -485,7 +485,7 @@ async def get_runs(
 # later if supplied. Also deprecation shall be used once we move to v2 for all v1 routesthrough
 
 @router.get('/v1/compare')
-async def compare_in_repo(ids: str, force_mode:str | None = None, user: User = Depends(authenticate)):
+def compare_in_repo(ids: str, force_mode:str | None = None, user: User = Depends(authenticate)):
     if ids is None or not ids.strip():
         raise HTTPException(status_code=422, detail='run_id is empty')
     ids = ids.split(',')
@@ -587,7 +587,7 @@ async def compare_in_repo(ids: str, force_mode:str | None = None, user: User = D
 
 
 @router.get('/v1/phase_stats/single/{run_id}')
-async def get_phase_stats_single(run_id: str, user: User = Depends(authenticate)):
+def get_phase_stats_single(run_id: str, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
 
@@ -610,7 +610,7 @@ async def get_phase_stats_single(run_id: str, user: User = Depends(authenticate)
 
 # This route gets the measurements to be displayed in a timeline chart
 @router.get('/v1/measurements/single/{run_id}')
-async def get_measurements_single(run_id: str, user: User = Depends(authenticate)):
+def get_measurements_single(run_id: str, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
 
@@ -639,7 +639,7 @@ async def get_measurements_single(run_id: str, user: User = Depends(authenticate
     return ORJSONResponseObjKeep({'success': True, 'data': data})
 
 @router.get('/v1/timeline', deprecated=True)
-async def get_timeline_stats(
+def get_timeline_stats(
     uri: str, machine_id: int, branch: str | None = None, filename: str | None = None,
     metric: str | None = None, phase: str | None = None,
     show_archived: bool | None = None,
@@ -665,7 +665,7 @@ async def get_timeline_stats(
     return CustomORJSONResponse({'success': True, 'data': data})
 
 @router.get('/v2/timeline')
-async def get_timeline_stats_v2(
+def get_timeline_stats_v2(
     uri: str, machine_id: int, branch: str | None = None, filename: str | None = None,
     metric: str | None = None, phase: str | None = None,
     show_archived: bool | None = None,
@@ -698,7 +698,7 @@ async def get_timeline_stats_v2(
 ## an unexpected result because they occur at same timepoints but the trend assumes them to be at sequential timepoints.
 ## You might get unexpected results, but generally it is desireable to have a regression of all CPU cores for instance forthe cpu energy reporter
 @router.get('/v1/badge/timeline')
-async def get_timeline_badge(
+def get_timeline_badge(
     metric: str, uri: str,
     unit: str = 'watt-hours',
     detail_name: str | None = None, machine_id: int | None = None, branch: str | None = None, filename: str | None = None,
@@ -770,7 +770,7 @@ async def get_timeline_badge(
 ## A complex case to allow public visibility of the badge but restricting everything else would be to have
 ## User 1 restricted to only this route but a fully populated 'visible_users' array
 @router.get('/v1/badge/single/{run_id}')
-async def get_badge_single(run_id: str, metric: str = 'cpu_energy_rapl_msr_component', unit: str = 'watt-hours', phase: str | None = None, user: User = Depends(authenticate)):
+def get_badge_single(run_id: str, metric: str = 'cpu_energy_rapl_msr_component', unit: str = 'watt-hours', phase: str | None = None, user: User = Depends(authenticate)):
 
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
@@ -861,7 +861,7 @@ async def get_badge_single(run_id: str, metric: str = 'cpu_energy_rapl_msr_compo
 
 
 @router.get('/v1/watchlist')
-async def get_watchlist(user: User = Depends(authenticate)):
+def get_watchlist(user: User = Depends(authenticate)):
     # Do not get the email jobs as they do not need to be display in the frontend atm
     # Also do not get the email field for privacy
     query = '''
@@ -899,7 +899,7 @@ async def get_watchlist(user: User = Depends(authenticate)):
 
 
 @router.post('/v1/runs/add')
-async def runs_add(software: Software, no_url_check: bool = False, user: User = Depends(authenticate)):
+def runs_add(software: Software, no_url_check: bool = False, user: User = Depends(authenticate)):
 
     if software.name is None or software.name.strip() == '':
         raise HTTPException(status_code=422, detail='Name is empty')
@@ -1004,7 +1004,7 @@ def old_v1_run_endpoint():
 
 
 @router.get('/v2/run/{run_id}')
-async def get_run(run_id: str, user: User = Depends(authenticate)):
+def get_run(run_id: str, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
     try:
@@ -1068,7 +1068,7 @@ def update_run(
 
 
 @router.get('/v1/optimizations/{run_id}')
-async def get_optimizations(run_id: str, user: User = Depends(authenticate)):
+def get_optimizations(run_id: str, user: User = Depends(authenticate)):
     if run_id is None or not is_valid_uuid(run_id):
         raise HTTPException(status_code=422, detail='Run ID is not a valid UUID or empty')
 
@@ -1092,7 +1092,7 @@ async def get_optimizations(run_id: str, user: User = Depends(authenticate)):
 
 
 @router.get('/v1/diff')
-async def diff(ids: str, user: User = Depends(authenticate)):
+def diff(ids: str, user: User = Depends(authenticate)):
     if ids is None or not ids.strip():
         raise HTTPException(status_code=422, detail='run_ids are empty')
     ids = ids.split(',')
@@ -1115,7 +1115,7 @@ async def diff(ids: str, user: User = Depends(authenticate)):
 
 
 @router.get('/v1/insights')
-async def get_insights(user: User = Depends(authenticate)):
+def get_insights(user: User = Depends(authenticate)):
 
     query = '''
             SELECT COUNT(id), DATE(MIN(created_at))

--- a/api/software.py
+++ b/api/software.py
@@ -14,7 +14,7 @@ router = APIRouter()
 HOURS_STORAGE_12=43200
 
 @router.get('/v1/software/categories')
-async def get_software_categories(
+def get_software_categories(
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
     user: User = Depends(authenticate), # pylint: disable=unused-argument
     ):
@@ -44,7 +44,7 @@ async def get_software_categories(
 
 
 @router.get('/v1/software')
-async def get_softwares(
+def get_softwares(
     category: str | None = None,
     page: int = 1,
     # Endpoint without user restriction on DB. But authenticate() must be present to check if route is allowed in general
@@ -95,7 +95,7 @@ async def get_softwares(
 
 
 @router.get('/v1/software/{software_id}/tasks')
-async def get_software_tasks(
+def get_software_tasks(
     software_id: int,
     user: User = Depends(authenticate),
     ):
@@ -197,7 +197,7 @@ async def get_software_tasks(
 
 
 @router.get('/v1/software/similar')
-async def get_similar_software(
+def get_similar_software(
     name: str,
     exclude_software_id: int | None = None,
     categories: str | None = None,

--- a/cron/backfill_carbon_intensity.py
+++ b/cron/backfill_carbon_intensity.py
@@ -8,6 +8,7 @@ faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to st
 import os
 import json
 import fcntl
+import threading
 
 import requests
 from cachetools import cached
@@ -130,8 +131,9 @@ def update_carbondb_data_raw_carbon():
     return DB().fetch_all(query)
 
 
-# The decorator will not work between workers, but since uvicorn_worker.UvicornWorker is using asyncIO it has some functionality between requests
-@cached(cache=NoNoneOrNegativeValuesCache(maxsize=1024, ttl=3600)) # 60 Minutes
+# The cache is not shared between worker processes, but the lock makes it safe within a worker
+# even if this function is ever called from multiple threads.
+@cached(cache=NoNoneOrNegativeValuesCache(maxsize=1024, ttl=3600), lock=threading.Lock()) # 60 Minutes
 def get_carbon_intensity(latitude, longitude):
 
     if latitude is None or longitude is None:

--- a/cron/backfill_geo.py
+++ b/cron/backfill_geo.py
@@ -7,6 +7,7 @@ faulthandler.enable(file=sys.__stderr__)  # will catch segfaults and write to st
 
 import os
 import fcntl
+import threading
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -102,8 +103,9 @@ def backfill_geo_missing(table, data):
         DB().query(query, params=(latitude, longitude, row_id))
 
 
-# The decorator will not work between workers, but since uvicorn_worker.UvicornWorker is using asyncIO it has some functionality between requests
-@cached(cache=NoNoneOrNegativeValuesCache(maxsize=1024, ttl=86400)) # 24 hours
+# The cache is not shared between worker processes, but the lock makes it safe within a worker
+# even if this function is ever called from multiple threads.
+@cached(cache=NoNoneOrNegativeValuesCache(maxsize=1024, ttl=86400), lock=threading.Lock()) # 24 hours
 def get_geo(ip):
     ip_obj = ipaddress.ip_address(ip) # may raise a ValueError
     if ip_obj.is_private:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,6 +19,9 @@ This directory contains the integration and unit-style test harness for the repo
 - Never run the full test suite, but always run targeted tests or files:
   - e.g. for single test `cd tests && pytest test_usage_scenario.py::test_labels_allow_unsafe_true`
   - e.g. for full test `cd tests && pytest test_usage_scenario.py`
+- Benchmark scripts (e.g. `api/benchmark_api_concurrency.py`) are named without the `test_`/`_test`
+  prefix on purpose, so a bare `pytest` run never collects them. Run them explicitly by path:
+  `cd tests && pytest api/benchmark_api_concurrency.py -v -s`.
 
 ## Working rules
 

--- a/tests/api/benchmark_api_concurrency.py
+++ b/tests/api/benchmark_api_concurrency.py
@@ -1,0 +1,98 @@
+"""
+Benchmark for the async/threading fix in api/*.py (routes converted from blocking
+`async def` to plain `def` so Starlette dispatches them through its AnyIO thread pool
+instead of running them inline on the event loop).
+
+Not part of the normal test suite: this file is deliberately NOT named `test_*.py`, so
+plain `pytest` runs (tests/run-tests.sh, CI's default `gmt-pytest` action) never collect
+it. Run it explicitly, on request, from the `tests/` directory with the test containers up:
+
+    pytest api/benchmark_api_concurrency.py -v -s
+
+`-s` is required to see the printed report; pytest captures stdout otherwise.
+
+What it measures: a batch of GET requests against a real, DB-backed endpoint, once fired
+serially and once fired concurrently from a thread pool. If routes block the event loop
+(the bug this benchmark guards against), concurrent wall time collapses to roughly the
+serial wall time - one request has to finish before the next one on that worker can even
+start. If routes are properly offloaded, concurrent wall time drops well below serial,
+bounded only by the DB connection pool (lib/db.py) and worker count (docker/startup_gunicorn.sh).
+"""
+import os
+import statistics
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+from lib.global_config import GlobalConfig
+
+API_URL = GlobalConfig().config['cluster']['api_url']  # will be pre-loaded with test-config.yml due to conftest.py
+
+# DB-backed, side-effect-free, cheap to call repeatedly.
+BENCHMARK_ENDPOINT = '/v1/machines'
+HEADERS = {'X-Authentication': 'DEFAULT'}
+
+REQUEST_COUNT = int(os.environ.get('BENCHMARK_REQUEST_COUNT', 40))
+WARMUP_REQUESTS = 5
+
+# Loose on purpose: real parallelism is capped by the DB pool (max_size=2 per worker,
+# lib/db.py) and worker count (8, docker/startup_gunicorn.sh), so we're not expecting a
+# clean N-times speedup - just a speedup clearly above 1.0, which is what a fully
+# serialized (blocked event loop) API would produce.
+MIN_EXPECTED_SPEEDUP = 1.5
+
+
+def _timed_get():
+    start = time.monotonic()
+    response = requests.get(f"{API_URL}{BENCHMARK_ENDPOINT}", timeout=30, headers=HEADERS)
+    elapsed = time.monotonic() - start
+    assert response.status_code == 200, response.text
+    return elapsed
+
+
+def _run_serial(count):
+    start = time.monotonic()
+    latencies = [_timed_get() for _ in range(count)]
+    total = time.monotonic() - start
+    return total, latencies
+
+
+def _run_concurrent(count):
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=count) as executor:
+        latencies = list(executor.map(lambda _: _timed_get(), range(count)))
+    total = time.monotonic() - start
+    return total, latencies
+
+
+def _report(label, total, latencies):
+    print(f"\n{label}")
+    print(f"  requests:      {len(latencies)}")
+    print(f"  total time:    {total:.3f}s")
+    print(f"  mean latency:  {statistics.mean(latencies) * 1000:.1f}ms")
+    print(f"  median latency:{statistics.median(latencies) * 1000:.1f}ms")
+    print(f"  max latency:   {max(latencies) * 1000:.1f}ms")
+
+
+def test_concurrent_requests_are_faster_than_serial():
+    # Warm up connections/pools so the first-connection cost doesn't skew either phase.
+    for _ in range(WARMUP_REQUESTS):
+        _timed_get()
+
+    serial_total, serial_latencies = _run_serial(REQUEST_COUNT)
+    concurrent_total, concurrent_latencies = _run_concurrent(REQUEST_COUNT)
+
+    speedup = serial_total / concurrent_total
+
+    _report('Serial', serial_total, serial_latencies)
+    _report('Concurrent', concurrent_total, concurrent_latencies)
+    print(f"\nSpeedup (serial / concurrent): {speedup:.2f}x")
+    print(f"Endpoint: {BENCHMARK_ENDPOINT}, requests per phase: {REQUEST_COUNT}\n")
+
+    assert speedup >= MIN_EXPECTED_SPEEDUP, (
+        f"Concurrent requests were only {speedup:.2f}x faster than serial "
+        f"(expected >= {MIN_EXPECTED_SPEEDUP}x). This is the signature of an API route "
+        f"blocking the event loop again - check for `async def` routes in api/ that call "
+        f"blocking code (e.g. DB()) directly instead of being plain `def`."
+    )


### PR DESCRIPTION
This PR reworks how the FastAPI routes work.

We were using async routes so far. But due to the blocking nature of the SQL calls we could not really use the async feature of the uvicorn workers.

This this PR moved all routes to non-async and python threads. They still have a GIL lock, but can through this also better share the postgresql connection pool, which is probably one of our most limiting factors.

This PR is a draft and still needs some work:
- Determining a good value for postgresql overall max connections
- Increasing connection pool size
- Determining good value for max workers and threads per worker
- Benchmarking how much more performance we achieve through that approach

## AI background explanation on threads vs. async in our case
  threading.Thread in CPython is an OS thread. When you create one, CPython calls pthread_create (on Linux) under the hood. It's scheduled by
  the kernel just like any other thread — not a userspace/green-thread construct like a goroutine or a greenlet. The GIL doesn't change that;
  it just means only one of those OS threads is allowed to execute Python bytecode at any given instant. A thread blocked inside a C-level
  blocking syscall (like the recv() psycopg does while waiting on the Postgres socket) releases the GIL for that duration, which is exactly why
  handing blocking DB calls to a thread pool helps here.

  AnyIO's to_thread.run_sync doesn't spawn a fresh OS thread per call. It keeps a small pool of idle worker threads alive and reuses them (each
  one really is a threading.Thread/pthread that sits idle waiting for the next job), bounded by a CapacityLimiter — default 40 concurrent
  tokens per event loop. So per UvicornWorker process you get up to ~40 real, kernel-scheduled OS threads available to run blocking route
  bodies concurrently, on top of the one thread running the asyncio event loop itself.

  The new change is now: 8 Gunicorn processes → each with 1 event-loop OS thread + up to 40 AnyIO worker OS threads → each thread,
  while blocked on psycopg's socket I/O, releases the GIL so others can run → but only 2 of them per process can actually be talking to
  Postgres concurrently, since that's capped by lib/db.py:107's connection pool max_size=2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787914980&installation_model_id=428550&pr_number=1800&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1800&signature=69ca45141e9ae73aa43e1a2121467fcd14a0202a3b49d6c765fd3c6dd5e1c092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->