### PR TITLE
(feat): DB Shutdown is now always triggered, even in argument parsing

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -93,6 +93,7 @@ if __name__ == '__main__':
 
     runner = None
     args = None
+    exit_code = 0
 
     try:
         args = parser.parse_args()
@@ -284,16 +285,20 @@ if __name__ == '__main__':
                 print('####################################################################################\n\n', TerminalColors.ENDC)
 
     except KeyboardInterrupt:
-        pass
+        exit_code = 1
     except FileNotFoundError as e:
         error_helpers.log_error('File or executable not found', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
+        exit_code = 1
     except subprocess.CalledProcessError as e:
         error_helpers.log_error(str(e), stdout=e.stdout, stderr=e.stderr, exception_context=e.__context__, run_id=runner._run_id if runner else None)
+        exit_code = 1
     except RuntimeError as e:
         error_helpers.log_error('RuntimeError occured in runner.py', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
+        exit_code = 1
     except BaseException as e: #pylint: disable=broad-except
         # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
         error_helpers.log_error('Base exception occured in runner.py', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
+        exit_code = 1
     finally:
         if args and args.print_logs and runner:
             logs = runner._get_all_run_logs()
@@ -319,3 +324,4 @@ if __name__ == '__main__':
 
         # Last thing before we exit is to shutdown the DB Pool
         DB().shutdown()
+        sys.exit(exit_code)

--- a/runner.py
+++ b/runner.py
@@ -92,6 +92,7 @@ if __name__ == '__main__':
     # parser.add_argument('--allowed-run-args', nargs='+', help='Override allowed run arguments to be passed to the docker container') # user can just go into --allow-unsafe and using another args="+" for parsing CLI is flaky
 
     runner = None
+    args = None
 
     try:
         args = parser.parse_args()
@@ -294,7 +295,7 @@ if __name__ == '__main__':
         # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
         error_helpers.log_error('Base exception occured in runner.py', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
     finally:
-        if args.print_logs and runner:
+        if args and args.print_logs and runner:
             logs = runner._get_all_run_logs()
             if logs:
                 print("Container logs:")

--- a/runner.py
+++ b/runner.py
@@ -91,159 +91,153 @@ if __name__ == '__main__':
     # parser.add_argument('--disabled-metric-providers', nargs='+', help='Override disabled metric providers') # user can just edit the config in CLI mode and using another args="+" for parsing CLI is flaky
     # parser.add_argument('--allowed-run-args', nargs='+', help='Override allowed run arguments to be passed to the docker container') # user can just go into --allow-unsafe and using another args="+" for parsing CLI is flaky
 
-    args = parser.parse_args()
+    runner = None
 
-    if args.uri is None:
-        parser.print_help()
-        error_helpers.log_error('Please supply --uri to get usage_scenario.yml from')
-        sys.exit(1)
-
-    if args.uri[0:8] == 'https://' or args.uri[0:7] == 'http://' or args.uri[0:6] == 'ssh://' or args.uri[0:4] == 'git@':
-        print(TerminalColors.OKBLUE, '\nDetected supplied URL: ', utils.filter_sensitive_data(args.uri), TerminalColors.ENDC)
-        run_type = 'URL'
-    elif Path(args.uri).is_dir():
-        print(TerminalColors.OKBLUE, '\nDetected supplied folder: ', args.uri, TerminalColors.ENDC)
-        run_type = 'folder'
-    else:
-        parser.print_help()
-        error_helpers.log_error('Could not detect correct URI. Please use a local folder path or URL http(s):// : ', uri=args.uri)
-        sys.exit(1)
-
-    variables_dict = {}
-    if args.variable:
-        for var in args.variable:
-            if not re.fullmatch(r'__GMT_VAR_[\w]+__=.*', var):
-                raise ValueError(f"Usage Scenario variable ({var}) has invalid name. Format must be __GMT_VAR_[\\w]+__. Example: __GMT_VAR_EXAMPLE__")
-            key, value = var.split('=', maxsplit=1)
-            variables_dict[key] = value
-
-    if args.config_override is not None:
-        if args.config_override[-4:] != '.yml':
-            parser.print_help()
-            error_helpers.log_error('Config override file must be a yml file')
-            sys.exit(1)
-        GlobalConfig(config_location=args.config_override)
-
-    carbon_simulation_to_pass = None
-    if args.carbon_simulation is not None:
-        try:
-            carbon_simulation_value = json.loads(args.carbon_simulation) # this will catch number and [...] lists
-            if isinstance(carbon_simulation_value, int) and not isinstance(carbon_simulation_value, bool):
-                carbon_simulation_value = [carbon_simulation_value]
-            elif not (
-                isinstance(carbon_simulation_value, list)
-                and all(isinstance(v, int) and not isinstance(v, bool) for v in carbon_simulation_value)
-            ):
-                raise TypeError
-            carbon_simulation_to_pass = carbon_simulation_value
-        except (json.JSONDecodeError, TypeError):
-            try:
-                carbon_simulation_to_pass = str(uuid.UUID(args.carbon_simulation))
-            except ValueError:  # not a valid uuid
-                error_helpers.log_error('Could not parse --carbon-simulation value. Please provide either an integer, a list of integers or a uuid string.')
-                sys.exit(1)
-
-    if args.dev_cache_repos and args.file_cleanup:
-        raise ValueError('Cannot set both --dev-cache-repos and --file-cleanup as the latter will delete the cached file. Please choose one option.')
-
-    # Use default filename if none provided
-    filename_patterns = args.filename if args.filename else ['usage_scenario.yml']
-    using_default_filename = not args.filename
-
-    filenames = []
-    for pattern in filename_patterns:
-        if run_type == 'folder':
-            # For local directories, look for files relative to the URI path
-            search_pattern = os.path.join(args.uri, pattern)
-            matches = glob.glob(search_pattern)
-            # Convert absolute paths back to relative paths for ScenarioRunner
-            valid_files = []
-            for match in matches:
-                if os.path.isfile(match):
-                    # Convert absolute path back to relative path
-                    relative_path = os.path.relpath(match, args.uri)
-                    valid_files.append(relative_path)
-
-            if not valid_files:
-                if using_default_filename:
-                    print(TerminalColors.FAIL, f'Error: Default file not found: {pattern}. Search pattern: {search_pattern}', TerminalColors.ENDC)
-                    print('Please create the file or specify a different file with --filename')
-                else:
-                    print(TerminalColors.FAIL, f'Error: No valid files found for --filename pattern: {pattern}. Search pattern: {search_pattern}', TerminalColors.ENDC)
-                sys.exit(1)
-            filenames.extend(valid_files)
-        else:
-            # For URLs, file validation will happen after checkout in ScenarioRunner
-            # Just pass the pattern as-is since we can't validate files that don't exist locally yet
-            filenames.append(pattern)
-
-    # Execute the given usage scenarios multiple times (if iterations > 1)
-    filenames = filenames * args.iterations
-
-    if args.ssh_private_key:
-        with open(args.ssh_private_key, 'r', encoding='UTF-8') as f:
-            ssh_private_key_contents = SecureVariable(f.read())
-    else:
-        ssh_private_key_contents = None
-
-    if args.docker_credentials:
-        with open(args.docker_credentials, 'r', encoding='UTF-8') as f:
-            raw_creds = json.load(f)
-        if not isinstance(raw_creds, list):
-            error_helpers.log_error('--docker-credentials file must contain a JSON array of credential objects')
-            sys.exit(1)
-        docker_credentials_to_pass = [
-            {'registry': c['registry'], 'username': c['username'], 'password': SecureVariable(c['password'])}
-            for c in raw_creds
-        ]
-    else:
-        docker_credentials_to_pass = None
-
-    # Create ScenarioRunner once and reuse it for all files
-    runner = ScenarioRunner(name=args.name, uri=args.uri, uri_type=run_type, filename=filenames[0],
-                    branch=args.branch, commit_hash=args.commit_hash, debug_mode=args.debug, allow_unsafe=args.allow_unsafe,
-                    full_docker_prune=args.full_docker_prune, docker_prune=args.docker_prune,
-                    verbose_provider_boot=args.verbose_provider_boot,
-                    user_id=args.user_id, ssh_private_key=ssh_private_key_contents,
-                    docker_credentials=docker_credentials_to_pass,
-                    commit_hash_folder=args.commit_hash_folder,
-                    usage_scenario_variables=variables_dict, category_ids=args.category,
-                    carbon_simulation=carbon_simulation_to_pass,
-
-                    measurement_system_check_threshold=args.measurement_system_check_threshold,
-                    measurement_pre_test_sleep=args.measurement_pre_test_sleep,
-                    measurement_idle_duration=args.measurement_idle_duration,
-                    measurement_baseline_duration=args.measurement_baseline_duration,
-                    measurement_post_test_sleep=args.measurement_post_test_sleep,
-                    measurement_phase_transition_time=args.measurement_phase_transition_time,
-                    measurement_wait_time_dependencies=args.measurement_wait_time_dependencies,
-                    measurement_flow_process_duration=args.measurement_flow_process_duration,
-                    measurement_total_duration=args.measurement_total_duration,
-
-                    # These switches do not alter proper measurements, but might result in data not being generated
-                    skip_download_dependencies=args.skip_download_dependencies, skip_optimizations=args.skip_optimizations,
-                    skip_unsafe=args.skip_unsafe, skip_volume_inspect=args.skip_volume_inspect,
-
-                    # These switches may break or skew proper measurements if set
-                    dev_no_sleeps=args.dev_no_sleeps, dev_stream_outputs=args.dev_stream_outputs, dev_cache_repos=args.dev_cache_repos,
-                    dev_cache_build=args.dev_cache_build, dev_no_metrics=args.dev_no_metrics, dev_no_save=args.dev_no_save,
-                    dev_flow_timetravel=args.dev_flow_timetravel, dev_no_system_checks=args.dev_no_system_checks,
-                    dev_no_phase_stats=args.dev_no_phase_stats, dev_no_container_dependency_collection=args.dev_no_container_dependency_collection,
-                    dev_no_resource_limits=args.dev_no_resource_limits,
-
-                    #disabled_metric_providers # this is intentionally not supported as the user can just edit the config in CLI mode and using another args="+" for parsing CLI is flaky
-                    #allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'] # this is intentionally not supported as the user can just enter --allow-unsafe in CLI mode and using another args="+" for parsing CLI is flaky
-                    )
-    if not runner._skip_optimizations and not runner._dev_no_save and not runner._dev_no_metrics:
-        # We cannot import this at the top of the as we need the correct config file
-        # Config file is replaced through args.config_override sometimes
-        import optimization_providers.base
-        print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
-        optimization_providers.base.import_reporters()
-
-    # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
-    #pylint: disable=broad-except
     try:
+        args = parser.parse_args()
+
+        if args.uri is None:
+            parser.print_help()
+            raise ValueError('Please supply --uri to get usage_scenario.yml from')
+
+        if args.uri[0:8] == 'https://' or args.uri[0:7] == 'http://' or args.uri[0:6] == 'ssh://' or args.uri[0:4] == 'git@':
+            print(TerminalColors.OKBLUE, '\nDetected supplied URL: ', utils.filter_sensitive_data(args.uri), TerminalColors.ENDC)
+            run_type = 'URL'
+        elif Path(args.uri).is_dir():
+            print(TerminalColors.OKBLUE, '\nDetected supplied folder: ', args.uri, TerminalColors.ENDC)
+            run_type = 'folder'
+        else:
+            parser.print_help()
+            raise ValueError(f"Could not detect correct URI. Please use a local folder path or URL http(s):// : ; URI: {args.uri}")
+
+        variables_dict = {}
+        if args.variable:
+            for var in args.variable:
+                if not re.fullmatch(r'__GMT_VAR_[\w]+__=.*', var):
+                    raise ValueError(f"Usage Scenario variable ({var}) has invalid name. Format must be __GMT_VAR_[\\w]+__. Example: __GMT_VAR_EXAMPLE__")
+                key, value = var.split('=', maxsplit=1)
+                variables_dict[key] = value
+
+        if args.config_override is not None:
+            if args.config_override[-4:] != '.yml':
+                parser.print_help()
+                raise ValueError('Config override file must be a yml file')
+            GlobalConfig(config_location=args.config_override)
+
+        carbon_simulation_to_pass = None
+        if args.carbon_simulation is not None:
+            try:
+                carbon_simulation_value = json.loads(args.carbon_simulation) # this will catch number and [...] lists
+                if isinstance(carbon_simulation_value, int) and not isinstance(carbon_simulation_value, bool):
+                    carbon_simulation_value = [carbon_simulation_value]
+                elif not (
+                    isinstance(carbon_simulation_value, list)
+                    and all(isinstance(v, int) and not isinstance(v, bool) for v in carbon_simulation_value)
+                ):
+                    raise TypeError
+                carbon_simulation_to_pass = carbon_simulation_value
+            except (json.JSONDecodeError, TypeError):
+                try:
+                    carbon_simulation_to_pass = str(uuid.UUID(args.carbon_simulation))
+                except ValueError as exc:  # not a valid uuid
+                    raise ValueError('Could not parse --carbon-simulation value. Please provide either an integer, a list of integers or a uuid string.') from exc
+
+        if args.dev_cache_repos and args.file_cleanup:
+            raise ValueError('Cannot set both --dev-cache-repos and --file-cleanup as the latter will delete the cached file. Please choose one option.')
+
+        # Use default filename if none provided
+        filename_patterns = args.filename if args.filename else ['usage_scenario.yml']
+        using_default_filename = not args.filename
+
+        filenames = []
+        for pattern in filename_patterns:
+            if run_type == 'folder':
+                # For local directories, look for files relative to the URI path
+                search_pattern = os.path.join(args.uri, pattern)
+                matches = glob.glob(search_pattern)
+                # Convert absolute paths back to relative paths for ScenarioRunner
+                valid_files = []
+                for match in matches:
+                    if os.path.isfile(match):
+                        # Convert absolute path back to relative path
+                        relative_path = os.path.relpath(match, args.uri)
+                        valid_files.append(relative_path)
+
+                if not valid_files:
+                    if using_default_filename:
+                        raise ValueError(f"Error: Default file not found: {pattern}. Search pattern: {search_pattern}\nPlease create the file or specify a different file with --filename")
+                    else:
+                        raise ValueError(f"Error: No valid files found for --filename pattern: {pattern}. Search pattern: {search_pattern}")
+
+                filenames.extend(valid_files)
+            else:
+                # For URLs, file validation will happen after checkout in ScenarioRunner
+                # Just pass the pattern as-is since we can't validate files that don't exist locally yet
+                filenames.append(pattern)
+
+        # Execute the given usage scenarios multiple times (if iterations > 1)
+        filenames = filenames * args.iterations
+
+        if args.ssh_private_key:
+            with open(args.ssh_private_key, 'r', encoding='UTF-8') as f:
+                ssh_private_key_contents = SecureVariable(f.read())
+        else:
+            ssh_private_key_contents = None
+
+        if args.docker_credentials:
+            with open(args.docker_credentials, 'r', encoding='UTF-8') as f:
+                raw_creds = json.load(f)
+            if not isinstance(raw_creds, list):
+                raise ValueError('--docker-credentials file must contain a JSON array of credential objects')
+            docker_credentials_to_pass = [
+                {'registry': c['registry'], 'username': c['username'], 'password': SecureVariable(c['password'])}
+                for c in raw_creds
+            ]
+        else:
+            docker_credentials_to_pass = None
+
+        # Create ScenarioRunner once and reuse it for all files
+        runner = ScenarioRunner(name=args.name, uri=args.uri, uri_type=run_type, filename=filenames[0],
+                        branch=args.branch, commit_hash=args.commit_hash, debug_mode=args.debug, allow_unsafe=args.allow_unsafe,
+                        full_docker_prune=args.full_docker_prune, docker_prune=args.docker_prune,
+                        verbose_provider_boot=args.verbose_provider_boot,
+                        user_id=args.user_id, ssh_private_key=ssh_private_key_contents,
+                        docker_credentials=docker_credentials_to_pass,
+                        commit_hash_folder=args.commit_hash_folder,
+                        usage_scenario_variables=variables_dict, category_ids=args.category,
+                        carbon_simulation=carbon_simulation_to_pass,
+
+                        measurement_system_check_threshold=args.measurement_system_check_threshold,
+                        measurement_pre_test_sleep=args.measurement_pre_test_sleep,
+                        measurement_idle_duration=args.measurement_idle_duration,
+                        measurement_baseline_duration=args.measurement_baseline_duration,
+                        measurement_post_test_sleep=args.measurement_post_test_sleep,
+                        measurement_phase_transition_time=args.measurement_phase_transition_time,
+                        measurement_wait_time_dependencies=args.measurement_wait_time_dependencies,
+                        measurement_flow_process_duration=args.measurement_flow_process_duration,
+                        measurement_total_duration=args.measurement_total_duration,
+
+                        # These switches do not alter proper measurements, but might result in data not being generated
+                        skip_download_dependencies=args.skip_download_dependencies, skip_optimizations=args.skip_optimizations,
+                        skip_unsafe=args.skip_unsafe, skip_volume_inspect=args.skip_volume_inspect,
+
+                        # These switches may break or skew proper measurements if set
+                        dev_no_sleeps=args.dev_no_sleeps, dev_stream_outputs=args.dev_stream_outputs, dev_cache_repos=args.dev_cache_repos,
+                        dev_cache_build=args.dev_cache_build, dev_no_metrics=args.dev_no_metrics, dev_no_save=args.dev_no_save,
+                        dev_flow_timetravel=args.dev_flow_timetravel, dev_no_system_checks=args.dev_no_system_checks,
+                        dev_no_phase_stats=args.dev_no_phase_stats, dev_no_container_dependency_collection=args.dev_no_container_dependency_collection,
+                        dev_no_resource_limits=args.dev_no_resource_limits,
+
+                        #disabled_metric_providers # this is intentionally not supported as the user can just edit the config in CLI mode and using another args="+" for parsing CLI is flaky
+                        #allowed_run_args=user._capabilities['measurement']['orchestrators']['docker']['allowed_run_args'] # this is intentionally not supported as the user can just enter --allow-unsafe in CLI mode and using another args="+" for parsing CLI is flaky
+                        )
+        if not runner._skip_optimizations and not runner._dev_no_save and not runner._dev_no_metrics:
+            # We cannot import this at the top of the as we need the correct config file
+            # Config file is replaced through args.config_override sometimes
+            import optimization_providers.base
+            print(TerminalColors.HEADER, '\nImporting optimization reporters ...', TerminalColors.ENDC)
+            optimization_providers.base.import_reporters()
+
         for filename in filenames:
             print(TerminalColors.OKBLUE, '\nRunning: ', filename, TerminalColors.ENDC)
 
@@ -296,7 +290,8 @@ if __name__ == '__main__':
         error_helpers.log_error(str(e), stdout=e.stdout, stderr=e.stderr, exception_context=e.__context__, run_id=runner._run_id if runner else None)
     except RuntimeError as e:
         error_helpers.log_error('RuntimeError occured in runner.py', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
-    except BaseException as e:
+    except BaseException as e: #pylint: disable=broad-except
+        # Using a very broad exception makes sense in this case as we have excepted all the specific ones before
         error_helpers.log_error('Base exception occured in runner.py', exception_context=e.__context__, final_exception=e, run_id=runner._run_id if runner else None)
     finally:
         if args.print_logs and runner:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -384,7 +384,7 @@ def test_runner_filename_pattern_no_match_error():
     )
 
     assert ps.returncode == 1, "Runner should fail when no files match pattern"
-    assert 'No valid files found for --filename pattern' in ps.stdout
+    assert 'No valid files found for --filename pattern' in ps.stderr
 
     # if file does not exist and ScenarioRunner is called directly
 def test_different_filename_missing():


### PR DESCRIPTION
In newer Python versions > 3.14 the interpreter crashed with:

```python3
Exception ignored while calling deallocator <function ConnectionPool.__del__ at 0x1119d8930>:
Traceback (most recent call last):
  File "/Users/arne/Sites/green-coding/green-metrics-tool/venv/lib/python3.14/site-packages/psycopg_pool/pool.py", line 126, in __del__
  File "/Users/arne/Sites/green-coding/green-metrics-tool/venv/lib/python3.14/site-packages/psycopg_pool/_acompat.py", line 152, in gather
  File "/opt/homebrew/Cellar/python@3.14/3.14.7/Frameworks/Python.framework/Versions/3.14/lib/python3.14/threading.py", line 1133, in join
PythonFinalizationError: cannot join thread at interpreter shutdown
```

This was because the DB was not properly closed and somehow internal pool handing in psycopg changed.

This PR moves everything in runner.py in the try-catch block to always close DB and remove old sys.exit handling

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791703374&installation_model_id=428550&pr_number=1856&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1856&signature=7c00232ed8c834ea38f71ae199fcaf9f116a32251ecf056a7c6f62b5b7443c9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Ensured `DB().shutdown()` runs when argument parsing fails.
- Added explicit nonzero exit codes for handled errors.
- Guarded log printing when parsing does not produce `args`.
- Updated the filename-pattern test to check stderr output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->