### PR TITLE
(rework): Jobs.py does not take CLI arguments anymore

### DIFF
--- a/cron/client.py
+++ b/cron/client.py
@@ -248,7 +248,7 @@ if __name__ == '__main__':
             if job:
                 set_status('job_start', run_id=job._run_id)
                 try:
-                    job.process(docker_prune=config['cluster']['client']['docker_prune'], full_docker_prune=config['cluster']['client']['full_docker_prune'])
+                    job.process()
                     if temperature_cooldown_time > 0:
                         DB().query('UPDATE machines SET cooldown_time_after_job=%s WHERE id = %s', params=(temperature_cooldown_time, config['machine']['id']))
                     temperature_errors = 0

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -42,8 +42,6 @@ if __name__ == '__main__':
         parser = argparse.ArgumentParser()
         parser.add_argument('type', help='Select the operation mode.', choices=['email-simple', 'run', 'email-report'])
         parser.add_argument('--config-override', type=str, help='Override the configuration file with the passed in yml file. Supply full path.')
-        parser.add_argument('--full-docker-prune', action='store_true', default=False, help='Prune all images and build caches on the system')
-        parser.add_argument('--docker-prune', action='store_true', help='Prune all unassociated build caches, networks volumes and stopped containers on the system')
 
         args = parser.parse_args()  # script will exit if type is not present
 
@@ -62,10 +60,7 @@ if __name__ == '__main__':
             print(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), 'No job to process. Exiting')
             sys.exit(0)
         print(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), 'Processing Job ID#: ', job_main._id)
-        if args.type == 'run':
-            job_main.process(docker_prune=args.docker_prune, full_docker_prune=args.full_docker_prune)
-        else:
-            job_main.process()
+        job_main.process()
         print('Successfully processed jobs queue item.')
     except Exception as exc: #pylint: disable=broad-except
         if job_main:

--- a/lib/job/run.py
+++ b/lib/job/run.py
@@ -17,6 +17,7 @@ from lib.db import DB
 from lib.user import User
 from lib.terminal_colors import TerminalColors
 from lib.scenario_runner import ScenarioRunner
+from lib.global_config import GlobalConfig
 
 class RunJob(Job):
     JOB_TYPE = 'run'
@@ -46,8 +47,9 @@ class RunJob(Job):
         )
 
     #pylint: disable=arguments-differ
-    def _process(self, docker_prune=False, full_docker_prune=False):
+    def _process(self):
 
+        config = GlobalConfig().config
         user = User(self._user_id)
 
         if not user.can_use_machine(self._machine_id):
@@ -70,8 +72,8 @@ class RunJob(Job):
             dev_no_system_checks=user._capabilities['measurement']['dev_no_system_checks'],
             skip_volume_inspect=user._capabilities['measurement']['skip_volume_inspect'],
             skip_optimizations=user._capabilities['measurement']['skip_optimizations'],
-            full_docker_prune=full_docker_prune, # is no user setting as it can change behaviour of subsequent runs. Thus set by machine / cluster
-            docker_prune=docker_prune, # is no user setting as it can change behaviour of subsequent runs. Thus set by machine / cluster
+            full_docker_prune=config['cluster']['client']['full_docker_prune'], # is no user setting as it can change behaviour of subsequent runs. Thus set by machine / cluster
+            docker_prune=config['cluster']['client']['docker_prune'], # is no user setting as it can change behaviour of subsequent runs. Thus set by machine / cluster
             job_id=self._id,
             user_id=self._user_id,
             usage_scenario_variables=self._usage_scenario_variables,


### PR DESCRIPTION
Everything is now directly derived from the user config

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788511373&installation_model_id=428550&pr_number=1812&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1812&signature=7627e04ffe9299d0b3b860bab1744953be1e73851e090fbaca31fa5cc46170d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->