### PR TITLE
(feat): Limiting install times with timeouts to fail.

### DIFF
--- a/.devcontainer/codespace-setup.sh
+++ b/.devcontainer/codespace-setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-sudo apt update
-sudo apt install acl -y
+sudo timeout 180 apt update
+sudo apt -o Acquire::http::ConnectTimeout=10 -o Acquire::https::ConnectTimeout=10 install acl -y
 
 sudo setfacl -bk /tmp
 

--- a/docker/auxiliary-containers/squid_reverse_proxy/Dockerfile
+++ b/docker/auxiliary-containers/squid_reverse_proxy/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update && apt-get install -y curl squid-openssl
+RUN timeout 180 apt-get -y update && apt-get -o Acquire::http::ConnectTimeout=10 -o Acquire::https::ConnectTimeout=10 install -y curl squid-openssl
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -6,6 +6,20 @@ if [[ $(uname) != "Linux" ]]; then
   exit 1
 fi
 
+# Refreshing repo metadata (apt/dnf update) must never hang indefinitely, so we cap it hard at 3 minutes.
+# Installs are not capped overall, as they can legitimately take a while,
+# but we still bound how long connecting to the repo may take.
+repo_metadata_refresh_timeout_s=180
+apt_connect_timeout_opts=(-o Acquire::http::ConnectTimeout=10 -o Acquire::https::ConnectTimeout=10)
+
+# dnf's 'timeout' setting is applied per mirror connection attempt (like apt's ConnectTimeout),
+# not to the overall download/install, so this is safe to use unconditionally.
+dnf_connect_timeout_opts=(--setopt=timeout=10)
+
+# zypper has no CLI flag for a connection-only timeout, so as a fallback we cap the whole
+# invocation. Kept generous since it also covers the actual package install.
+zypper_timeout_s=300
+
 source lib/install_shared.sh # will parse opts immediately
 
 prepare_config
@@ -19,22 +33,22 @@ build_containers
 if [[ $activate_scenario_runner == true ]] ; then
     print_message "Installing needed binaries for building ..."
     if cat /etc/os-release | grep -q "Fedora"; then
-        sudo dnf -y install tinyproxy stress-ng lshw libcurl-devel
+        sudo dnf "${dnf_connect_timeout_opts[@]}" -y install tinyproxy stress-ng lshw libcurl-devel
     elif cat /etc/os-release | grep -q "openSUSE"; then
-        sudo zypper -n in stress-ng lshw libcurl-devel
+        sudo timeout "$zypper_timeout_s" zypper -n in stress-ng lshw libcurl-devel
     else
-        sudo apt-get update
-        sudo apt-get install -y  libglib2.0-0 libglib2.0-dev tinyproxy stress-ng lshw libcurl4-openssl-dev
+        sudo timeout "$repo_metadata_refresh_timeout_s" apt-get update
+        sudo apt-get "${apt_connect_timeout_opts[@]}" install -y  libglib2.0-0 libglib2.0-dev tinyproxy stress-ng lshw libcurl4-openssl-dev
     fi
 
     if [[ $install_tinyproxy == true ]] ; then
         if cat /etc/os-release | grep -q "Fedora"; then
-            sudo dnf -y install tinyproxy
+            sudo dnf "${dnf_connect_timeout_opts[@]}" -y install tinyproxy
         elif cat /etc/os-release | grep -q "openSUSE"; then
-            sudo zypper -n in tinyproxy
+            sudo timeout "$zypper_timeout_s" zypper -n in tinyproxy
         else
-            sudo apt-get update
-            sudo apt-get install -y tinyproxy
+            sudo timeout "$repo_metadata_refresh_timeout_s" apt-get update
+            sudo apt-get "${apt_connect_timeout_opts[@]}" install -y tinyproxy
         fi
         sudo systemctl stop tinyproxy
         sudo systemctl disable tinyproxy
@@ -46,17 +60,17 @@ if [[ $activate_scenario_runner == true ]] ; then
 
     if [[ $install_sensors == true ]] ; then
         if cat /etc/os-release | grep -q "Fedora"; then
-            if ! sudo dnf -y install glib2 glib2-devel lm_sensors lm_sensors-devel; then
+            if ! sudo dnf "${dnf_connect_timeout_opts[@]}" -y install glib2 glib2-devel lm_sensors lm_sensors-devel; then
                 print_message "Failed to install lm_sensors lm_sensors-devel;" >&2
                 print_message "You can add -S to the install script to skip installing lm_sensors. However cluster mode and temperature reporters will not work then." >&2
                 exit 1
             fi
         elif cat /etc/os-release | grep -q "openSUSE"; then
-            if ! sudo zypper -n in glib2-tools glib2-devel sensors libsensors4-devel; then
+            if ! sudo timeout "$zypper_timeout_s" zypper -n in glib2-tools glib2-devel sensors libsensors4-devel; then
                 print_message "Failed to install sensors libsensors4-devel; continuing without Sensors."
             fi
         else
-            if ! sudo apt-get install -y lm-sensors libsensors-dev; then
+            if ! sudo apt-get "${apt_connect_timeout_opts[@]}" install -y lm-sensors libsensors-dev; then
                 print_message "Failed to install libglib2.0-0 libglib2.0-dev lm-sensors libsensors-dev;" >&2
                 print_message "You can add -S to the install script to skip installing lm_sensors. However cluster mode and temperature reporters will not work then." >&2
                exit 1
@@ -67,17 +81,17 @@ if [[ $activate_scenario_runner == true ]] ; then
     if [[ $install_nvidia_toolkit_headers == true ]] ; then
         print_message "Installing nvidia toolkit headers"
         if cat /etc/os-release | grep -q "Fedora"; then
-            curl -O https://developer.download.nvidia.com/compute/cuda/repos/fedora$(rpm -E %fedora)/x86_64/cuda-fedora$(rpm -E %fedora).repo
+            curl --connect-timeout 10 -O https://developer.download.nvidia.com/compute/cuda/repos/fedora$(rpm -E %fedora)/x86_64/cuda-fedora$(rpm -E %fedora).repo
             sudo mv cuda-fedora$(rpm -E %fedora).repo /etc/yum.repos.d/
-            sudo dnf makecache
-            if ! sudo dnf -y install libnvidia-ml cuda-nvml-devel-12-9; then
+            sudo timeout "$repo_metadata_refresh_timeout_s" dnf "${dnf_connect_timeout_opts[@]}" makecache
+            if ! sudo dnf "${dnf_connect_timeout_opts[@]}" -y install libnvidia-ml cuda-nvml-devel-12-9; then
                 print_message "Failed to install nvidia toolkit headers; Please remove --nvidia-gpu flag and install manually" >&2
                 exit 1
             else
                 sudo ln -s /usr/lib64/libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so
             fi
         else
-            if ! sudo apt-get install -y libnvidia-ml-dev; then
+            if ! sudo apt-get "${apt_connect_timeout_opts[@]}" install -y libnvidia-ml-dev; then
                 print_message "Failed to install nvidia toolkit headers; Please remove --nvidia-gpu flag and install manually" >&2
                 exit 1
             fi
@@ -119,16 +133,16 @@ if [[ $activate_scenario_runner == true ]] ; then
         print_message "Important: If this step fails it means msr-tools is not available on you system"
         print_message ""
         if cat /etc/os-release | grep -q "Fedora"; then
-            if ! sudo dnf -y install msr-tools; then
+            if ! sudo dnf "${dnf_connect_timeout_opts[@]}" -y install msr-tools; then
                 print_message "Failed to install msr-tools; If you do not plan to use RAPL you can skip the installation by appending '-R'" >&2
                 exit 1
             fi
         elif cat /etc/os-release | grep -q "openSUSE"; then
-            if ! sudo zypper -n in msr-tools; then
+            if ! sudo timeout "$zypper_timeout_s" zypper -n in msr-tools; then
                 print_message "Failed to install msr-tools; continuing without RAPL."
             fi
         else
-            if ! sudo apt-get install -y msr-tools; then
+            if ! sudo apt-get "${apt_connect_timeout_opts[@]}" install -y msr-tools; then
                 print_message "Failed to install msr-tools; If you do not plan to use RAPL you can skip the installation by appending '-R'" >&2
                 exit 1
             fi
@@ -140,11 +154,11 @@ if [[ $activate_scenario_runner == true ]] ; then
         print_message "Important: If this step fails it means ipmitool is not available on you system"
         {
             if cat /etc/os-release | grep -q "Fedora"; then
-                sudo dnf -y install freeipmi ipmitool
+                sudo dnf "${dnf_connect_timeout_opts[@]}" -y install freeipmi ipmitool
             elif cat /etc/os-release | grep -q "openSUSE"; then
-                sudo zypper -n in freeipmi ipmitool
+                sudo timeout "$zypper_timeout_s" zypper -n in freeipmi ipmitool
             else
-                sudo apt-get install -y freeipmi-tools ipmitool
+                sudo apt-get "${apt_connect_timeout_opts[@]}" install -y freeipmi-tools ipmitool
             fi
             print_message "Adding IPMI to sudoers file"
             ipmi_dcmi_path=$(realpath "/usr/sbin/ipmi-dcmi")

--- a/lib/install_shared.sh
+++ b/lib/install_shared.sh
@@ -390,15 +390,16 @@ function checkout_submodules() {
 
     print_message "Checking out further git submodules ..."
 
+    # these are small repos, so an overall timeout (rather than just a connect timeout) is fine here
     if [[ $(uname) != "Darwin" ]]; then
-        git submodule update --init lib/sgx-software-enable
+        timeout 120 git submodule update --init lib/sgx-software-enable
     fi
 
-    git submodule update --init metric_providers/psu/energy/ac/xgboost/machine/model
+    timeout 120 git submodule update --init metric_providers/psu/energy/ac/xgboost/machine/model
 
     if [[ $enterprise == true ]] ; then
         if [[ ! -d "ee" ]]; then
-            git clone git@github.com:green-coding-solutions/gmt-enterprise.git ee
+            timeout 120 git clone git@github.com:green-coding-solutions/gmt-enterprise.git ee
         fi
 
         if [[ ! -z $ee_branch ]]; then
@@ -488,6 +489,7 @@ function send_ping() {
     local os_version=$(uname -r)
 
     curl -i -X POST https://plausible.io/api/event \
+        --connect-timeout 5 --max-time 10 \
         -H "User-Agent: ${random_hash}" \
         -H 'Content-Type: application/json' \
         --data "{\"name\":\"install\",\"url\":\"http://hello.green-coding.io/install\",\"domain\":\"hello.green-coding.io\",\"props\":{\"unique_hash\":\"${unique_hash}\",\"arch\":\"${arch}\",\"os\":\"${os}\",\"os_version\":\"${os_version}\"}}" > /dev/null
@@ -749,6 +751,7 @@ done
 if [[ $enterprise == true ]] ; then
     echo "Validating enterprise token"
     curl --silent -X POST https://plausible.io/api/event \
+         --connect-timeout 5 --max-time 10 \
          -H 'Content-Type: application/json' \
          --data "{\"name\":\"api_test\",\"url\":\"https://www.green-coding.io/?utm_source=${ee_token}\",\"domain\":\"proxy.green-coding.io\"}" > /dev/null
 fi

--- a/tests/data/bare-metal/Dockerfile
+++ b/tests/data/bare-metal/Dockerfile
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN \
-    apt-get update && \
-    apt-get install -y curl git make gcc python3 python3-pip python3-venv sudo && \
+    timeout 180 apt-get update && \
+    apt-get -o Acquire::http::ConnectTimeout=10 -o Acquire::https::ConnectTimeout=10 install -y curl git make gcc python3 python3-pip python3-venv sudo && \
     rm -rf /var/lib/apt/lists/*
 
 ENV USER=root

--- a/tests/data/usage_scenarios/dependency_collection.yml
+++ b/tests/data/usage_scenarios/dependency_collection.yml
@@ -12,8 +12,8 @@ services:
           cd /root
           python3 -m virtualenv venv
           /root/venv/bin/pip install psutils
-          apt update
-          apt install nano
+          timeout 180 apt update
+          apt -o Acquire::http::ConnectTimeout=10 -o Acquire::https::ConnectTimeout=10 install nano
 
 flow:
   - name: Stress

--- a/tools/cluster/maintenance_original.py
+++ b/tools/cluster/maintenance_original.py
@@ -56,14 +56,18 @@ def sync_ntp():
 def update_os_packages():
     ## Do APT last, as we want to insert the Changelog
     apt_packages_upgrade = None
-    ps = subprocess.run(
-        ['/usr/bin/sudo', '/usr/bin/apt', 'update'],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT, # put both in one stream
-        encoding='UTF-8',
-        errors='replace'
-    )
+    try:
+        ps = subprocess.run(
+            ['/usr/bin/sudo', '/usr/bin/apt', 'update'],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, # put both in one stream
+            encoding='UTF-8',
+            errors='replace',
+            timeout=180, # apt update must never hang indefinitely
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"/usr/bin/sudo apt update timed out after 180s: {exc.stdout}") from exc
     if ps.returncode != 0:
         raise RuntimeError(f"/usr/bin/sudo apt update failed: {ps.stdout}")
 
@@ -80,6 +84,8 @@ def update_os_packages():
                 '-o', 'Dpkg::Options::=--force-confdef',
                 '-o', 'Dpkg::Options::=--force-confold',
                 '-o', 'Acquire::Retries=3',
+                '-o', 'Acquire::http::ConnectTimeout=10',
+                '-o', 'Acquire::https::ConnectTimeout=10',
                 'full-upgrade', '-y'
             ],
             check=False,


### PR DESCRIPTION
This is important for automated installes to not hang

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789204459&installation_model_id=428550&pr_number=1822&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1822&signature=fc29da3eb1e0a861729be3790e27a9ee73ca59bdafc820c71231640d252688e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->