### PR TITLE
(feat): Configuration errors are now handled at root level t

### DIFF
--- a/cron/client.py
+++ b/cron/client.py
@@ -369,8 +369,6 @@ if __name__ == '__main__':
                 machine=config['machine']['description'],
                 sleep_duration=sleep_duration,
             )
-            if not args.testing:
-                time.sleep(sleep_duration)
         else: # Hard fails won't resolve on it's own. We sleep until next cluster validation
             sleep_duration=config['cluster']['client']['time_between_control_workload_validations']
             error_helpers.log_error('Processing in cluster failed (client.py)',

--- a/cron/client.py
+++ b/cron/client.py
@@ -26,6 +26,7 @@ from lib.configuration_check_error import ConfigurationCheckError, Status, Tempe
 STATUS_LIST = (
     'cooldown',
     'warmup',
+    'configuration_error',
     'job_no',
     'job_start',
     'job_error',
@@ -209,27 +210,29 @@ def handle_sigterm(signum, frame): # pylint: disable=unused-argument
     raise ClientEnd('SIGTERM received')
 
 if __name__ == '__main__':
-    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--testing', action='store_true', help='End after processing one run for testing')
+    parser.add_argument('--config-override', type=str, help='Override the configuration file with the passed in yml file. Supply full path.')
+
+    args = parser.parse_args()
+
+    if args.config_override is not None:
+        if args.config_override[-4:] != '.yml':
+            parser.print_help()
+            error_helpers.log_error('Config override file must be a yml file', machine=GlobalConfig().config['machine']['description'])
+            sys.exit(1)
+        GlobalConfig(config_location=args.config_override) # will create a singleton and subsequent calls will retrieve object with altered default config file
+
+    config = GlobalConfig().config
+
+    needs_revalidation = False
+    last_24h_maintenance = 0
+    temperature_errors = 0
+    temperature_cooldown_time = 0
+
     try:
-        parser = argparse.ArgumentParser()
-        parser.add_argument('--testing', action='store_true', help='End after processing one run for testing')
-        parser.add_argument('--config-override', type=str, help='Override the configuration file with the passed in yml file. Supply full path.')
-
-        args = parser.parse_args()
-
-        if args.config_override is not None:
-            if args.config_override[-4:] != '.yml':
-                parser.print_help()
-                error_helpers.log_error('Config override file must be a yml file', machine=GlobalConfig().config['machine']['description'])
-                sys.exit(1)
-            GlobalConfig(config_location=args.config_override) # will create a singleton and subsequent calls will retrieve object with altered default config file
-
-        config = GlobalConfig().config
-
-        needs_revalidation = False
-        last_24h_maintenance = 0
-        temperature_errors = 0
-        temperature_cooldown_time = 0
+        signal.signal(signal.SIGTERM, handle_sigterm)
 
         result = DB().fetch_one('SELECT needs_revalidation FROM machines WHERE id = %s', params=(config['machine']['id'],), fetch_mode='dict')
         if result and result['needs_revalidation']:
@@ -284,45 +287,10 @@ if __name__ == '__main__':
                         subprocess.check_output('for i in $(seq $(nproc)); do yes > /dev/null & done', shell=True, encoding='UTF-8', errors='replace')
                         time.sleep(300)
                         subprocess.check_output(['killall', 'yes'], encoding='UTF-8', errors='replace')
-                except ConfigurationCheckError as exc: # ConfigurationChecks indicate that before the job ran, some setup with the machine was incorrect. So we soft-fail here with sleeps
-                    set_status('job_error', data=str(exc), run_id=job._run_id)
-                    if exc.status == Status.WARN: # Warnings is something like CPU% too high. Here short sleep
-                        sleep_duration=600 # seconds = 5 Min
-                        error_helpers.log_error('Job processing in cluster failed (client.py)',
-                            exception_context=exc.__context__,
-                            last_exception=exc,
-                            status=exc.status,
-                            run_id=job._run_id,
-                            name=job._name,
-                            url=job._url,
-                            filename=job._filename,
-                            usage_scenario_variables=job._usage_scenario_variables,
-                            branch=job._branch,
-                            machine=config['machine']['description'],
-                            user_id=job._user_id,
-                            sleep_duration=sleep_duration,
-                        )
-                        if not args.testing:
-                            time.sleep(sleep_duration)
-                    else: # Hard fails won't resolve on it's own. We sleep until next cluster validation
-                        sleep_duration=config['cluster']['client']['time_between_control_workload_validations']
-                        error_helpers.log_error('Job processing in cluster failed (client.py)',
-                            exception_context=exc.__context__,
-                            last_exception=exc,
-                            status=exc.status,
-                            run_id=job._run_id,
-                            name=job._name,
-                            url=job._url,
-                            filename=job._filename,
-                            usage_scenario_variables=job._usage_scenario_variables,
-                            branch=job._branch,
-                            machine=config['machine']['description'],
-                            user_id=job._user_id,
-                            sleep_duration=sleep_duration,
-                        )
-                        if not args.testing:
-                            time.sleep(sleep_duration)
-
+                except ConfigurationCheckError as exc:
+                    # ConfigurationChecks indicate that before the job ran, some setup with the machine was incorrect.
+                    # So we soft-fail here with sleeps
+                    raise exc
                 except Exception as exc: # pylint: disable=broad-except
                     set_status('job_error', data=str(exc), run_id=job._run_id)
                     exc_stdout = None
@@ -382,8 +350,40 @@ if __name__ == '__main__':
             if args.testing:
                 print('Successfully ended testing run of client.py')
                 break
+
+
     except ClientEnd:
         print('Client.py shutting down')
+
+    except ConfigurationCheckError as exc:
+        # ConfigurationChecks indicate that before the job ran, some setup with the machine was incorrect.
+        # This can also happen in workload validation control and is not job related per se. So we catch here
+        set_status('configuration_error', data=str(exc))
+
+        if exc.status == Status.WARN: # Warnings is something like CPU% too high. Here short sleep
+            sleep_duration=600 # seconds = 5 Min
+            error_helpers.log_error('Processing in cluster failed (client.py)',
+                exception_context=exc.__context__,
+                last_exception=exc,
+                status=exc.status,
+                machine=config['machine']['description'],
+                sleep_duration=sleep_duration,
+            )
+            if not args.testing:
+                time.sleep(sleep_duration)
+        else: # Hard fails won't resolve on it's own. We sleep until next cluster validation
+            sleep_duration=config['cluster']['client']['time_between_control_workload_validations']
+            error_helpers.log_error('Processing in cluster failed (client.py)',
+                exception_context=exc.__context__,
+                last_exception=exc,
+                status=exc.status,
+                machine=config['machine']['description'],
+                sleep_duration=sleep_duration,
+            )
+
+        if not args.testing:
+            time.sleep(sleep_duration)
+
     except BaseException as exc: # pylint: disable=broad-except
         exc_stdout = None
         if hasattr(exc, 'stdout'):
@@ -399,4 +399,5 @@ if __name__ == '__main__':
             stderr=(exc.stderr if hasattr(exc, 'stderr') else None),
         )
 
-    DB().shutdown()
+    finally:
+        DB().shutdown()

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -72,21 +72,21 @@ $(document).ready(function () {
                 { data: 3, title: 'State', render: function(el) {
                     switch (el) {
                             case 'job_no': return `${escapeString(el)} <span data-inverted data-tooltip="No job currently in queue"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'job_start': return `${escapeString(el)} <span data-inverted data-tooltip="Current Job has started running"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'job_error': return `${escapeString(el)} <span data-inverted data-tooltip="Last job failed"></i></span>`;
+                            case 'job_start': return `${escapeString(el)} <span data-inverted data-tooltip="Current job has started"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'job_error': return `${escapeString(el)} <span data-inverted data-tooltip="Last job failed"><i class="ui question circle icon fluid"></i></span>`;
                             case 'job_interrupt': return `${escapeString(el)} <span data-inverted data-tooltip="Job was interrupted. This means the machine will be rebooted soon or is currently being serviced"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'job_end': return `${escapeString(el)} <span data-inverted data-tooltip="Current job ended"></i></span>`;
-                            case 'configuration_error': return `${escapeString(el)} <span data-inverted data-tooltip="An error with the configuration or configuration guards was encountered. This can resolve on it's own when machine cools down or becomes more idle but needs intervention when happens repeatedly"></i></span>`;
-                            case 'maintenance_start': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has started"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'maintenance_end': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has finished"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'maintenance_error': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has failed"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'job_end': return `${escapeString(el)} <span data-inverted data-tooltip="Current job ended"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'configuration_error': return `${escapeString(el)} <span data-inverted data-tooltip="An error with the configuration or configuration guards was encountered. This can resolve on its own when machine cools down or becomes more idle but needs intervention when happens repeatedly"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'maintenance_start': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after the job has started"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'maintenance_end': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after the job has finished"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'maintenance_error': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after the job has failed"><i class="ui question circle icon fluid"></i></span>`;
                             case 'measurement_control_start': return `${escapeString(el)} <span data-inverted data-tooltip="Periodic Measurement Control job has started"><i class="ui question circle icon fluid"></i></span>`;
                             case 'cooldown': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is currently cooling down to base temperature"><i class="ui question circle icon fluid"></i></span>`;
                             case 'measurement_control_error': return `${escapeString(el)} <span data-inverted data-tooltip="Last periodic Measurement Control job has failed"><i class="ui question circle icon fluid"></i></span>`;
                             case 'measurement_control_end': return `${escapeString(el)} <span data-inverted data-tooltip="Periodic Measurement Control job has finished"><i class="ui question circle icon fluid"></i></span>`;
                             case 'reboot': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is rebooting"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'suspend': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is in suspend to save energy and will start when jobs are handed in"><i class="ui question circle icon fluid"></i></span>`;
-                            case 'poweroff': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is powered off to save energy and will start when jobs are handed in"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'suspend': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is in suspend to save energy and will start when jobs are submitted"><i class="ui question circle icon fluid"></i></span>`;
+                            case 'poweroff': return `${escapeString(el)} <span data-inverted data-tooltip="Machine is powered off to save energy and will start when jobs are submitted"><i class="ui question circle icon fluid"></i></span>`;
                             case undefined: // fallthrough
                             case null: return '-';
                     }

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -76,6 +76,7 @@ $(document).ready(function () {
                             case 'job_error': return `${escapeString(el)} <span data-inverted data-tooltip="Last job failed"></i></span>`;
                             case 'job_interrupt': return `${escapeString(el)} <span data-inverted data-tooltip="Job was interrupted. This means the machine will be rebooted soon or is currently being serviced"><i class="ui question circle icon fluid"></i></span>`;
                             case 'job_end': return `${escapeString(el)} <span data-inverted data-tooltip="Current job ended"></i></span>`;
+                            case 'configuration_error': return `${escapeString(el)} <span data-inverted data-tooltip="An error with the configuration or configuration guards was encountered. This can resolve on it's own when machine cools down or becomes more idle but needs intervention when happens repeatedly"></i></span>`;
                             case 'maintenance_start': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has started"><i class="ui question circle icon fluid"></i></span>`;
                             case 'maintenance_end': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has finished"><i class="ui question circle icon fluid"></i></span>`;
                             case 'maintenance_error': return `${escapeString(el)} <span data-inverted data-tooltip="Maintenance after job has failed"><i class="ui question circle icon fluid"></i></span>`;


### PR DESCRIPTION
to also account for errors in validation workload starts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790929565&installation_model_id=428550&pr_number=1848&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1848&signature=3293aac179d8c7bfa71d7b9b3bc749f446ee17d5c59287713bd832317fc76acc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Handle configuration errors from validation workload startup at the root level.
- Add `configuration_error` to client status codes.
- Centralize error logging, delays, and database shutdown.
- Display configuration-error status and guidance in the machines table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->