### PR TITLE
chore(frontend): enable strict mode in frontend JS modules

### DIFF
--- a/frontend/js/authentication.js
+++ b/frontend/js/authentication.js
@@ -1,3 +1,4 @@
+"use strict";
 (() => {
     const token_field = $("#authentication-token");
 

--- a/frontend/js/ci-index.js
+++ b/frontend/js/ci-index.js
@@ -1,3 +1,4 @@
+"use strict";
 async function getRepositories(sort_by = 'date') {
     try {
         var api_data = await makeAPICall(`/v1/ci/repositories?sort_by=${sort_by}`)

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -1,3 +1,4 @@
+"use strict";
 const createChartContainer = (container, el) => {
     const chart_node = document.createElement("div")
     chart_node.classList.add("card");

--- a/frontend/js/cluster-changelog.js
+++ b/frontend/js/cluster-changelog.js
@@ -1,3 +1,4 @@
+"use strict";
 $(document).ready(function () {
     (async () => {
 

--- a/frontend/js/cluster-status-history.js
+++ b/frontend/js/cluster-status-history.js
@@ -1,3 +1,4 @@
+"use strict";
 $(document).ready(function () {
     (async () => {
 

--- a/frontend/js/cluster-status.js
+++ b/frontend/js/cluster-status.js
@@ -1,3 +1,4 @@
+"use strict";
 
 async function deleteSystemLog(e){
     e.preventDefault()

--- a/frontend/js/compare.js
+++ b/frontend/js/compare.js
@@ -1,3 +1,4 @@
+"use strict";
 function createPythonDictTable(dataArray, labelPrefix = 'Item', keyHeader = 'Key') {
     // Parse Python dictionary data into a comparison table
     const items = Array.isArray(dataArray) ? dataArray : [dataArray];

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -1,3 +1,4 @@
+"use strict";
 (async () => {
     if (ACTIVATE_SCENARIO_RUNNER === true) {
         document.querySelectorAll('.scenario-runner').forEach(el => el.style.setProperty("display", "block", "important"))

--- a/frontend/js/request.js
+++ b/frontend/js/request.js
@@ -1,3 +1,4 @@
+"use strict";
 const populateFieldsFromURL = () => {
     const urlParams = new URLSearchParams(window.location.search);
 

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -1,3 +1,4 @@
+"use strict";
 const updateSetting = async (el) => {
     const left_el = el.parentElement.previousElementSibling.querySelector('input, select, textarea');
     const name = left_el.getAttribute('data-setting');

--- a/frontend/js/simulation-yearly.js
+++ b/frontend/js/simulation-yearly.js
@@ -1,3 +1,4 @@
+"use strict";
 const AVAILABLE_YEARS = [2021, 2022, 2023, 2024, 2025];
 
 const DEFAULT_NUM_RUNS = 1000;

--- a/frontend/js/simulation.js
+++ b/frontend/js/simulation.js
@@ -1,3 +1,4 @@
+"use strict";
 
 const MINI_CHART_COLORS = {
     provider: '#6ea9c9',

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -1,3 +1,4 @@
+"use strict";
 class CO2Tangible extends HTMLElement {
    connectedCallback() {
         this.innerHTML = `

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -1,3 +1,4 @@
+"use strict";
 let chart_instances = [];
 let repository_uri = null; // Store unescaped URI for URL construction
 

--- a/frontend/js/watchlist.js
+++ b/frontend/js/watchlist.js
@@ -1,3 +1,4 @@
+"use strict";
 $(document).ready(function () {
 
     (async () => {


### PR DESCRIPTION
## Summary
Enable \`\"use strict\";\` in first-party \`frontend/js\` modules so accidental globals and similar issues fail earlier.

## Changes
- Prepend \`\"use strict\";\` to 15 frontend JS files that did not already enable it
- Skipped large/minified vendor-style assets

Closes #1246

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/green-coding-solutions/codesmith/green-metrics-tool/pr/1858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791818497&installation_model_id=428550&pr_number=1858&repository=green-coding-solutions%2Fgreen-metrics-tool&return_to=https%3A%2F%2Fgithub.com%2Fgreen-coding-solutions%2Fgreen-metrics-tool%2Fpull%2F1858&signature=31c25a2e0ac1356fa29308e9f4c9676ab592a6c76892033ce5884b2211ff4ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->