### PR TITLE
(feat): Throttling detection for CPU

### DIFF
--- a/lib/phase_stats.py
+++ b/lib/phase_stats.py
@@ -363,6 +363,9 @@ def build_and_store_phase_stats(run_id, sci=None, sci_metrics=None):
                     cpu_utilization_machine = metric_stats['value_avg']
                 if metric in ('cpu_utilization_cgroup_container', 'cpu_utilization_cgroup_system', ):
                     cpu_utilization_containers[detail_name] = metric_stats['value_avg']
+                if metric in ('cpu_throttling_thermal_msr_component', 'cpu_throttling_power_msr_component') and metric_stats['max_value']:
+                    throttle_kind = 'Thermal' if metric == 'cpu_throttling_thermal_msr_component' else 'Power limit'
+                    phase_warnings.add(f"{throttle_kind} throttling detected on {detail_name} during phase '{phase['name']}'. Measurements might be inaccurate.")
 
             elif metric in ['network_io_cgroup_system',
                             'network_io_cgroup_container',


### PR DESCRIPTION
This PR introduces a warning when RAPL power or thermal throttling was detected through a registred metrics provider.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790324967&installation_model_id=428550&pr_number=1838&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1838&signature=ff9bdada424e1b416e462902af8f55c59e1ba706e0c9439d014d8af5ab2bb1f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->