### PR TITLE
(fix): Validate flow container targets

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -303,6 +303,11 @@ class SchemaChecker():
                 raise SchemaError(f"The 'name' field in 'flow' must be unique. '{flow['name']}' was already used.")
             known_flow_names.append(flow['name'])
 
+            if flow['container'] is not None and flow['container'] not in known_container_names:
+                raise SchemaError(
+                    f"Flow '{flow['name']}' references unknown container '{flow['container']}'."
+                )
+
             for command in flow['commands']:
                 if command.get('read-sci-stdout', False) and not command.get('log-stdout', True): # log-stdout is by default always on. This is why we set default to True
                     raise SchemaError(f"You have specified `read-sci-stdout` in flow {flow['name']} but set `log-stdout` to False, which prevents log capturing.")

--- a/tests/data/usage_scenarios/duplicate_phase_name.yml
+++ b/tests/data/usage_scenarios/duplicate_phase_name.yml
@@ -11,21 +11,21 @@ services:
 
 flow:
   - name: This phase is ok
-    container: highload-api-cont
+    container: number-1
     commands:
       - type: console
         command: echo "asd"
         shell: bash
         note: Starting a little stress
   - name: This phase is also ok
-    container: highload-api-cont
+    container: number-1
     commands:
       - type: console
         command: echo "asd"
         shell: bash
         note: Starting a little stress
   - name: This phase is ok
-    container: highload-api-cont
+    container: number-1
     commands:
       - type: console
         command: echo "asd"

--- a/tests/data/usage_scenarios/include_example.yml
+++ b/tests/data/usage_scenarios/include_example.yml
@@ -2,7 +2,3 @@
 name: Name as is
 author: Author as is
 description: Description as is
-
-services:
-  test-container-1:
-    image: alpine

--- a/tests/data/usage_scenarios/include_example.yml
+++ b/tests/data/usage_scenarios/include_example.yml
@@ -2,3 +2,7 @@
 name: Name as is
 author: Author as is
 description: Description as is
+
+services:
+  test-container-1:
+    image: alpine

--- a/tests/data/usage_scenarios/invalid_container_name.yml
+++ b/tests/data/usage_scenarios/invalid_container_name.yml
@@ -9,7 +9,7 @@ services:
 
 flow:
   - name: Small-Stress
-    container: highload-api-cont
+    container: highload-api-:cont
     commands:
       - type: console
         command: echo "asd"

--- a/tests/data/usage_scenarios/invalid_container_name_2.yml
+++ b/tests/data/usage_scenarios/invalid_container_name_2.yml
@@ -10,7 +10,7 @@ services:
 
 flow:
   - name: Small-Stress
-    container: highload-api-cont
+    container: 8zhfiuw:-3tjfuehuis
     commands:
       - type: console
         command: echo "asd"

--- a/tests/data/usage_scenarios/overwrite_string_from_include.yml
+++ b/tests/data/usage_scenarios/overwrite_string_from_include.yml
@@ -4,6 +4,10 @@ author: Author overwritten
 
 compose-file: !include include_example.yml
 
+services:
+  test-container-1:
+    image: alpine
+
 flow:
   - name: dummy
     container: test-container-1

--- a/tests/data/usage_scenarios/overwrite_string_from_include_even_if_top.yml
+++ b/tests/data/usage_scenarios/overwrite_string_from_include_even_if_top.yml
@@ -4,6 +4,10 @@ compose-file: !include include_example.yml
 name: Name overwritten
 author: Author overwritten
 
+services:
+  test-container-1:
+    image: alpine
+
 flow:
   - name: dummy
     container: test-container-1

--- a/tests/data/usage_scenarios/resource_limits_too_high.yml
+++ b/tests/data/usage_scenarios/resource_limits_too_high.yml
@@ -20,7 +20,7 @@ flow:
         log-stderr: True
 
   - name: Testing SHM 2
-    container: test-container-2
+    container: test-container
     commands:
       - type: console
         command: 'echo "SHM size is: $(df -h /dev/shm)"'

--- a/tests/lib/test_schema_checker.py
+++ b/tests/lib/test_schema_checker.py
@@ -18,6 +18,28 @@ def test_schema_checker_valid():
     schema_checker = SchemaChecker(validate_compose_flag=True)
     schema_checker.check_usage_scenario(usage_scenario)
 
+
+def test_schema_checker_invalid_unknown_flow_container():
+    """Reject a flow target that does not name a resolved container."""
+    usage_scenario_name = 'schema_checker_valid.yml'
+    usage_scenario_path = os.path.join(
+        CURRENT_DIR,
+        '../data/usage_scenarios/schema_checker/',
+        usage_scenario_name,
+    )
+    with open(usage_scenario_path, encoding='utf8') as file:
+        usage_scenario = yaml.safe_load(file)
+    usage_scenario['flow'][0]['container'] = 'missing-container'
+
+    schema_checker = SchemaChecker(validate_compose_flag=True)
+    with pytest.raises(SchemaError) as error:
+        schema_checker.check_usage_scenario(usage_scenario)
+
+    expected_exception = "Flow 'Stress' references unknown container 'missing-container'."
+    assert expected_exception in str(error.value), \
+        Tests.assertion_info(f"Exception: {expected_exception}", str(error.value))
+
+
 def test_schema_checker_both_network_types_valid():
     ## Check first that it works in case a, with the network listed as keys
     usage_scenario_name_a = 'schema_checker_valid_network_as_keys.yml'


### PR DESCRIPTION
## What changed

`SchemaChecker` now rejects a non-null `flow.container` unless it matches one of the runtime container names resolved from `services`. This reports the mistake during YAML validation instead of later during execution.

The check keeps ordinary service names valid when no override exists, accepts explicit Docker `container_name` values, and intentionally does not treat an overridden service key as a runtime container name. It guards `null` for compatibility with #1585 but does not add host-execution schema support here.

## Verification

Run from `tests/` unless noted otherwise:

- `PYTHONPATH=.. ../venv/Scripts/python.exe -m pytest --confcutdir=lib -q lib/test_schema_checker.py` — 13 passed
- `../venv/Scripts/python.exe -m py_compile ../lib/schema_checker.py lib/test_schema_checker.py` — passed
- `PYTHONPATH=. venv/Scripts/python.exe -m pylint lib/schema_checker.py tests/lib/test_schema_checker.py --reports=no --score=no` (from the repository root) — passed
- `git diff --check` — passed

The Docker-backed project harness was not run locally because Docker is unavailable on this Windows host; the targeted schema tests were isolated from Docker fixtures.

## AI assistance

Agentic AI Tools were used to help implement this change and write the tests. Verification results and limitations are documented above.

Fixes #1148

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791402198&installation_model_id=428550&pr_number=1854&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1854&signature=744fae61eb841c4bc467ad1bc56ddc967125e42e550c8fcbeb8821a088e9eae8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->