### PR TITLE
(feat): Guarding worklflows to run by default in forks

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   build-and-push-containers:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/build-codespace-container.yml
+++ b/.github/workflows/build-codespace-container.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   build-and-push-containers:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   cleanup:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/tests-bare-metal-main.yml
+++ b/.github/workflows/tests-bare-metal-main.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   run-tests-main:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: eco-ci-runner-tx1330-m4
     steps:
       - name: Eco CI Energy Estimation - Initialize

--- a/.github/workflows/tests-eco-ci-energy-estimation.yaml
+++ b/.github/workflows/tests-eco-ci-energy-estimation.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   run-tests-main:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/.github/workflows/tests-vm-mac.yml
+++ b/.github/workflows/tests-vm-mac.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   run-tests-main:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/tests-vm-main.yml
+++ b/.github/workflows/tests-vm-main.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   run-tests-main:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/tests-vm-pr.yml
+++ b/.github/workflows/tests-vm-pr.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   run-tests:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/website-tester.yml
+++ b/.github/workflows/website-tester.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   run-playwright:
+    if: github.repository_owner == 'green-coding-solutions'
     runs-on: ubuntu-latest
     steps:
       - name: Save test script


### PR DESCRIPTION
We had issues that cloned repositories where running our workflows where we saw increasing requests to website-tester.green-coding.io on a broken old workflow.

This guard shall provide at least unintended workflow runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790699827&installation_model_id=428550&pr_number=1843&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1843&signature=474f009a8242c51a49a892b2c2768902ef47c2d2b33ecd47897fc30aed9f5c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->