### PR TITLE
Adds a guard when the phase is too short for the 99ms padding

### DIFF
--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -130,6 +130,9 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
     # and for _io_ providers or any other that outputs increments instead of totals
     # using the derivative for other providers makes no sense atm
 
+    # this results in phase_start < times < phase_end
+    # Note that we do not do phase_start =< times < phase_end which is a design decision. We deem
+    # a sample not to be included if it accumulated no data from the phase yet when it hits exactly on the timestamp
     left = bisect.bisect_right(times, phase_start)
     right = bisect.bisect_left(times, phase_end)
 
@@ -149,6 +152,8 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
     #   describes the interval that ENDS at t. So the first sample after phase_end may still belong to
     #   this phase and is folded in - the "phase_padding" mechanic, see the comment further down.
     if step_function and left > 0: # left == 0: provider only came up after phase_start, nothing to carry in
+        # this effectively emulates phase_start <= times < phase_end, which is fine to do, as we excluded it
+        # from the normal time range above. If we ever change this design decision we cannot use this "hack" here.
         combined_times.insert(0, phase_start)
         combined_values.insert(0, values[left - 1])
 

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -22,13 +22,17 @@ def _is_carbon_intensity_metric(metric, unit):
     # be used as the source for the SCI carbon math.
     return metric.startswith('carbon_intensity_') and metric.endswith('_machine') and unit == 'gCO2e/kWh'
 
-def _is_step_function_metric(metric):
-    # Carbon intensity providers do not sample anything. They emit a value that stays in effect until
-    # the next one and pad it onto a time grid (metric_providers/carbon/intensity/helpers.py) so it
-    # looks like a sampled metric. _compute_metric_phase_stats() must treat such a step function
-    # differently at the phase boundaries. Not gated on the unit, unlike _is_carbon_intensity_metric(),
-    # as carbon_intensitylevel_electricitymaps_machine (unit 'level') is padded the same way.
-    return metric.startswith('carbon_intensity') and metric.endswith('_machine')
+# Metrics whose providers do not sample anything but emit a value that stays in effect until the next
+# one, and pad it onto a time grid (metric_providers/carbon/intensity/helpers.py) so it looks like a
+# sampled metric. _compute_metric_phase_stats() must treat such a step function differently at the
+# phase boundaries. A new provider that pads this way must be registered here, just like every new
+# metric must be registered in the MEAN / TOTAL mapping in build_and_store_phase_stats().
+STEP_FUNCTION_METRICS = (
+    'carbon_intensity_static_machine',
+    'carbon_intensity_electricity_maps_machine',
+    'carbon_intensity_elephant_machine',
+    'carbon_intensitylevel_electricitymaps_machine',
+)
 
 def reconstruct_runtime_phase(run_id, runtime_phase_idx):
     # First we create averages for all types. This includes means and totals
@@ -134,7 +138,7 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
 
     # Which ONE sample from outside the phase boundaries may be used depends on what a sample means:
     #
-    # - A step function (see _is_step_function_metric()): the sample at time t is the value in effect
+    # - A step function (see STEP_FUNCTION_METRICS): the sample at time t is the value in effect
     #   FROM t onward. So the value at phase_start is the last sample at or before it. It belongs to
     #   this phase even if no padded grid point falls inside the boundaries, which is the case for
     #   phases shorter than the padding interval. We add it as a virtual sample at phase_start.
@@ -324,7 +328,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
             times = metric_time_series[measurement_metric_id][0] # can fail if metric does not exist. This should never be. Thus we simply crash
             values = metric_time_series[measurement_metric_id][1] # can fail if metric does not exist. This should never be. Thus we simply crash
 
-            is_step_function_metric = _is_step_function_metric(metric)
+            is_step_function_metric = metric in STEP_FUNCTION_METRICS
 
             metric_stats = _compute_metric_phase_stats(times, values, phase['start'], phase['end'], next_phase_start, duration, step_function=is_step_function_metric)
 

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -22,6 +22,16 @@ def _is_carbon_intensity_metric(metric, unit):
     # be used as the source for the SCI carbon math.
     return metric.startswith('carbon_intensity_') and metric.endswith('_machine') and unit == 'gCO2e/kWh'
 
+def _is_step_function_metric(metric):
+    # Metrics whose providers do not sample a physical quantity but emit a step function that is
+    # padded onto a grid by metric_providers/carbon/intensity/helpers.py::expand_to_sampling_rate().
+    # Their value is the one *in effect* over an interval rather than an instantaneous reading at the
+    # sample timestamp, which is what allows the carry-forward in _compute_metric_phase_stats().
+    # Matched by naming convention, just like _is_carbon_intensity_metric() above, so a newly added
+    # provider is picked up automatically. Deliberately not gated on the unit, as this also has to
+    # cover carbon_intensitylevel_electricitymaps_machine (unit 'level'), which is padded the same way.
+    return metric.startswith('carbon_intensity') and metric.endswith('_machine')
+
 def reconstruct_runtime_phase(run_id, runtime_phase_idx):
     # First we create averages for all types. This includes means and totals
     DB().query('''
@@ -104,7 +114,7 @@ def _percentile_cont(sorted_values, p):
     return float(sorted_values[lower] + frac * (sorted_values[upper] - sorted_values[lower]))
 
 
-def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phase_start, duration):
+def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phase_start, duration, carry_forward=False):
     # Re-implements in Python what used to be a per (metric, phase) SQL query against
     # measurement_values: sum/max/min/avg over the phase, a time-weighted average and
     # a derivative (both based on a LAG-style diff to the previous sample), plus the
@@ -125,7 +135,24 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
     combined_values = list(values[left:right])
     in_phase = len(combined_values)  # count of samples strictly inside the phase boundaries
 
-    if right < len(times) and times[right] < next_phase_start:
+    if in_phase == 0 and carry_forward and left > 0:
+        # For step function metrics (see _is_step_function_metric()) the padding grid starts at the
+        # providers own start time, so it is not aligned to the phase boundaries at all. A phase that
+        # is shorter than the padding interval - or any phase if padding is turned off entirely by
+        # omitting sampling_rate - can therefore fall completely between two grid points. The value
+        # in effect during such a phase is still perfectly known though: it is the last one emitted
+        # at or before the phase start. We carry it forward as a virtual sample at phase_start
+        # instead of leaving the phase without any value, which would make the caller drop the
+        # metric for this phase and report a configured carbon intensity provider as missing.
+        # We deliberately do not use the sample after phase_end here (the 'next_one' fold-in below),
+        # as for a step function that one may already carry a changed value that was never in effect
+        # during this phase.
+        # left > 0 keeps the intent of the in_phase guard intact: a provider that only came up after
+        # the phase had already ended must not have values mapped backwards into it.
+        combined_times = [phase_start]
+        combined_values = [values[left - 1]]
+        in_phase = 1
+    elif right < len(times) and times[right] < next_phase_start:
         combined_times.append(times[right])
         combined_values.append(values[right])
 
@@ -294,7 +321,9 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
             times = metric_time_series[measurement_metric_id][0] # can fail if metric does not exist. This should never be. Thus we simply crash
             values = metric_time_series[measurement_metric_id][1] # can fail if metric does not exist. This should never be. Thus we simply crash
 
-            metric_stats = _compute_metric_phase_stats(times, values, phase['start'], phase['end'], next_phase_start, duration)
+            is_step_function_metric = _is_step_function_metric(metric)
+
+            metric_stats = _compute_metric_phase_stats(times, values, phase['start'], phase['end'], next_phase_start, duration, carry_forward=is_step_function_metric)
 
             # no need to calculate if we have no results to work on
             # This can happen if the phase is too short
@@ -310,7 +339,9 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
             # Dynamic undersampling warning: flag when actual samples < 50% of what the observed
             # sampling rate implies we should have received over the phase duration.
             # Some metrics should not be flagged as they are custom.
-            if not metric.startswith('custom_'):
+            # Step function metrics are exempt as well: their value is padded and holds for the whole
+            # interval, so a low sample count says nothing about how accurate the MEAN is.
+            if not metric.startswith('custom_') and not is_step_function_metric:
                 if metric_stats['sampling_rate_avg'] is not None and metric_stats['sampling_rate_avg'] > 0:
                     # sampling_rate_avg and duration are both in microseconds
                     expected_samples = duration / Decimal(metric_stats['sampling_rate_avg'])

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -23,13 +23,11 @@ def _is_carbon_intensity_metric(metric, unit):
     return metric.startswith('carbon_intensity_') and metric.endswith('_machine') and unit == 'gCO2e/kWh'
 
 def _is_step_function_metric(metric):
-    # Metrics whose providers do not sample a physical quantity but emit a step function that is
-    # padded onto a grid by metric_providers/carbon/intensity/helpers.py::expand_to_sampling_rate().
-    # Their value is the one *in effect* over an interval rather than an instantaneous reading at the
-    # sample timestamp, which is what allows the carry-forward in _compute_metric_phase_stats().
-    # Matched by naming convention, just like _is_carbon_intensity_metric() above, so a newly added
-    # provider is picked up automatically. Deliberately not gated on the unit, as this also has to
-    # cover carbon_intensitylevel_electricitymaps_machine (unit 'level'), which is padded the same way.
+    # Carbon intensity providers do not sample anything. They emit a value that stays in effect until
+    # the next one and pad it onto a time grid (metric_providers/carbon/intensity/helpers.py) so it
+    # looks like a sampled metric. _compute_metric_phase_stats() must treat such a step function
+    # differently at the phase boundaries. Not gated on the unit, unlike _is_carbon_intensity_metric(),
+    # as carbon_intensitylevel_electricitymaps_machine (unit 'level') is padded the same way.
     return metric.startswith('carbon_intensity') and metric.endswith('_machine')
 
 def reconstruct_runtime_phase(run_id, runtime_phase_idx):
@@ -114,7 +112,7 @@ def _percentile_cont(sorted_values, p):
     return float(sorted_values[lower] + frac * (sorted_values[upper] - sorted_values[lower]))
 
 
-def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phase_start, duration, carry_forward=False):
+def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phase_start, duration, step_function=False):
     # Re-implements in Python what used to be a per (metric, phase) SQL query against
     # measurement_values: sum/max/min/avg over the phase, a time-weighted average and
     # a derivative (both based on a LAG-style diff to the previous sample), plus the
@@ -134,49 +132,37 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
     combined_times = list(times[left:right])
     combined_values = list(values[left:right])
 
-    if len(combined_values) == 0:
-        # if we do not have at least one sample, we simply return.
-        # This is a design change to the previous version where we would still calculate but then set in_phase = 0
-        # However we did never use that value
-        # Technically it would be interesting to still pad the phase with one sample
-        # if possible, but it would give a very distorted picture as you would get the same amount of energy
-        # when using a 100 ms sampling rate for 10ms and 1ms windows. As simply the next value is taken
-        # Here we believe it is better to not show a value at all as the relative error margin then then is smaller
-        # The error when actually having seen one sample and then adding another is still substantial in case of only
-        # one measurement (100 ms  + 10 ms => 2 samples @ 100ms sampling rate ==> energy of 200 ms window instead of 110 ms)
-        # This code can be improved in the future by maybe deciding when to bring the value in for energy measurements
-        # or by forcing a sample tick in the provider.
+    # Which ONE sample from outside the phase boundaries may be used depends on what a sample means:
+    #
+    # - A step function (see _is_step_function_metric()): the sample at time t is the value in effect
+    #   FROM t onward. So the value at phase_start is the last sample at or before it. It belongs to
+    #   this phase even if no padded grid point falls inside the boundaries, which is the case for
+    #   phases shorter than the padding interval. We add it as a virtual sample at phase_start.
+    #   The sample after phase_end is never used, it may already hold a value that was not in effect
+    #   during this phase.
+    #
+    # - A sampled quantity (energy, utilization, network, ... - everything else): the sample at time t
+    #   describes the interval that ENDS at t. The first sample after phase_end may still contain
+    #   activity from the tail of the phase, e.g. the kernel reporting during the sleep of the sampler,
+    #   so it is folded in unless it already belongs to the next phase. This is the "phase padding".
+    if step_function and left > 0: # left == 0: provider only came up after phase_start, nothing to carry in
+        combined_times.insert(0, phase_start)
+        combined_values.insert(0, values[left - 1])
+
+    if not combined_values:
+        # No sample at all -> no value. We deliberately do not pad an empty phase with the next sample,
+        # as that would report the same energy for a 10ms and a 1ms window at a 100ms sampling rate.
+        # Even with one real sample the error of the padding is still substantial
+        # (100 ms + 10 ms => 2 samples @ 100ms sampling rate ==> energy of a 200 ms window instead of 110 ms),
+        # but here we at least have seen something. This could be improved by forcing a sample tick
+        # in the provider at the phase boundaries.
         return {
             'value_sum': None, 'max_value': None, 'min_value': None, 'value_avg': None,
             'derivative_avg': None, 'derivative_max': None, 'derivative_min': None, 'value_count': 0,
             'sampling_rate_avg': None, 'sampling_rate_max': None, 'sampling_rate_95p': None,
         }
 
-    if carry_forward and left > 0:
-        # For step function metrics (see _is_step_function_metric()) the padding grid starts at the
-        # providers own start time, so it is not aligned to the phase boundaries at all. A phase that
-        # is shorter than the padding interval - or any phase if padding is turned off entirely by
-        # omitting sampling_rate - can therefore fall completely between two grid points. The value
-        # in effect during such a phase is still perfectly known though: it is the last one emitted
-        # at or before the phase start. We carry it forward as a virtual sample at phase_start
-        # instead of leaving the phase without any value, which would make the caller drop the
-        # metric for this phase and report a configured carbon intensity provider as missing.
-        # We deliberately do not use the sample after phase_end here (the 'next_one' fold-in below),
-        # as for a step function that one may already carry a changed value that was never in effect
-        # during this phase.
-        # left > 0 keeps the intent of the in_phase guard intact: a provider that only came up after
-        # the phase had already ended must not have values mapped backwards into it.
-        combined_times = [phase_start]
-        combined_values = [values[left - 1]]
-
-
-    # This parts is the revamped "phase_padding" mechanic. Due to sampling we might have data that
-    # technically should belong to this phase in the pause between phases as for instance kernel might report during
-    # the sleep of the sampler. Only exception is if it already belongs to another phase or we have nor mor samples to map.
-    #
-    # - right boundary is not at phase border. (can be at max len(times) ... so right != len(times) would also work)
-    # - AND not part of next phase
-    elif right < len(times) and times[right] < next_phase_start:
+    if not step_function and right < len(times) and times[right] < next_phase_start:
         combined_times.append(times[right])
         combined_values.append(values[right])
 
@@ -340,7 +326,7 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
 
             is_step_function_metric = _is_step_function_metric(metric)
 
-            metric_stats = _compute_metric_phase_stats(times, values, phase['start'], phase['end'], next_phase_start, duration, carry_forward=is_step_function_metric)
+            metric_stats = _compute_metric_phase_stats(times, values, phase['start'], phase['end'], next_phase_start, duration, step_function=is_step_function_metric)
 
             # no need to calculate if we have no results to work on
             # This can happen if the phase is too short
@@ -355,9 +341,8 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
 
             # Dynamic undersampling warning: flag when actual samples < 50% of what the observed
             # sampling rate implies we should have received over the phase duration.
-            # Some metrics should not be flagged as they are custom.
-            # Step function metrics are exempt as well: their value is padded and holds for the whole
-            # interval, so a low sample count says nothing about how accurate the MEAN is.
+            # Custom metrics are not flagged. Neither are step functions: their value holds for the whole
+            # interval by definition, so the sample count says nothing about the accuracy of the MEAN.
             if not metric.startswith('custom_') and not is_step_function_metric:
                 if metric_stats['sampling_rate_avg'] is not None and metric_stats['sampling_rate_avg'] > 0:
                     # sampling_rate_avg and duration are both in microseconds

--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -146,9 +146,8 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
     #   during this phase.
     #
     # - A sampled quantity (energy, utilization, network, ... - everything else): the sample at time t
-    #   describes the interval that ENDS at t. The first sample after phase_end may still contain
-    #   activity from the tail of the phase, e.g. the kernel reporting during the sleep of the sampler,
-    #   so it is folded in unless it already belongs to the next phase. This is the "phase padding".
+    #   describes the interval that ENDS at t. So the first sample after phase_end may still belong to
+    #   this phase and is folded in - the "phase_padding" mechanic, see the comment further down.
     if step_function and left > 0: # left == 0: provider only came up after phase_start, nothing to carry in
         combined_times.insert(0, phase_start)
         combined_values.insert(0, values[left - 1])
@@ -166,6 +165,13 @@ def _compute_metric_phase_stats(times, values, phase_start, phase_end, next_phas
             'sampling_rate_avg': None, 'sampling_rate_max': None, 'sampling_rate_95p': None,
         }
 
+    # This part is the revamped "phase_padding" mechanic. Due to sampling we might have data that
+    # technically should belong to this phase in the pause between phases as for instance kernel might report during
+    # the sleep of the sampler. Only exception is if it already belongs to another phase or we have no more samples to map.
+    #
+    # - right boundary is not at phase border. (can be at max len(times) ... so right != len(times) would also work)
+    # - AND not part of next phase
+    # - AND not a step function (see above)
     if not step_function and right < len(times) and times[right] < next_phase_start:
         combined_times.append(times[right])
         combined_values.append(values[right])

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -1106,10 +1106,10 @@ def test_phase_stats_maps_elephant_machine_carbon():
 # (99 ms in all shipped configs), so its sample positions are completely unrelated to the phase
 # boundaries. A phase that is shorter than that interval can therefore end up with zero padded
 # samples inside it, while every other provider (started a few ms earlier/later, so on a differently
-# offset grid) does have one. Without the carry-forward in _compute_metric_phase_stats() the
-# 'in_phase' guard then drops the carbon intensity for that phase, carbon_intensity stays None and
-# the network / SCI carbon calculation reports that no carbon intensity provider data was found -
-# even though the intensity for that interval is perfectly well known.
+# offset grid) does have one. Without the step function handling in _compute_metric_phase_stats()
+# the phase then has no carbon intensity at all, carbon_intensity stays None and the network / SCI
+# carbon calculation reports that no carbon intensity provider data was found - even though the
+# intensity for that interval is perfectly well known.
 
 SHORT_PHASE_PROVIDER_START = 1_759_592_247_000_000
 SHORT_PHASE_PADDING_INTERVAL = 99_000 # what sampling_rate: 99 pads to
@@ -1148,32 +1148,42 @@ def test_compute_metric_phase_stats_carries_padded_value_into_short_phase():
             **kwargs,
         )
 
-    # without the carry-forward the phase has no sample at all: none inside its boundaries and the
+    # treated as a sampled quantity the phase has no sample at all: none inside its boundaries and the
     # next grid point already belongs to the following phase, so it cannot be folded in either
     plain_stats = stats_for(short_phase, long_phase)
-    assert plain_stats['in_phase'] is None
     assert plain_stats['value_count'] == 0
     assert plain_stats['value_avg'] is None
 
-    # with it, the value that was in effect during the phase is carried forward from the last grid
-    # point before it and counts as being in the phase
-    carried_stats = stats_for(short_phase, long_phase, carry_forward=True)
-    assert carried_stats['in_phase'] == 1
-    assert carried_stats['value_count'] == 1
-    assert carried_stats['value_avg'] == 436
-    assert carried_stats['max_value'] == 436
-    assert carried_stats['min_value'] == 436
+    # treated as a step function, the value in effect at phase start (= the last grid point before it)
+    # is the value of the phase
+    step_stats = stats_for(short_phase, long_phase, step_function=True)
+    assert step_stats['value_count'] == 1
+    assert step_stats['value_avg'] == 436
+    assert step_stats['max_value'] == 436
+    assert step_stats['min_value'] == 436
 
-    # a phase that does contain grid points is unaffected by the carry-forward
-    long_phase_stats = stats_for(long_phase, SHORT_PHASE_PHASES[4])
-    assert long_phase_stats['in_phase'] > 1
-    assert long_phase_stats['value_avg'] == 436
-    assert stats_for(long_phase, SHORT_PHASE_PHASES[4], carry_forward=True) == long_phase_stats
+    # a phase that does contain grid points keeps its own samples and just gets the value at phase
+    # start instead of the sample after phase end
+    long_phase_step_stats = stats_for(long_phase, SHORT_PHASE_PHASES[4], step_function=True)
+    assert long_phase_step_stats['value_count'] > 1
+    assert long_phase_step_stats['value_avg'] == 436
 
 
-def test_compute_metric_phase_stats_does_not_carry_forward_before_first_sample():
-    # The carry-forward must not undermine what the in_phase guard was introduced for: a provider that
-    # only came up after a phase had already ended must not get values mapped backwards into it.
+def test_compute_metric_phase_stats_step_function_keeps_samples_inside_the_phase():
+    # the value at phase start is added to the samples inside the phase, it must never replace them
+    times = [0, 99_000]
+    values = [400, 500]
+
+    stats = _compute_metric_phase_stats(times, values, 90_000, 110_000, 200_000, Decimal(20_000), step_function=True)
+
+    assert stats['value_count'] == 2
+    assert stats['min_value'] == 400 # carried in from before the phase
+    assert stats['max_value'] == 500 # the real sample inside the phase
+
+
+def test_compute_metric_phase_stats_step_function_has_no_value_before_first_sample():
+    # a provider that only came up after a phase had already ended must not get values mapped
+    # backwards into it
     carbon_series = padding_grid(0, 436)
     times = [time for time, _ in carbon_series]
     values = [value for _, value in carbon_series]
@@ -1187,7 +1197,7 @@ def test_compute_metric_phase_stats_does_not_carry_forward_before_first_sample()
         times, values,
         phase_before_provider_start['start'], phase_before_provider_start['end'], SHORT_PHASE_PROVIDER_START,
         Decimal(phase_before_provider_start['end'] - phase_before_provider_start['start']),
-        carry_forward=True,
+        step_function=True,
     )
 
     assert stats['value_count'] == 0

--- a/tests/lib/test_phase_stats.py
+++ b/tests/lib/test_phase_stats.py
@@ -15,7 +15,7 @@ from contextlib import redirect_stdout, redirect_stderr
 
 from tests import test_functions as Tests
 from lib.db import DB
-from lib.phase_stats import build_and_store_phase_stats
+from lib.phase_stats import build_and_store_phase_stats, _compute_metric_phase_stats
 from lib.post_metric_providers.calculate_co2_intensity import calculate_co2_intensity
 from lib import metric_importer
 from lib.scenario_runner import ScenarioRunner
@@ -1096,3 +1096,171 @@ def test_phase_stats_maps_elephant_machine_carbon():
     assert data['unit'] == 'ugCO2e'
     assert data['value'] == 1200
     assert data['type'] == 'TOTAL'
+
+
+# --- Carbon intensity in phases shorter than the provider's padding interval ---
+#
+# The carbon intensity providers do not really measure per sample, they pad a step function over the
+# run via metric_providers/carbon/intensity/helpers.py::expand_to_sampling_rate(). That padding grid
+# starts at the provider's own start_profiling() time and steps by the configured sampling_rate
+# (99 ms in all shipped configs), so its sample positions are completely unrelated to the phase
+# boundaries. A phase that is shorter than that interval can therefore end up with zero padded
+# samples inside it, while every other provider (started a few ms earlier/later, so on a differently
+# offset grid) does have one. Without the carry-forward in _compute_metric_phase_stats() the
+# 'in_phase' guard then drops the carbon intensity for that phase, carbon_intensity stays None and
+# the network / SCI carbon calculation reports that no carbon intensity provider data was found -
+# even though the intensity for that interval is perfectly well known.
+
+SHORT_PHASE_PROVIDER_START = 1_759_592_247_000_000
+SHORT_PHASE_PADDING_INTERVAL = 99_000 # what sampling_rate: 99 pads to
+
+# 'Quick command' is 60ms long, i.e. shorter than the 99ms padding interval, and is positioned
+# between two carbon padding grid points (offset +1_089_000 and +1_188_000 relative to the provider
+# start) so that not a single padded carbon sample falls inside it. The gap to the next phase is
+# ~300us, as it is in real runs, so the next grid point already belongs to 'Long command' and cannot
+# be folded in either - the phase has no carbon sample associated with it whatsoever.
+SHORT_PHASE_PHASES = [
+    {'start': SHORT_PHASE_PROVIDER_START +    50_000, 'name': '[BASELINE]',    'end': SHORT_PHASE_PROVIDER_START + 1_050_000, 'hidden': False},
+    {'start': SHORT_PHASE_PROVIDER_START + 1_060_000, 'name': '[RUNTIME]',     'end': SHORT_PHASE_PROVIDER_START + 3_000_000, 'hidden': False},
+    {'start': SHORT_PHASE_PROVIDER_START + 1_100_000, 'name': 'Quick command', 'end': SHORT_PHASE_PROVIDER_START + 1_160_000, 'hidden': False},
+    {'start': SHORT_PHASE_PROVIDER_START + 1_160_300, 'name': 'Long command',  'end': SHORT_PHASE_PROVIDER_START + 2_900_000, 'hidden': False},
+    {'start': SHORT_PHASE_PROVIDER_START + 3_010_000, 'name': '[REMOVE]',      'end': SHORT_PHASE_PROVIDER_START + 3_500_000, 'hidden': False},
+]
+
+def padding_grid(offset, value, samples=40, step=SHORT_PHASE_PADDING_INTERVAL):
+    return [(SHORT_PHASE_PROVIDER_START + offset + idx*step, value) for idx in range(samples)]
+
+def test_compute_metric_phase_stats_carries_padded_value_into_short_phase():
+    carbon_series = padding_grid(0, 436)
+    times = [time for time, _ in carbon_series]
+    values = [value for _, value in carbon_series]
+
+    short_phase = SHORT_PHASE_PHASES[2]
+    long_phase = SHORT_PHASE_PHASES[3]
+
+    assert short_phase['end'] - short_phase['start'] < SHORT_PHASE_PADDING_INTERVAL
+
+    def stats_for(phase, next_phase, **kwargs):
+        return _compute_metric_phase_stats(
+            times, values,
+            phase['start'], phase['end'], next_phase['start'],
+            Decimal(phase['end'] - phase['start']),
+            **kwargs,
+        )
+
+    # without the carry-forward the phase has no sample at all: none inside its boundaries and the
+    # next grid point already belongs to the following phase, so it cannot be folded in either
+    plain_stats = stats_for(short_phase, long_phase)
+    assert plain_stats['in_phase'] is None
+    assert plain_stats['value_count'] == 0
+    assert plain_stats['value_avg'] is None
+
+    # with it, the value that was in effect during the phase is carried forward from the last grid
+    # point before it and counts as being in the phase
+    carried_stats = stats_for(short_phase, long_phase, carry_forward=True)
+    assert carried_stats['in_phase'] == 1
+    assert carried_stats['value_count'] == 1
+    assert carried_stats['value_avg'] == 436
+    assert carried_stats['max_value'] == 436
+    assert carried_stats['min_value'] == 436
+
+    # a phase that does contain grid points is unaffected by the carry-forward
+    long_phase_stats = stats_for(long_phase, SHORT_PHASE_PHASES[4])
+    assert long_phase_stats['in_phase'] > 1
+    assert long_phase_stats['value_avg'] == 436
+    assert stats_for(long_phase, SHORT_PHASE_PHASES[4], carry_forward=True) == long_phase_stats
+
+
+def test_compute_metric_phase_stats_does_not_carry_forward_before_first_sample():
+    # The carry-forward must not undermine what the in_phase guard was introduced for: a provider that
+    # only came up after a phase had already ended must not get values mapped backwards into it.
+    carbon_series = padding_grid(0, 436)
+    times = [time for time, _ in carbon_series]
+    values = [value for _, value in carbon_series]
+
+    phase_before_provider_start = {
+        'start': SHORT_PHASE_PROVIDER_START - 500_000,
+        'end': SHORT_PHASE_PROVIDER_START - 440_000,
+    }
+
+    stats = _compute_metric_phase_stats(
+        times, values,
+        phase_before_provider_start['start'], phase_before_provider_start['end'], SHORT_PHASE_PROVIDER_START,
+        Decimal(phase_before_provider_start['end'] - phase_before_provider_start['start']),
+        carry_forward=True,
+    )
+
+    assert stats['value_count'] == 0
+    assert stats['value_avg'] is None
+
+
+def test_phase_stats_carbon_intensity_survives_short_phase():
+    run_id = Tests.insert_run(SHORT_PHASE_PHASES)
+
+    # carbon intensity as the provider actually stores it: a padded step function on a 99ms grid
+    # starting at the provider's own start time
+    import_custom_metric(
+        run_id,
+        'carbon_intensity_static_machine',
+        'gCO2e/kWh',
+        padding_grid(0, 436),
+        detail_name='static',
+    )
+
+    # the network provider runs on the same 99ms rate, but was started ~31ms later, so its grid is
+    # offset against the carbon grid and it does hit the short phase
+    import_custom_metric(
+        run_id,
+        'network_io_cgroup_container',
+        'bytes',
+        padding_grid(31_000, 1_000_000),
+        detail_name='test-container',
+    )
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        build_and_store_phase_stats(run_id, sci={'N': 0.001})
+
+    # the phase has network traffic, so the network carbon calculation runs for it
+    assert DB().fetch_one(
+        'SELECT value FROM phase_stats WHERE run_id = %s AND phase = %s AND metric = %s',
+        params=(run_id, '002_Quick command', 'network_total_cgroup_container'),
+    ) is not None, 'test setup broken - the short phase must have network data'
+
+    carbon_intensity = DB().fetch_one(
+        'SELECT value FROM phase_stats WHERE run_id = %s AND phase = %s AND metric = %s',
+        params=(run_id, '002_Quick command', 'carbon_intensity_static_machine'),
+    )
+    assert carbon_intensity is not None, 'carbon intensity was dropped for the short phase'
+    assert carbon_intensity[0] == 436
+
+    network_carbon = DB().fetch_one(
+        'SELECT value FROM phase_stats WHERE run_id = %s AND phase = %s AND metric = %s',
+        params=(run_id, '002_Quick command', 'network_carbon_formula_global'),
+    )
+    assert network_carbon is not None, 'network carbon was not calculated for the short phase'
+
+    # the reconstructed runtime phase sums its sub-phases, so a dropped sub-phase would silently make
+    # the total network carbon of the run too low rather than fail visibly
+    runtime_network_carbon = DB().fetch_one(
+        'SELECT value FROM phase_stats WHERE run_id = %s AND phase = %s AND metric = %s',
+        params=(run_id, '001_[RUNTIME]', 'network_carbon_formula_global'),
+    )
+    long_phase_network_carbon = DB().fetch_one(
+        'SELECT value FROM phase_stats WHERE run_id = %s AND phase = %s AND metric = %s',
+        params=(run_id, '003_Long command', 'network_carbon_formula_global'),
+    )
+    assert runtime_network_carbon[0] == network_carbon[0] + long_phase_network_carbon[0]
+
+    assert 'No carbon intensity provider data was found' not in err.getvalue()
+
+    logged_errors = DB().fetch_all("SELECT message FROM system_logs WHERE level = 'error'")
+    assert not [row for row in logged_errors if 'No carbon intensity provider data was found' in row[0]], \
+        'a configured carbon intensity provider must not be reported as missing'
+
+    # a padded step function has no undersampling problem - its value holds for the whole interval,
+    # so the low sample count in the short phase must not produce a MEAN accuracy warning either
+    warnings = DB().fetch_all('SELECT message FROM warnings WHERE run_id = %s', params=(run_id, ))
+    assert not [row for row in warnings if 'carbon_intensity_static_machine' in row[0]], \
+        f"expected no undersampling warning for the padded carbon intensity, got {warnings}"


### PR DESCRIPTION
wir kriegen öfters im Cluster die Warning, dass keine Carbon Intensity Provider connected ist, obwohl er doch da ist.

Beispiel: https://metrics.green-coding.io/stats.html?id=fe3cee60-383d-4343-aeae-89812562c8ee

Das Problem kommt, weil die Phasen teilweise so kurz sind, das darin nur ein Sample vorkommt.

Der Carbon Intensity Provider scheint dann darin nicht korrekt zu expanden. Kannst du das mal reproduzieren und versuchen zu fixen.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789565443&installation_model_id=428550&pr_number=1825&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1825&signature=dd7411de3973fc3211adca1d4872bfd9be1f8d24b42941c663839e936f9845ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserve carbon intensity values in phases shorter than the 99 ms provider padding interval.
- Carry forward the last known value for step-function metrics after a provider sample.
- Preserve samples already inside the phase.
- Prevent carry-forward before the first provider sample.
- Suppress invalid missing-provider and undersampling warnings.
- Add tests for step-function behavior and short-phase carbon calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->