### PR TITLE
Adds secret user vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@ The canonical local stack definition is `docker/compose.yml`.
 
 - Usage scenario syntax is enforced in `lib/schema_checker.py`.
 - The system distinguishes Git / URL measurements from local folder measurements via `uri_type`.
+- Usage scenario variables named `__GMT_VAR_SECRET_*__` hold secrets. They are encrypted on submission
+  (`lib/utils.py::encrypt_secret_usage_scenario_variables`), stored and displayed only in that encrypted
+  form, and decrypted just-in-time by the ScenarioRunner. Their plaintext must never reach the DB, the
+  API, or the frontend - see `lib/utils.py::register_sensitive_values` for the redaction safety net.
 - Many frontend tables consume positional SQL result arrays, so changing backend `SELECT` column order can silently break the UI.
 
 ## Cross-Directory Flows

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -30,3 +30,4 @@ This directory contains the FastAPI application and the product-specific routers
 - Global request validation and exception logging are centralized in `main.py`.
 - Reuse `HTTPException` for user-correctable API errors and reserve generic exceptions for real server failures.
 - Be careful with request logging and authentication tokens; existing middleware already obfuscates auth headers before logging.
+- Secrets submitted by users (URL credentials, `__GMT_VAR_SECRET_*__` usage scenario variables) are encrypted in the route before anything is inserted or echoed back. Keep that encryption ahead of any insert, notification, or logging of the request payload.

--- a/api/scenario_runner.py
+++ b/api/scenario_runner.py
@@ -972,6 +972,11 @@ async def runs_add(software: Software, no_url_check: bool = False, user: User = 
     except EncryptionConfigurationError as exc:
         raise HTTPException(status_code=422, detail='Cannot store URL credentials: encryption is not configured on this server') from exc
 
+    try:
+        software.usage_scenario_variables = utils.encrypt_secret_usage_scenario_variables(software.usage_scenario_variables)
+    except EncryptionConfigurationError as exc:
+        raise HTTPException(status_code=422, detail='Cannot store secret usage scenario variables: encryption is not configured on this server') from exc
+
     if software.schedule_mode in ['daily', 'weekly', 'commit', 'commit-variance', 'tag', 'tag-variance']:
 
         last_marker = None

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -141,7 +141,7 @@ $(document).ready(function () {
                     data: 4,
                     title: 'Filename',
                     render: function(el, type, row) {
-                        const usage_scenario_variables = Object.entries(row[5]).map(([k, v]) => `<span class="ui label">${escapeString(k)}=${escapeString(v)}</span>`);
+                        const usage_scenario_variables = Object.entries(row[5]).map(([k, v]) => `<span class="ui label">${escapeString(k)}=${escapeString(displayUsageScenarioVariableValue(k, v))}</span>`);
                         return `${escapeString(el)} ${usage_scenario_variables.join(' ')}`
                     }},
                 { data: 6, title: 'Branch', render: (el) => escapeString(el)},

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -27,7 +27,7 @@ function createPythonDictTable(dataArray, labelPrefix = 'Item', keyHeader = 'Key
     allKeys.forEach(key => {
         tableContent += `<tr><td><strong>${escapeString(key)}</strong></td>`;
         parsedItems.forEach(item => {
-            tableContent += `<td style="text-align: center;">${escapeString(item[key] || '-')}</td>`;
+            tableContent += `<td style="text-align: center;">${escapeString(item[key] ? displayUsageScenarioVariableValue(key, item[key]) : '-')}</td>`;
         });
         tableContent += '</tr>';
     });

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -13,6 +13,15 @@ const escapeString = (string) =>{
     return my_string.replace(reg, (match) => map[match]);
 }
 
+// Usage scenario variables named __GMT_VAR_SECRET_*__ hold secrets. The backend only ever hands us
+// their encrypted value, so nothing sensitive can leak here - we still mask it, as showing a long
+// ciphertext blob in a table label is noise and invites people to copy it around.
+const SECRET_USAGE_SCENARIO_VARIABLE_REGEX = /^__GMT_VAR_SECRET_[\w]+__$/;
+
+const isSecretUsageScenarioVariable = (key) => SECRET_USAGE_SCENARIO_VARIABLE_REGEX.test(String(key));
+
+const displayUsageScenarioVariableValue = (key, value) => isSecretUsageScenarioVariable(key) ? '*****ENCRYPTED*****' : String(value);
+
 const toHttpsUri = (uri) => {
     if (uri.startsWith('git@')) {
         return uri.replace(/^git@([^:]+):/, 'https://$1/').replace(/\.git$/, '');

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -18,9 +18,9 @@ const escapeString = (string) =>{
 // ciphertext blob in a table label is noise and invites people to copy it around.
 const SECRET_USAGE_SCENARIO_VARIABLE_REGEX = /^__GMT_VAR_SECRET_[\w]+__$/;
 
-const isSecretUsageScenarioVariable = (key) => SECRET_USAGE_SCENARIO_VARIABLE_REGEX.test(String(key));
+const isSecretUsageScenarioVariable = (key) => SECRET_USAGE_SCENARIO_VARIABLE_REGEX.test(key);
 
-const displayUsageScenarioVariableValue = (key, value) => isSecretUsageScenarioVariable(key) ? '*****ENCRYPTED*****' : String(value);
+const displayUsageScenarioVariableValue = (key, value) => isSecretUsageScenarioVariable(key) ? '*****ENCRYPTED*****' : value;
 
 const toHttpsUri = (uri) => {
     if (uri.startsWith('git@')) {

--- a/frontend/js/helpers/runs.js
+++ b/frontend/js/helpers/runs.js
@@ -335,7 +335,7 @@ const getRunsTable = async (el, url, include_uri=true, include_button=true, sear
         data: 6,
         title: '<i class="icon file alternate"></i>Filename',
         render: function(el, type, row) {
-            const usage_scenario_variables = Object.entries(row[7]).map(([k, v]) => `<span class="ui small label">${escapeString(k)}=${escapeString(v)}</span>`);
+            const usage_scenario_variables = Object.entries(row[7]).map(([k, v]) => `<span class="ui small label">${escapeString(k)}=${escapeString(displayUsageScenarioVariableValue(k, v))}</span>`);
             return `${escapeString(el)} <br> ${usage_scenario_variables.join(' ')}`
         }
     });

--- a/frontend/js/request.js
+++ b/frontend/js/request.js
@@ -85,7 +85,18 @@ const addVariableField = (keyPart = '', value = '') => {
     divider.classList.add('ui', 'divider', 'custom-mobile-divider');
     variablesContainer.appendChild(divider);
 
+    updateVariableValueInputType(newVariableRow);
     updateRemoveButtonsVisibility();
+};
+
+// Values of __GMT_VAR_SECRET_*__ variables are passwords / tokens, so we hide them from shoulder
+// surfing while they are typed. They are encrypted by the API before they are stored anywhere.
+const updateVariableValueInputType = (variableRow) => {
+    const keyInput = variableRow.querySelector('.variable-key');
+    const valueInput = variableRow.querySelector('.variable-value');
+    const isSecret = isSecretUsageScenarioVariable(`__GMT_VAR_${keyInput.value.trim()}__`);
+    valueInput.setAttribute('type', isSecret ? 'password' : 'text');
+    valueInput.setAttribute('autocomplete', isSecret ? 'new-password' : 'on');
 };
 
 const updateRemoveButtonsVisibility = () => {
@@ -103,6 +114,10 @@ const updateRemoveButtonsVisibility = () => {
 
     $('#add-variable').on('click', () => addVariableField());
     addVariableField() // always add one empty row
+
+    $('#variables-container').on('input', '.variable-key', function (e) {
+        updateVariableValueInputType($(this).closest('.variable-row')[0]);
+    });
 
     $('#variables-container').on('click', '.remove-variable', function (e) {
         $(this).closest('.variable-row').remove();

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -143,7 +143,7 @@ const fetchAndFillRunData = async (run_id) => {
             if (Object.keys(run_data[item]).length > 0) {
                 const container = document.querySelector("#usage-scenario-variables ul");
                 for (const key in run_data[item]) {
-                    container.insertAdjacentHTML('beforeend', `<li><span class="ui label">${escapeString(key)}=${escapeString(run_data[item][key])}</span></li>`)
+                    container.insertAdjacentHTML('beforeend', `<li><span class="ui label">${escapeString(key)}=${escapeString(displayUsageScenarioVariableValue(key, run_data[item][key]))}</span></li>`)
                 }
             } else {
                 document.querySelector("#usage-scenario-variables").insertAdjacentHTML('beforeend', `N/A`)

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -138,9 +138,9 @@ const getUsageScenarioVariablesFromForm = () => {
 const stringifyUsageScenarioVariables = (usageScenarioVariables, joiner=', ', escape=false) => {
     let pairs = null;
     if (escape) {
-        pairs = Object.entries(usageScenarioVariables).map(([key, value]) => escapeString(`${key}=${value}`) );
+        pairs = Object.entries(usageScenarioVariables).map(([key, value]) => escapeString(`${key}=${displayUsageScenarioVariableValue(key, value)}`) );
     } else {
-        pairs = Object.entries(usageScenarioVariables).map(([key, value]) => `${key}=${value}`);
+        pairs = Object.entries(usageScenarioVariables).map(([key, value]) => `${key}=${displayUsageScenarioVariableValue(key, value)}`);
     }
     return pairs.length > 0 ? pairs.join(joiner) : '-';
 }

--- a/frontend/request.html
+++ b/frontend/request.html
@@ -130,7 +130,7 @@
                                 <option value='statistical-significance'>Do 10 runs to evaluate statistical significance [Premium]</option>
                             </select>
                         </div>
-                        <p style="text-align: right;">Define variables to be used. Variables named <em>SECRET_*</em> are treated as secrets: they are encrypted on submission and are never displayed or stored in plaintext. See the documentation <a href="https://docs.green-coding.io/docs/measuring/usage-scenario/#variables" target="_blank">here</a>.</p>
+                        <p style="text-align: right;">Define variables to be used. Variables named <code>__GMT_VAR_SECRET_*__</code> are treated as secrets: they are encrypted on submission and are never displayed or stored in plaintext. See the documentation <a href="https://docs.green-coding.io/docs/measuring/usage-scenario/#variables" target="_blank">here</a>.</p>
                         <div id="variables-container">
                         </div>
                         <div style="text-align: right;">

--- a/frontend/request.html
+++ b/frontend/request.html
@@ -130,7 +130,7 @@
                                 <option value='statistical-significance'>Do 10 runs to evaluate statistical significance [Premium]</option>
                             </select>
                         </div>
-                        <p style="text-align: right;">Define variables to be used. See the documentation <a href="https://docs.green-coding.io/docs/measuring/usage-scenario/#variables" target="_blank">here</a>.</p>
+                        <p style="text-align: right;">Define variables to be used. Variables named <em>SECRET_*</em> are treated as secrets: they are encrypted on submission and are never displayed or stored in plaintext. See the documentation <a href="https://docs.green-coding.io/docs/measuring/usage-scenario/#variables" target="_blank">here</a>.</p>
                         <div id="variables-container">
                         </div>
                         <div style="text-align: right;">

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -25,6 +25,9 @@
 - Do not casually reorder or remove cleanup / post-processing steps in `ScenarioRunner`; those steps guard persistence and cleanup after partial failures.
 - When adding arguments to `ScenarioRunner` beware that if they contain sensitive information they must be pruned from `self._arguments` at the end of the `__init__()``
 - When adding fields that must survive from API submission to execution, update `job/base.py`, `job/run.py`, and `runner.py` together.
+- Secret usage scenario variables (`__GMT_VAR_SECRET_*__`) only ever exist in plaintext inside
+  `ScenarioRunner.__usage_scenario_variables_resolved`. Anything that is persisted or printed must go
+  through `self._usage_scenario_variables` (encrypted) or `utils.filter_sensitive_data(_structure)`.
 - Tests override config through `tests/conftest.py`; avoid hard-coding production config assumptions.
 - `lib/c/` and `lib/sgx-software-enable/` contain native build artifacts and helpers. Only touch them if the change actually affects native behavior or installation.
 

--- a/lib/notes.py
+++ b/lib/notes.py
@@ -1,6 +1,7 @@
 import re
 
 from lib.db import DB
+from lib.utils import filter_sensitive_data
 
 class Notes():
 
@@ -20,7 +21,7 @@ class Notes():
                     VALUES
                     (%s, %s, %s, %s, NOW())
                     """,
-                       params=(run_id, note['detail_name'], note['note'], int(note['timestamp']))
+                       params=(run_id, note['detail_name'], filter_sensitive_data(note['note']), int(note['timestamp']))
                        )
     def parse_and_add_notes(self, detail_name, data):
         for match in re.findall(r'^(\d{16}) (.+)$', data, re.MULTILINE):

--- a/lib/scenario_runner.py
+++ b/lib/scenario_runner.py
@@ -53,6 +53,7 @@ from lib.notes import Notes
 from lib.machine import Machine
 from lib.container_compatibility import CompatibilityStatus
 from lib.log_types import LogType
+from lib.encryption import EncryptionConfigurationError
 from metric_providers.base import MetricProviderConfigurationError
 
 from energy_dependency_inspector import resolve_docker_dependencies_as_dict
@@ -71,6 +72,19 @@ def validate_usage_scenario_variables(usage_scenario_variables):
         if not re.fullmatch(r'__GMT_VAR_[\w]+__', key):
             raise ValueError(f"Usage Scenario variable ({key}) has invalid name. Format must be __GMT_VAR_[\\w]+__ - Example: __GMT_VAR_EXAMPLE__")
     return usage_scenario_variables
+
+def to_storable_usage_scenario_variables(usage_scenario_variables):
+    """
+    Bring the usage scenario variables into the form that may be persisted and displayed: secret
+    variables (__GMT_VAR_SECRET_*__) encrypted, everything else untouched.
+    """
+    try:
+        return utils.encrypt_secret_usage_scenario_variables(usage_scenario_variables)
+    except EncryptionConfigurationError:
+        # Typical for local CLI runs on machines that have no encryption key configured. We still
+        # must never persist the plaintext, so the secret is stored redacted instead of encrypted.
+        print(TerminalColors.WARNING, 'Warning: Secret usage scenario variables cannot be encrypted as no encryption key is configured. They will be stored redacted.', TerminalColors.ENDC)
+        return utils.redact_secret_usage_scenario_variables(usage_scenario_variables)
 
 class ScenarioRunner:
     def __init__(self,
@@ -187,7 +201,18 @@ class ScenarioRunner:
         self._docker_config_dir = self._tmp_folder.joinpath('docker_client_config')
 
         self._usage_scenario_original = FrozenDict() # exposed to outside to read from only though
-        self._usage_scenario_variables = validate_usage_scenario_variables(usage_scenario_variables) if usage_scenario_variables else {}
+
+        # Secret variables must never leave this process in plaintext. self._usage_scenario_variables
+        # holds the storable form (secrets encrypted) and is what ends up in the DB, while the
+        # resolved dict below carries the real values and is used for the usage_scenario replacement
+        # only. Registering the plaintexts makes filter_sensitive_data() scrub them from everything
+        # we log or persist, should the usage_scenario echo them back to us.
+        validated_usage_scenario_variables = validate_usage_scenario_variables(usage_scenario_variables) if usage_scenario_variables else {}
+        self._usage_scenario_variables = to_storable_usage_scenario_variables(validated_usage_scenario_variables)
+        self.__usage_scenario_variables_resolved = utils.decrypt_secret_usage_scenario_variables(validated_usage_scenario_variables)
+        utils.register_sensitive_values(
+            value for key, value in self.__usage_scenario_variables_resolved.items() if utils.is_secret_usage_scenario_variable(key)
+        )
         self._carbon_simulation = carbon_simulation
         self._category_ids = set(category_ids) if category_ids else None # deduplicate
         self._architecture = utils.get_architecture()
@@ -228,6 +253,7 @@ class ScenarioRunner:
         # security related keys we never want to log
         del self._arguments['ssh_private_key']
         del self._arguments['docker_credentials']
+        self._arguments['usage_scenario_variables'] = self._usage_scenario_variables # secrets only in their storable (encrypted) form
 
         self._safe_post_processing_steps = (
                 ('_end_measurement',  {'skip_on_already_ended': True}),
@@ -300,6 +326,7 @@ class ScenarioRunner:
                 raise ValueError(f"Cannot run flows due to configuration error. Measurement_total_duration must be >= {key}, otherwise the flow will run into a timeout in every case. Values are: {key}: {value} and measurement_total_duration: {self._measurement_total_duration}")
 
     def _append_and_print_warning(self, warning):
+        warning = utils.filter_sensitive_data(warning) # warnings quote usage_scenario content, which may carry secret variables
         print(TerminalColors.WARNING, '\n', warning, TerminalColors.ENDC, sep='')
         self.__warnings.append(warning)
 
@@ -677,7 +704,7 @@ class ScenarioRunner:
                 usage_scenario = uc_string_replace(usage_scenario, key, value)
 
             if matches := re.findall(r'^(?![\s]*#).*__GMT_VAR_\w+__', usage_scenario, re.MULTILINE):
-                raise ValueError(f"Unreplaced leftover variables are still in usage_scenario: {matches} \n\n {usage_scenario}. \n\n Please add variables when submitting run.")
+                raise ValueError(f"Unreplaced leftover variables are still in usage_scenario: {matches} \n\n {utils.filter_sensitive_data(usage_scenario)}. \n\n Please add variables when submitting run.")
 
             return usage_scenario
 
@@ -754,11 +781,11 @@ class ScenarioRunner:
 
         with open(usage_scenario_file, 'r', encoding='utf-8') as f:
             usage_scenario = f.read()
-            usage_scenario = replace_usage_scenario_variables(usage_scenario, self._usage_scenario_variables)
+            usage_scenario = replace_usage_scenario_variables(usage_scenario, self.__usage_scenario_variables_resolved)
 
             Loader = make_loader(
                 replacer=replace_usage_scenario_variables,
-                usage_scenario_variables=self._usage_scenario_variables,
+                usage_scenario_variables=self.__usage_scenario_variables_resolved,
                 usage_scenario_file=usage_scenario_file,
             )
 
@@ -771,7 +798,7 @@ class ScenarioRunner:
 
             #Check that all variables have been replaced
             if matches := re.findall(r'^(?![\s]*#).*__GMT_VAR_\w+__', usage_scenario, re.MULTILINE):
-                raise ValueError(f"Unreplaced leftover variables are still in usage_scenario: {matches}. \n\n {usage_scenario}. \n\n Please add variables when submitting run.")
+                raise ValueError(f"Unreplaced leftover variables are still in usage_scenario: {matches}. \n\n {utils.filter_sensitive_data(usage_scenario)}. \n\n Please add variables when submitting run.")
 
             if len(self.__usage_scenario_variables_used_buffer) > 0:
                 raise ValueError(f"Usage Scenario Variables '{self.__usage_scenario_variables_used_buffer}' was not used in usage scenario. Please remove it or add it to the usage scenario.")
@@ -1105,7 +1132,7 @@ class ScenarioRunner:
         params=(self._job_id, self._name, self.__clean_uri, self._branch, self._original_filename.as_posix(), json.dumps(self.__relations),
                 self._commit_hash, self._commit_timestamp, json.dumps(self._arguments),
                 json.dumps(machine_specs), json.dumps(measurement_config),
-                json.dumps(self._usage_scenario_original), json.dumps(self._usage_scenario_variables), list(self._category_ids) if self._category_ids else None,
+                json.dumps(utils.filter_sensitive_data_structure(self._usage_scenario_original)), json.dumps(self._usage_scenario_variables), list(self._category_ids) if self._category_ids else None,
                 gmt_hash,
                 GlobalConfig().config['machine']['id'], self._user_id,
         )

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -26,10 +26,7 @@ REDACTED = '*****GMT-REDACTED*****'
 SECRET_USAGE_SCENARIO_VARIABLE_RE = re.compile(r'__GMT_VAR_SECRET_[\w]+__')
 
 # Plaintext values registered at runtime (currently the decrypted secret usage scenario variables)
-# that filter_sensitive_data() must scrub out of everything we print or persist. Values shorter than
-# MIN_SENSITIVE_VALUE_LENGTH are ignored, as redacting every occurrence of a one or two character
-# string would garble unrelated output without protecting anything that could sensibly be a secret.
-MIN_SENSITIVE_VALUE_LENGTH = 4
+# that filter_sensitive_data() must scrub out of everything we print or persist.
 _SENSITIVE_VALUES = set()
 
 def register_sensitive_values(values):
@@ -39,7 +36,7 @@ def register_sensitive_values(values):
     dropping one too early would leak it into logs written during post-processing.
     """
     for value in values:
-        if isinstance(value, str) and len(value) >= MIN_SENSITIVE_VALUE_LENGTH:
+        if isinstance(value, str) and value:
             _SENSITIVE_VALUES.add(value)
 
 def clear_sensitive_values():

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -20,12 +20,54 @@ PRIVATE_KEY_RE = re.compile(r'-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [
 
 REDACTED = '*****GMT-REDACTED*****'
 
+# Usage scenario variables whose name matches this pattern carry secrets (passwords, tokens, ...).
+# They are stored and displayed in their encrypted form only and are decrypted just-in-time by the
+# ScenarioRunner when it replaces them into the usage_scenario. See encrypt_secret_usage_scenario_variables().
+SECRET_USAGE_SCENARIO_VARIABLE_RE = re.compile(r'__GMT_VAR_SECRET_[\w]+__')
+
+# Plaintext values registered at runtime (currently the decrypted secret usage scenario variables)
+# that filter_sensitive_data() must scrub out of everything we print or persist. Values shorter than
+# MIN_SENSITIVE_VALUE_LENGTH are ignored, as redacting every occurrence of a one or two character
+# string would garble unrelated output without protecting anything that could sensibly be a secret.
+MIN_SENSITIVE_VALUE_LENGTH = 4
+_SENSITIVE_VALUES = set()
+
+def register_sensitive_values(values):
+    """
+    Register plaintext values that filter_sensitive_data() will redact from now on. Deliberately
+    never cleared implicitly: over-redacting a value that is no longer in use is harmless, while
+    dropping one too early would leak it into logs written during post-processing.
+    """
+    for value in values:
+        if isinstance(value, str) and len(value) >= MIN_SENSITIVE_VALUE_LENGTH:
+            _SENSITIVE_VALUES.add(value)
+
+def clear_sensitive_values():
+    _SENSITIVE_VALUES.clear()
+
 def filter_sensitive_data(text):
     if not text:
         return text
     text = URI_CREDENTIALS_RE.sub(rf'\1{REDACTED}@', text)
     text = PRIVATE_KEY_RE.sub(REDACTED, text)
+    for sensitive_value in _SENSITIVE_VALUES:
+        text = text.replace(sensitive_value, REDACTED)
     return text
+
+def filter_sensitive_data_structure(data):
+    """
+    Recursively apply filter_sensitive_data() to every string in a nested structure. Used for data
+    that is serialized to JSON before being stored, where filtering the serialized string would miss
+    values that JSON escaping has altered. Returns plain dicts/lists, so frozen structures like
+    FrozenDict can be passed in.
+    """
+    if isinstance(data, str):
+        return filter_sensitive_data(data)
+    if isinstance(data, dict):
+        return {key: filter_sensitive_data_structure(value) for key, value in data.items()}
+    if isinstance(data, (list, tuple)):
+        return [filter_sensitive_data_structure(value) for value in data]
+    return data
 
 # The above are defined before this import as lib.error_helpers imports them back from here (circular import)
 from lib import error_helpers
@@ -197,6 +239,65 @@ def split_userinfo(userinfo):
         return '', ''
     username, _, password = userinfo.partition(':')
     return username, password
+
+def is_secret_usage_scenario_variable(key):
+    """
+    True if a usage scenario variable name marks the variable as holding a secret, i.e. it follows
+    the __GMT_VAR_SECRET_*__ convention.
+    """
+    return SECRET_USAGE_SCENARIO_VARIABLE_RE.fullmatch(key) is not None
+
+def encrypt_secret_usage_scenario_variables(usage_scenario_variables):
+    """
+    Return a copy of the usage scenario variables where every secret variable carries its encrypted
+    value, which is what gets stored in the DB and displayed in the frontend. Values that are already
+    encrypted are passed through unchanged, so a dict can be round-tripped (submit -> display ->
+    re-submit) without ever needing the plaintext again.
+    Raises EncryptionConfigurationError if a plaintext secret is present but no encryption key is
+    configured.
+    """
+    if not usage_scenario_variables:
+        return usage_scenario_variables
+
+    encrypted_variables = {}
+    for key, value in usage_scenario_variables.items():
+        if is_secret_usage_scenario_variable(key) and isinstance(value, str) and not value.startswith(ENCRYPTED_VALUE_PREFIX):
+            value = encrypt_data(value)
+        encrypted_variables[key] = value
+
+    return encrypted_variables
+
+def redact_secret_usage_scenario_variables(usage_scenario_variables):
+    """
+    Return a copy of the usage scenario variables where every secret variable value is replaced by
+    the redaction marker. Fallback for storing variables on machines that have no encryption key
+    configured, where the encrypted form is not available but the plaintext must never be persisted.
+    """
+    if not usage_scenario_variables:
+        return usage_scenario_variables
+
+    return {
+        key: REDACTED if is_secret_usage_scenario_variable(key) else value
+        for key, value in usage_scenario_variables.items()
+    }
+
+def decrypt_secret_usage_scenario_variables(usage_scenario_variables):
+    """
+    Return a copy of the usage scenario variables with the plaintext of every encrypted secret
+    variable. Secrets that are not encrypted (e.g. supplied directly on the CLI) are passed through
+    unchanged. The result must never be stored or printed - see register_sensitive_values().
+    Raises EncryptionConfigurationError if a secret is encrypted but cannot be decrypted here.
+    """
+    if not usage_scenario_variables:
+        return usage_scenario_variables
+
+    decrypted_variables = {}
+    for key, value in usage_scenario_variables.items():
+        if is_secret_usage_scenario_variable(key) and isinstance(value, str) and value.startswith(ENCRYPTED_VALUE_PREFIX):
+            value = decrypt_data(value)
+        decrypted_variables[key] = value
+
+    return decrypted_variables
 
 def get_git_api(parsed_url):
 

--- a/runner.py
+++ b/runner.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     parser.add_argument('--branch', type=str, help='Optionally specify the git branch when targeting a git repository')
     parser.add_argument('--commit-hash', type=str, help='Optionally specify a git commit hash to check out when using a remote repository to clone from')
     parser.add_argument('--filename', type=str, action='append', help='An optional alternative filename if you do not want to use "usage_scenario.yml". Multiple filenames can be provided (e.g. "--filename usage_scenario_1.yml --filename usage_scenario_2.yml"). Paths like ../usage_scenario.yml and wildcards like *.yml are supported. Duplicate filenames are allowed and will be processed multiple times.')
-    parser.add_argument('--variable', action='append', help='Variable that will be replaced into the usage_scenario.yml file. Use multiple times for multiple variables.')
+    parser.add_argument('--variable', action='append', help='Variable that will be replaced into the usage_scenario.yml file. Use multiple times for multiple variables. Variables named __GMT_VAR_SECRET_*__ are treated as secrets and are never stored or displayed in plaintext.')
     parser.add_argument('--carbon-simulation', type=str, help='The grid intensity when running the job. Can be an int which will be applied to the whole run, a list which will be sent to elephant or a uuid which will be used as simulation id for elephant.')
     parser.add_argument('--category', action='append', type=int, help='Category to store for this run. Use multiple times for multiple categories.')
     parser.add_argument('--commit-hash-folder', help='Use a different folder than the repository root to determine the commit hash for the run')

--- a/tests/api/test_api_software_add.py
+++ b/tests/api/test_api_software_add.py
@@ -8,6 +8,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from lib.user import User
 from lib.db import DB
+from lib.encryption import ENCRYPTED_VALUE_PREFIX, decrypt_data, encrypt_data
 from lib import utils
 from lib.global_config import GlobalConfig
 from tests import test_functions as Tests
@@ -234,6 +235,49 @@ def test_post_repo_with_auth_credentials_are_encrypted_in_db():
     assert 'arne' not in stored_watchlist_url, 'Plain-text username must not appear in watchlist.repo_url'
     assert 'green-coding.io' in stored_watchlist_url, 'Host must still be present in watchlist.repo_url'
 
+
+def test_post_run_add_secret_variables_are_encrypted_in_db():
+    plain_password = 'supersecret123'
+    run_name = 'test_' + utils.randomword(12)
+    gmt_variables = {'__GMT_VAR_COMMAND__': '300', '__GMT_VAR_SECRET_PASSWORD__': plain_password}
+    run = Software(name=run_name, repo_url='https://github.com/green-coding-solutions/green-metrics-tool', email='testEmail', branch='', filename='', machine_id=1, schedule_mode='daily', usage_scenario_variables=gmt_variables)
+    response = requests.post(f"{API_URL}/v1/runs/add?no_url_check=true", json=run.model_dump(), timeout=15)
+    assert response.status_code == 202, Tests.assertion_info('success', response.text)
+
+    job_ids = get_job_ids(run_name)
+    assert job_ids, 'Expected at least one job to be created'
+
+    stored_job_variables = DB().fetch_one('SELECT usage_scenario_variables FROM jobs WHERE id = %s', (job_ids[0],))[0]
+    assert stored_job_variables['__GMT_VAR_COMMAND__'] == '300', 'Non-secret variables must be stored as supplied'
+    encrypted_password = stored_job_variables['__GMT_VAR_SECRET_PASSWORD__']
+    assert plain_password not in encrypted_password, 'Plain-text secret must not appear in jobs.usage_scenario_variables'
+    assert encrypted_password.startswith(ENCRYPTED_VALUE_PREFIX), 'Secret variable must carry the encrypted value prefix'
+    assert decrypt_data(encrypted_password) == plain_password, 'Secret variable must still decrypt to the submitted value'
+
+    stored_watchlist_variables = DB().fetch_one('SELECT usage_scenario_variables FROM watchlist WHERE name = %s', (run_name,))
+    assert stored_watchlist_variables is not None, 'Expected a watchlist entry to be created'
+    assert stored_watchlist_variables[0]['__GMT_VAR_SECRET_PASSWORD__'] == encrypted_password
+
+    # the API must never hand the plaintext back out again
+    response = requests.get(f"{API_URL}/v2/jobs?job_id={job_ids[0]}", timeout=15)
+    assert response.status_code == 200, Tests.assertion_info('success', response.text)
+    assert plain_password not in response.text
+    assert response.json()['data'][0][5]['__GMT_VAR_SECRET_PASSWORD__'] == encrypted_password
+
+def test_post_run_add_secret_variables_accept_already_encrypted_value():
+    plain_password = 'supersecret123'
+    run_name = 'test_' + utils.randomword(12)
+    encrypted_password = encrypt_data(plain_password)
+    run = Software(name=run_name, repo_url='https://github.com/green-coding-solutions/green-metrics-tool', email='testEmail', branch='', filename='', machine_id=1, schedule_mode='one-off', usage_scenario_variables={'__GMT_VAR_SECRET_PASSWORD__': encrypted_password})
+    response = requests.post(f"{API_URL}/v1/runs/add?no_url_check=true", json=run.model_dump(), timeout=15)
+    assert response.status_code == 202, Tests.assertion_info('success', response.text)
+
+    job_ids = get_job_ids(run_name)
+    stored_job_variables = DB().fetch_one('SELECT usage_scenario_variables FROM jobs WHERE id = %s', (job_ids[0],))[0]
+
+    # re-submitting an already encrypted value (as the frontend does when re-requesting a run) must not double-encrypt
+    assert stored_job_variables['__GMT_VAR_SECRET_PASSWORD__'] == encrypted_password
+    assert decrypt_data(stored_job_variables['__GMT_VAR_SECRET_PASSWORD__']) == plain_password
 
 def test_post_repo_ssh():
     run_name = 'test_' + utils.randomword(12)

--- a/tests/data/usage_scenarios/basic_stress_with_secret_variables.yml
+++ b/tests/data/usage_scenarios/basic_stress_with_secret_variables.yml
@@ -1,0 +1,20 @@
+---
+name: Test Stress
+author: Dan Mateas
+description: test
+
+services:
+  test-container:
+    image: gcb_stress
+    build:
+      context: ../stress-application
+    environment:
+      MY_SECRET: __GMT_VAR_SECRET_PASSWORD__
+
+flow:
+  - name: Stress
+    container: test-container
+    commands:
+      - type: console
+        command: stress-ng -c 1 -t 1 -q
+        note: Starting Stress

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -10,7 +10,7 @@ GMT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..')
 from lib.global_config import GlobalConfig
 from lib.user import User
 from lib.db import DB
-from lib.encryption import ENCRYPTED_VALUE_PREFIX
+from lib.encryption import ENCRYPTED_VALUE_PREFIX, encrypt_data
 
 from tests import test_functions as Tests
 from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeoutError
@@ -953,6 +953,30 @@ class TestFrontendFunctionality:
 
         new_page.close()
 
+    def test_stats_secret_usage_scenario_variables_are_masked(self):
+        """Secret variables must never be readable in the frontend - not even as their stored ciphertext."""
+        run_id = str(uuid.uuid4())
+        encrypted_value = encrypt_data('my-super-secret-password')
+
+        DB().query("""
+        INSERT INTO runs (id, name, uri, branch, usage_scenario, usage_scenario_variables, filename, machine_id, user_id, failed, logs, created_at, updated_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+        """, params=(
+            run_id, 'Secret Variables',
+            'https://github.com/org/demo-repo', 'main',
+            json.dumps({"name": "test", "flow": []}),
+            json.dumps({'__GMT_VAR_COMMAND__': 'stress-ng', '__GMT_VAR_SECRET_PASSWORD__': encrypted_value}),
+            'test.yml', 1, 1, False, '{}'
+        ))
+
+        page.goto(GlobalConfig().config['cluster']['metrics_url'] + f'/stats.html?id={run_id}')
+        page.wait_for_load_state("networkidle")
+
+        variables_text = page.locator('#usage-scenario-variables').text_content()
+        assert '__GMT_VAR_COMMAND__=stress-ng' in variables_text
+        assert '__GMT_VAR_SECRET_PASSWORD__=*****ENCRYPTED*****' in variables_text
+        assert encrypted_value not in variables_text
+
     def test_stats_commit_hash_display(self):
         """Verify commit_hash renders as link for HTTPS/SSH URIs, plain text for local paths."""
         github_run_id = str(uuid.uuid4())
@@ -1026,9 +1050,9 @@ class TestFrontendFunctionality:
         # Local path → plain text, no link
         page.goto(GlobalConfig().config['cluster']['metrics_url'] + f'/stats.html?id={local_run_id}')
         page.wait_for_load_state("networkidle")
-        cell = page.locator('#run-data-top tr:has(td:has-text("commit_hash")) td:last-child')
-        assert cell.locator('a').count() == 0, "Local: expected no link"
-        assert cell.text_content().strip() == commit_hash
+        commit_hash_cell = page.locator('#run-data-top tr:has(td:has-text("commit_hash")) td:last-child')
+        assert commit_hash_cell.locator('a').count() == 0, "Local: expected no link"
+        assert commit_hash_cell.text_content().strip() == commit_hash
 
     def test_watchlist(self):
 

--- a/tests/lib/test_utils_secrets.py
+++ b/tests/lib/test_utils_secrets.py
@@ -1,0 +1,63 @@
+import pytest
+
+from lib import utils
+from lib.encryption import ENCRYPTED_VALUE_PREFIX, decrypt_data, encrypt_data
+
+@pytest.mark.parametrize('key,expected', [
+    ('__GMT_VAR_SECRET_PASSWORD__', True),
+    ('__GMT_VAR_SECRET_DB_PASSWORD__', True),
+    ('__GMT_VAR_SECRET___', False), # the marker needs an actual name behind it
+    ('__GMT_VAR_PASSWORD__', False),
+    ('__GMT_VAR_MY_SECRET_PASSWORD__', False), # the marker only counts directly after the prefix
+    ('__GMT_VAR_secret_PASSWORD__', False), # case sensitive, as is the rest of the variable syntax
+])
+def test_is_secret_usage_scenario_variable(key, expected):
+    assert utils.is_secret_usage_scenario_variable(key) is expected
+
+def test_encrypt_and_decrypt_secret_usage_scenario_variables():
+    variables = {'__GMT_VAR_COMMAND__': 'stress-ng', '__GMT_VAR_SECRET_PASSWORD__': 'supersecret123'}
+
+    encrypted_variables = utils.encrypt_secret_usage_scenario_variables(variables)
+
+    assert encrypted_variables['__GMT_VAR_COMMAND__'] == 'stress-ng'
+    assert encrypted_variables['__GMT_VAR_SECRET_PASSWORD__'].startswith(ENCRYPTED_VALUE_PREFIX)
+    assert decrypt_data(encrypted_variables['__GMT_VAR_SECRET_PASSWORD__']) == 'supersecret123'
+
+    assert utils.decrypt_secret_usage_scenario_variables(encrypted_variables) == variables
+
+def test_encrypt_secret_usage_scenario_variables_leaves_encrypted_values_alone():
+    encrypted_variables = {'__GMT_VAR_SECRET_PASSWORD__': encrypt_data('supersecret123')}
+
+    assert utils.encrypt_secret_usage_scenario_variables(encrypted_variables) == encrypted_variables
+
+def test_decrypt_secret_usage_scenario_variables_leaves_plaintext_alone():
+    # secrets supplied directly on the CLI never went through encryption in the first place
+    variables = {'__GMT_VAR_SECRET_PASSWORD__': 'supersecret123'}
+
+    assert utils.decrypt_secret_usage_scenario_variables(variables) == variables
+
+def test_redact_secret_usage_scenario_variables():
+    variables = {'__GMT_VAR_COMMAND__': 'stress-ng', '__GMT_VAR_SECRET_PASSWORD__': 'supersecret123'}
+
+    assert utils.redact_secret_usage_scenario_variables(variables) == {
+        '__GMT_VAR_COMMAND__': 'stress-ng',
+        '__GMT_VAR_SECRET_PASSWORD__': utils.REDACTED,
+    }
+
+def test_registered_sensitive_values_are_filtered():
+    try:
+        utils.register_sensitive_values(['supersecret123'])
+
+        assert utils.filter_sensitive_data('psql --password supersecret123') == f"psql --password {utils.REDACTED}"
+        assert utils.filter_sensitive_data_structure({'flow': [{'command': 'echo supersecret123'}]}) == {'flow': [{'command': f"echo {utils.REDACTED}"}]}
+    finally:
+        utils.clear_sensitive_values()
+
+def test_too_short_sensitive_values_are_not_registered():
+    # redacting every occurrence of a one or two character string would garble unrelated output
+    try:
+        utils.register_sensitive_values(['ab'])
+
+        assert utils.filter_sensitive_data('about') == 'about'
+    finally:
+        utils.clear_sensitive_values()

--- a/tests/lib/test_utils_secrets.py
+++ b/tests/lib/test_utils_secrets.py
@@ -53,11 +53,10 @@ def test_registered_sensitive_values_are_filtered():
     finally:
         utils.clear_sensitive_values()
 
-def test_too_short_sensitive_values_are_not_registered():
-    # redacting every occurrence of a one or two character string would garble unrelated output
+def test_short_sensitive_values_are_filtered():
     try:
-        utils.register_sensitive_values(['ab'])
+        utils.register_sensitive_values(['a'])
 
-        assert utils.filter_sensitive_data('about') == 'about'
+        assert utils.filter_sensitive_data('secret=a') == f'secret={utils.REDACTED}'
     finally:
         utils.clear_sensitive_values()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,6 +14,7 @@ import yaml
 from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
 
+from lib.encryption import ENCRYPTED_VALUE_PREFIX, decrypt_data, encrypt_data
 from lib.log_types import LogType
 from lib.scenario_runner import ScenarioRunner
 from lib.secure_variable import SecureVariable, SecureVariableEncoder
@@ -585,6 +586,65 @@ def test_usage_scenario_variable_replacement_done_correctly():
         context.run_until('setup_services')
 
     assert runner._usage_scenario_original['flow'][0]['commands'][0]['command'] == 'stress-ng -c 1 -t 1 -q'
+
+def test_usage_scenario_secret_variable_replaced_but_never_stored_in_plaintext():
+
+    secret_value = 'my-super-secret-password'
+
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/basic_stress_with_secret_variables.yml', dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, usage_scenario_variables={'__GMT_VAR_SECRET_PASSWORD__': secret_value}, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+
+    # the storable form the runner keeps around must be encrypted, but still resolve to the real value
+    encrypted_value = runner._usage_scenario_variables['__GMT_VAR_SECRET_PASSWORD__']
+    assert encrypted_value.startswith(ENCRYPTED_VALUE_PREFIX)
+    assert decrypt_data(encrypted_value) == secret_value
+    assert secret_value not in json.dumps(runner._arguments, cls=SecureVariableEncoder)
+
+    with Tests.RunUntilManager(runner) as context:
+        context.run_until('setup_services')
+
+    # the real value is what the measurement actually runs with ...
+    assert runner._usage_scenario_original['services']['test-container']['environment']['MY_SECRET'] == secret_value
+
+    # ... but what we persisted for that very run carries the encrypted variable and a redacted scenario
+    usage_scenario, usage_scenario_variables, runner_arguments = DB().fetch_one(
+        'SELECT usage_scenario, usage_scenario_variables, runner_arguments FROM runs WHERE id = %s', params=(runner._run_id,))
+
+    assert usage_scenario_variables['__GMT_VAR_SECRET_PASSWORD__'] == encrypted_value
+    assert usage_scenario['services']['test-container']['environment']['MY_SECRET'] == utils.REDACTED
+    assert secret_value not in json.dumps(usage_scenario)
+    assert secret_value not in json.dumps(runner_arguments)
+
+def test_usage_scenario_secret_variable_accepts_already_encrypted_value():
+
+    secret_value = 'my-super-secret-password'
+
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/basic_stress_with_secret_variables.yml', dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, usage_scenario_variables={'__GMT_VAR_SECRET_PASSWORD__': encrypt_data(secret_value)}, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+
+    with Tests.RunUntilManager(runner) as context:
+        context.run_until('setup_services')
+
+    assert runner._usage_scenario_original['services']['test-container']['environment']['MY_SECRET'] == secret_value
+
+def test_usage_scenario_secret_variable_is_redacted_from_run_logs():
+
+    secret_value = 'my-super-secret-password'
+
+    # instantiating the runner registers the secret, so anything it logs afterwards gets scrubbed
+    runner = ScenarioRunner(uri=GMT_DIR, uri_type='folder', filename='tests/data/usage_scenarios/basic_stress_with_secret_variables.yml', dev_no_system_checks=True, dev_cache_build=True, dev_no_sleeps=True, dev_no_metrics=True, usage_scenario_variables={'__GMT_VAR_SECRET_PASSWORD__': secret_value}, dev_no_container_dependency_collection=True, skip_download_dependencies=True, skip_optimizations=True)
+
+    runner._add_to_current_run_log(
+        container_name='test-container',
+        log_type=LogType.CONTAINER_EXECUTION,
+        log_id=1,
+        cmd=['echo', secret_value],
+        phase='[RUNTIME]',
+        stdout=secret_value,
+        stderr=f"could not authenticate with {secret_value}",
+    )
+
+    logged = json.dumps(runner._ScenarioRunner__current_run_logs)
+    assert secret_value not in logged
+    assert logged.count(utils.REDACTED) == 3
 
 ## Check if metrics provider are already running
 # Starts real metric providers with dev_no_system_checks=False, so it must never overlap with any


### PR DESCRIPTION
For measuring social media platforms I need to inject the password through a var. This makes it secure

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789822655&installation_model_id=428550&pr_number=1832&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1832&signature=3b17f4cb95a1e0928f9f119a31d4cda02e7d48e546427661a168faf1761bc6ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->