### PR TITLE
Splitting out CPU performance measurement test and giving tests some headroom so they do not fail with code 125 or frontend timeouts

### DIFF
--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -147,8 +147,13 @@ runs:
 
         source ../venv/bin/activate
 
+        # Leave 2 cores unassigned to xdist workers so the host (dockerd, gunicorn, etc.) has some
+        # headroom instead of every core being claimed by a worker's pinned containers.
+        WORKERS=$(python3 -c "import os; print(max(1, (os.cpu_count() or 3) - 2))")
+        echo "Running with $WORKERS parallel pytest-xdist workers"
+
         set +e
-        python3 -m ${{ inputs.tests-command }} -n auto --dist=loadgroup ${TEST_PATH} -rA | tee /tmp/test-results.txt
+        python3 -m ${{ inputs.tests-command }} -n "$WORKERS" --dist=loadgroup ${TEST_PATH} -rA | tee /tmp/test-results.txt
         PARALLEL_EXIT_CODE=${PIPESTATUS[0]}
         # these marked tests must run sequentially after, as it restarts the DB which will collide with other parallel tests running
         python3 -m ${{ inputs.tests-command }} -m serial -rA | tee -a /tmp/test-results.txt

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -1,5 +1,6 @@
 import io
 import math
+import os
 import shutil
 import tempfile
 
@@ -765,10 +766,18 @@ def test_phase_stats_process_user_custom_metrics():
     assert runtime_data['type'] == 'TOTAL'
 
 # Starts the full default set of real metric providers from test-config.yml (dev_no_metrics=False)
-# for real, so it must never overlap with any other test that also starts real metric providers -
-# see the comment on pytestmark in tests/smoke_test.py for why xdist_group is what actually
-# prevents that under -n.
-@pytest.mark.xdist_group(name="real-metric-providers")
+# for real and asserts a narrow numeric range on the resulting real energy/SCI measurements
+# (custom_api_hits_sci_global etc.) - same class of flakiness as test_metric_providers.py's
+# cpu_utilization assertions: under -n/xdist every worker pins its containers to the same
+# '--cpuset-cpus' range (resource_limits.get_assignable_cpus() is host-wide, not worker-aware), so
+# concurrent workers contend for the same physical cores and skew the real measurements this test
+# checks. So, like test_database_reconnection_during_run (tests/test_runner.py) and the whole of
+# tests/metric_providers/test_metric_providers.py, this test is excluded from -n runs entirely and
+# only runs in the separate, non-parallel 'pytest -m serial' pass - which also means it no longer
+# overlaps in time with the rest of the real-metric-providers xdist_group, so that marker is no
+# longer needed here either.
+@pytest.mark.serial
+@pytest.mark.skipif(bool(os.environ.get('PYTEST_XDIST_WORKER')), reason="needs the whole machine's CPUs uncontended for accurate real energy/SCI assertions - run this outside of -n/xdist, on its own")
 def test_custom_metric_sci_run():
     runner = ScenarioRunner(uri=GMT_ROOT_DIR.as_posix(), uri_type='folder', filename='tests/data/usage_scenarios/stress_custom_metrics.yml', dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=False, dev_no_phase_stats=False, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
 

--- a/tests/metric_providers/test_metric_providers.py
+++ b/tests/metric_providers/test_metric_providers.py
@@ -17,13 +17,20 @@ from lib import resource_limits
 from lib.scenario_runner import ScenarioRunner
 from metric_providers.network.io.procfs.system.provider import NetworkIoProcfsSystemProvider
 
-# setup_module below starts the full default set of real metric providers from test-config.yml
-# (dev_no_metrics=False) for real - even though dev_no_system_checks=True means this file never
-# checks for a collision itself, another test elsewhere that DOES check (dev_no_system_checks=False,
-# e.g. tests/smoke_test.py) would still trip on these providers if it ran concurrently on a
-# different xdist worker. See the comment on pytestmark in tests/smoke_test.py for why xdist_group
-# is what actually prevents that under -n.
-pytestmark = pytest.mark.xdist_group(name="real-metric-providers")
+# This file asserts precise cpu_utilization percentages (e.g. stress-container must sit >90% of its
+# pinned cores) which only hold if it has the whole machine's CPUs to itself. Under -n/xdist, every
+# worker computes its own '--cpuset-cpus' from resource_limits.get_assignable_cpus() independently -
+# that function is host-wide, not worker-aware - so concurrent workers all pin their containers to the
+# *same* physical cores and fight each other for cycles, which is what made these assertions flaky.
+# So, like test_database_reconnection_during_run (tests/test_runner.py), this whole module is excluded
+# from -n runs entirely (skipif below) and runs only in the separate, non-parallel 'pytest -m serial'
+# pass (tests/run-tests.sh / the gmt-pytest action run this after the parallel pass finishes) - which
+# also means setup_module's real-metric-provider run never overlaps in time with the real-metric-
+# providers group in tests/smoke_test.py etc., so xdist_group is no longer needed here for that either.
+pytestmark = [
+    pytest.mark.serial,
+    pytest.mark.skipif(bool(os.environ.get('PYTEST_XDIST_WORKER')), reason="needs the whole machine's CPUs uncontended for accurate cpu_utilization assertions - run this outside of -n/xdist, on its own"),
+]
 
 #pylint: disable=unused-argument
 @pytest.fixture(autouse=True, scope='module') # override by setting scope to module only
@@ -189,7 +196,6 @@ def test_memory_providers():
 
         assert psutil.virtual_memory().total*0.55 <= val <= psutil.virtual_memory().total * 0.65 , f"memory_used_procfs_system avg is not between 55% and 65% of total memory but {val} {metric_provider['unit']}"
 
-@pytest.mark.skip(reason="Test is currently in maintenance")
 def test_cpu_time_carbon_providers():
 
     assert run_id


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789202730&installation_model_id=428550&pr_number=1821&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1821&signature=05ef26e28a9daaa51cc813ec0e1c658f52042056186cd4e47cbed013a4022791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->