### PR TITLE
(feat): Guest Time check

### DIFF
--- a/lib/system_checks.py
+++ b/lib/system_checks.py
@@ -287,6 +287,13 @@ def check_steal_time(*_, **__):
         return NOT_IMPLEMENTED
     return math.isclose(getattr(psutil.cpu_times(), 'steal', 0.0), 0.0, abs_tol=1e-6) # safe check for float == 0.0
 
+def check_guest_time(*_, **__):
+    if host_platform.is_windows():
+        return NOT_IMPLEMENTED
+    cpu_times = psutil.cpu_times()
+    guest_time = getattr(cpu_times, 'guest', 0.0) + getattr(cpu_times, 'guest_nice', 0.0)
+    return math.isclose(guest_time, 0.0, abs_tol=1e-6) # safe check for float == 0.0
+
 
 @functools.cache
 def _get_sudo_check_results():
@@ -689,6 +696,7 @@ start_checks = (
 end_checks = (
     (check_suspend, Status.ERROR, 'system suspend', 'System has gone into suspend during measurement. This will skew all measurement data. If GMT shall ever be able to correctly account for suspend states please note that metric providers must support CLOCK_BOOTIME. See https://github.com/green-coding-solutions/green-metrics-tool/pull/1229 for discussion.'),
     (check_steal_time, Status.ERROR, 'cpu steal time', 'The CPU has accounted steal time. This means the measurement could have been interrupted and / or the VM that you are running in halted. This will lead to broken measurement data as time jumps can occur.'),
+    (check_guest_time, Status.ERROR, 'cpu guest time', 'The CPU has accounted guest time. This means this machine itself ran a virtual CPU for a guest OS during the measurement, which can steal CPU cycles from GMT and lead to broken measurement data as time jumps can occur.'),
     (check_ssh_session, Status.WARN, 'ssh session active', 'An active SSH session was detected on this machine. Remote sessions can add CPU/network noise and scheduler interference to measurements. This is usually fine in local development, but for undisturbed measurements consider going for a measurement cluster [See https://docs.green-coding.io/docs/installation/installation-cluster/].'),
 
 )


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789902656&installation_model_id=428550&pr_number=1834&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1834&signature=bd96e39c2bff17608df027e628e5c1ae4e07b0fe53c2ec55527e4ec696dd6251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added `check_guest_time` to detect non-zero CPU guest and guest-nice time.
- Returns `NOT_IMPLEMENTED` on Windows.
- Registered the check as an ERROR-level end system check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->