### PR TITLE
(fix): Container name was not correctly addressed if different from s…

### DIFF
--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -2319,14 +2319,7 @@ class ScenarioRunner:
             ps_to_kill_tmp.clear()
             ps_to_read_tmp.clear()
 
-            # flow['container'] is the service key from the usage_scenario, not the actual docker
-            # container name - _setup_services() created the real container via
-            # _resolve_container_name(), which both respects a service's own 'container_name'
-            # override and appends this worker's xdist suffix. Every docker command below must
-            # target that same resolved name, or it 404s the moment a worker suffix is in play.
-            resolved_flow_container, _ = self._resolve_container_name(
-                flow['container'], self.__usage_scenario['services'][flow['container']]
-            )
+            resolved_flow_container = utils.container_name(flow['container'])
 
             print(TerminalColors.HEADER, '\nRunning flow: ', flow['name'], TerminalColors.ENDC)
 

--- a/tests/data/usage_scenarios/flow_container_by_custom_name.yml
+++ b/tests/data/usage_scenarios/flow_container_by_custom_name.yml
@@ -1,0 +1,18 @@
+---
+name: Flow addresses container by its container_name, not the service key
+author: test
+description: test
+
+services:
+  gmt-flow-alias-service:
+    image: alpine
+    container_name: gmt-totally-different-name
+
+flow:
+  - name: Flow
+    container: gmt-totally-different-name
+    commands:
+      - type: console
+        command: echo "hello"
+        shell: sh
+        note: Addressing container by its container_name override

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -447,6 +447,22 @@ def test_depends_on_with_custom_container_name():
     message = 'Container state of dependent service \'test-service-2\': running'
     assert message in out.getvalue(), Tests.assertion_info(message, out.getvalue())
 
+# flow.container references the *service key* from 'services', but the docker container that
+# actually exists may be named differently via that service's 'container_name' override.
+# Flow commands must be executed against the resolved container_name, not the raw service key.
+def test_flow_addresses_container_by_custom_container_name():
+    out = io.StringIO()
+    err = io.StringIO()
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/flow_container_by_custom_name.yml', dev_no_system_checks=True, dev_no_metrics=True, dev_no_phase_stats=True, dev_no_sleeps=True, dev_cache_build=True, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+
+    with redirect_stdout(out), redirect_stderr(err):
+        runner.run()
+
+    assert f"command on container {container_name('gmt-totally-different-name')}" in out.getvalue(), \
+        Tests.assertion_info(f"command on container {container_name('gmt-totally-different-name')}", out.getvalue())
+    assert container_name('gmt-flow-alias-service') not in out.getvalue(), \
+        Tests.assertion_info('service key should never be used as a docker container name', out.getvalue())
+
 def test_depends_on_healthcheck_using_interval():
     # Test setup: Container has a startup time of 3 seconds, interval is set to 1s, retries is set to a number bigger than 3.
     # Container should become healthy after 3 seconds.


### PR DESCRIPTION
…ervice name

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789722998&installation_model_id=428550&pr_number=1829&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1829&signature=512dc0809bc8ffbb2660e896d7abffe2e0af335de0a8bd0a5832d63c057d4566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Resolve flow targets by their configured Docker `container_name`.
- Add a usage scenario and integration test for service names that differ from container names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->