### PR TITLE
(feat): Table compare mode becomes default fallback instead of error

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -456,17 +456,23 @@ def determine_comparison_case(user, ids, force_mode=None):
         if usage_scenario_variables == 1:
             return ('Repeated Run on same Commit Hash', 'commit_hash')  # Case A - Everything is identical and just repeating runs
 
-    except RuntimeError as exc:
+        raise RuntimeError('Could not determine comparison case after checking all conditions')
+
+    except RuntimeError:
+        # Although the check appears also couple of lines above we need it here again
+        # Reason being is that two scenarios with two repos and two machines for instance will get into here
+        # We then want to show this fallback
         if len(ids) == 2:
             ### DUO Case ####
             # In case we only encounter two IDs we can try to short circuit.
             # Before we would fail here. However for two scenarios we can ALWAYS
             # show a comparison case as it is guaranteed that we will encounter only two different cases somewhere.
             return ('IDs', 'id')
-        else:
-            raise exc
 
-    raise RuntimeError('Could not determine comparison case after checking all conditions')
+        ### TABLE / IDs Case ####
+        # If auto mode cannot find a single differing attribute to compare on we fall back to
+        # a generic per-run table view. This always works, as every run has a unique id.
+        return ('Table', 'simple_table')
 
 def check_run_failed(user, ids):
     query = """

--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -9,7 +9,6 @@ from datetime import date, datetime, timedelta
 import pprint
 
 from fastapi import APIRouter, Response, Depends, HTTPException, Request
-
 import anybadge
 
 from api.object_specifications import Software, JobChange, WatchlistChange, RunChange, ArtifactType
@@ -488,6 +487,7 @@ async def get_runs(
 async def compare_in_repo(ids: str, force_mode:str | None = None, user: User = Depends(authenticate)):
     if ids is None or not ids.strip():
         raise HTTPException(status_code=422, detail='run_id is empty')
+
     ids = ids.split(',')
     if not all(is_valid_uuid(id) for id in ids):
         raise HTTPException(status_code=422, detail='One of Run IDs is not a valid UUID or empty')
@@ -501,6 +501,13 @@ async def compare_in_repo(ids: str, force_mode:str | None = None, user: User = D
         case, comparison_db_key = determine_comparison_case(user, ids, force_mode=force_mode)
     except (RuntimeError, ValueError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if case == 'Table':
+        return Response(
+            content='Compare endpoint cannot handle this set of IDs directly. Please redirect to compare-simple.html',
+            status_code=409,
+            media_type="text/plain",
+        )
 
     comparison_details = get_comparison_details(user, ids, comparison_db_key)
 

--- a/frontend/compare-simple.html
+++ b/frontend/compare-simple.html
@@ -115,7 +115,7 @@
                 redirected you to table mode. <br>
                 Please be aware that since Machine, Repository, Branch etc. might be different some metrics and phases are not present in all runs
                 - If you believe this is an error check which runs you selected.<br>
-                Please also consider that this comparsion can be harder to interpret as multiple factors may have changed at once.
+                Please also consider that this comparison can be harder to interpret as multiple factors may have changed at once.
             </div>
         </div>
 

--- a/frontend/compare-simple.html
+++ b/frontend/compare-simple.html
@@ -104,6 +104,21 @@
             </div>
         </div>
 
+
+        <div id="compare-mode-auto" class="ui icon message warning hidden">
+            <i class="info circle icon"></i>
+            <div class="content">
+                <div class="header">
+                    Comparing in Auto Mode
+                </div>
+                Auto mode could not find a single attribute that uniquely distinguishes the runs you are comparing, and thus
+                redirected you to table mode. <br>
+                Please be aware that since Machine, Repository, Branch etc. might be different some metrics and phases are not present in all runs
+                - If you believe this is an error check which runs you selected.<br>
+                Please also consider that this comparsion can be harder to interpret as multiple factors may have changed at once.
+            </div>
+        </div>
+
         <div class="ui full-width-card card">
             <div class="content">
                 <div class="header">

--- a/frontend/compare.html
+++ b/frontend/compare.html
@@ -81,7 +81,7 @@
                 <div class="header">
                     Comparing in IDs mode
                 </div>
-                You are comparing in IDs mode. This means the two runs you are comparing are differing in more than one attribute (Machine, Repository, Branch, Commit Hash). Please consider that this comparsion can be harder to interpret as mutliple factors changed at once.
+                Auto mode could not find a single attribute (Machine, Repository, Branch, Commit Hash, ...) that uniquely distinguishes the runs you are comparing, so they are shown side-by-side per run instead. Please consider that this comparsion can be harder to interpret as multiple factors may have changed at once.
             </div>
         </div>
 

--- a/frontend/compare.html
+++ b/frontend/compare.html
@@ -81,7 +81,7 @@
                 <div class="header">
                     Comparing in IDs mode
                 </div>
-                Auto mode could not find a single attribute (Machine, Repository, Branch, Commit Hash, ...) that uniquely distinguishes the runs you are comparing, so they are shown side-by-side per run instead. Please consider that this comparsion can be harder to interpret as multiple factors may have changed at once.
+                Auto mode could not find a single attribute (Machine, Repository, Branch, Commit Hash, ...) that uniquely distinguishes the runs you are comparing, so they are shown side-by-side per run instead. Please consider that this comparison can be harder to interpret as multiple factors may have changed at once.
             </div>
         </div>
 

--- a/frontend/js/compare-simple.js
+++ b/frontend/js/compare-simple.js
@@ -461,6 +461,11 @@ $(document).ready(() => {
 
         document.querySelector('#loader-compare-simple').remove();
 
+        if (url_params?.redirect_from_auto == 'true') {
+            document.querySelector('#compare-mode-auto').classList.remove('hidden');
+        }
+
+
         if (url_params['phase']) {
             if (compareSimpleState.availablePhases.has(url_params['phase'])) {
                 compareSimpleState.selectedPhase = url_params['phase'];

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -313,6 +313,12 @@ $(document).ready( () => {
             }
             phase_stats_data = (await makeAPICall(url)).data
         } catch (err) {
+            if (err instanceof APIHTTPError && err.status === 409) {
+                console.log('Endpoint cannot handle request. Will redirect to simple table.')
+                window.location.href = `/compare-simple.html?ids=${run_ids}&redirect_from_auto=true`;
+                return
+            }
+
             showNotification('Could not get compare in-repo data from API', err);
             return
         }

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -355,19 +355,20 @@ const dateToYMD = (date, short=false, no_break=false) => {
 
 async function makeAPICall(path, values=null, force_authentication_token=null, force_put=false) {
 
+    let options = {}
     if(values != null ) {
-        var options = {
+        options = {
             method: "POST",
             body: JSON.stringify(values),
             headers: {
                 'Content-Type': 'application/json'
-            }
+            },
         }
         if (force_put == true) {
             options.method = 'PUT';
         }
     }  else {
-        var options = { method: 'GET', headers: {} }
+        options = { method: 'GET', headers: {} }
     }
 
     if (force_authentication_token != null && force_authentication_token != '') {
@@ -386,12 +387,16 @@ async function makeAPICall(path, values=null, force_authentication_token=null, f
     await fetch(API_URL + path, options)
     .then(response => {
         _http_status = response.status;
-        if (response.status == 204) {
+        if (response.status === 204) {
             // 204 responses use no body, so json() call would fail
             throw new APIHTTPError(204, 'No data to display. API returned empty response (HTTP 204)')
         }
-        if (response.status == 202) {
+        if (response.status === 202) {
             return
+        }
+
+        if (response.status === 409) {
+            throw new APIHTTPError(409, 'Endpoint cannot handle request. Please redirect request.')
         }
 
         return response.json()

--- a/tests/api/test_api_scenario_runner.py
+++ b/tests/api/test_api_scenario_runner.py
@@ -100,15 +100,15 @@ def test_compare_valid():
 
     assert res_json['data'] == data
 
-def test_compare_fails():
+def test_compare_falls_back_to_table_mode():
     Tests.import_demo_data()
 
     DB().query(f"UPDATE runs SET commit_hash = 'test' WHERE id = '{RUN_1}' ")
 
+    # Auto mode cannot find a single differing attribute here (usage_scenario AND commit_hash
+    # differ at once), so it should fall back to the generic per-run 'IDs' table view instead of failing.
     response = requests.get(f"{API_URL}/v1/compare?ids={RUN_3},{RUN_1},{RUN_2}", timeout=15)
-    res_json = response.json()
-    assert response.status_code == 422
-    assert res_json['err'] == 'Different usage scenarios & commits not supported'
+    assert response.status_code == 409
 
 # Will force same style by comparing A vs B. No repeated run style
 def test_compare_force_mode_same_style():


### PR DESCRIPTION
Currently when a comparison is very complex GMT fails when it cannot find a pivot candidate.

However since we have table mode, we can also default to table mode and rather show a warning.

warnings looks like this now:
<img width="1761" height="299" alt="Screenshot 2026-08-12 at 2 31 05 PM" src="https://github.com/user-attachments/assets/0296a3af-e0a6-4601-b824-89001db6507c" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789130409&installation_model_id=428550&pr_number=1819&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1819&signature=d9fb31e49b995604d5f4842eebe3547557c7b7f4f0b2276eedbd2cb2d6ab9352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Default complex comparisons to table mode when Auto Mode cannot find a unique pivot attribute.
- Return HTTP 409 and redirect the frontend to the comparison table.
- Display warnings that explain the fallback and its interpretation limits.
- Update tests for the new fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->